### PR TITLE
Update mobile pricing route and rebrand to Sacred Pro

### DIFF
--- a/app/(mobile)/m/profile/page.tsx
+++ b/app/(mobile)/m/profile/page.tsx
@@ -184,15 +184,16 @@ export default function MobileProfilePage() {
         >
           <motion.button
             whileTap={{ scale: 0.98 }}
-            onClick={() => handleNavigate('/pricing')}
+            onClick={() => handleNavigate('/m/subscribe')}
             className="w-full p-4 rounded-2xl text-left bg-gradient-to-r from-[#d4a44c]/15 via-[#d4a44c]/15 to-pink-500/15 border border-[#d4a44c]/20"
+            aria-label="Upgrade to Sacred Pro plan"
           >
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 rounded-xl bg-[#d4a44c]/20 flex items-center justify-center">
                 <Crown className="w-5 h-5 text-[#d4a44c]" />
               </div>
               <div className="flex-1">
-                <p className="text-sm font-semibold">Upgrade to Premium</p>
+                <p className="text-sm font-semibold">Upgrade to Sacred Pro</p>
                 <p className="text-caption text-[var(--mv-text-muted)] mt-0.5">Unlock all journeys and unlimited KIAAN insights</p>
               </div>
               <ChevronRight className="w-5 h-5 text-slate-500" />

--- a/proxy.ts
+++ b/proxy.ts
@@ -78,6 +78,7 @@ const MOBILE_ROUTE_MAP: Record<string, string> = {
   '/analytics': '/m/analytics',
   '/account': '/m/account',
   '/feedback': '/m/feedback',
+  '/pricing': '/m/subscribe',
 };
 
 function isMobileUserAgent(userAgent: string): boolean {


### PR DESCRIPTION
## Summary

Updates the mobile profile page to route to the new `/m/subscribe` endpoint instead of `/pricing`, and rebrands the upgrade button from "Upgrade to Premium" to "Upgrade to Sacred Pro". Also adds a proxy route mapping for `/pricing` to `/m/subscribe` to handle legacy navigation.

## Changes

- Changed upgrade button navigation from `/pricing` to `/m/subscribe` on mobile profile page
- Updated button text from "Upgrade to Premium" to "Upgrade to Sacred Pro"
- Added `aria-label` attribute for improved accessibility
- Added proxy route mapping to redirect `/pricing` requests to `/m/subscribe` on mobile devices

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing

Verified that:
- Mobile profile page upgrade button navigates to `/m/subscribe`
- Button displays correct text and styling
- Proxy route correctly maps `/pricing` to `/m/subscribe` for mobile user agents

https://claude.ai/code/session_01BTgLdEDtQFCZLiS1RKpANK