### PR TITLE
Add CI workflow for testing with Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: "CI — tests"
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.10, 3.11]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Run tests
+        run: |
+          pytest -q


### PR DESCRIPTION
Add a human-friendly workflow name ("CI — tests") and ensure the workflow installs dev dependencies and runs pytest across Python 3.10 and 3.11

<!-- Describe the change and why it matters -->
## Summary

<!-- One-sentence summary of the change -->

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing
Describe how this change was tested locally (commands run).

## Reviewers
Tag any maintainers or teams that should review.
