### PR TITLE
refactor(canvas): P3-E Phase 2 — render DivineCelestialBackground globally from layout

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -3,9 +3,15 @@
 import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { IntroOverlay } from '@/components/divine/IntroOverlay'
+import { MobileRouteGuard } from '@/components/mobile/MobileRouteGuard'
 
 const GodParticles = dynamic(
   () => import('@/components/divine/GodParticles').then(mod => mod.GodParticles),
+  { ssr: false }
+)
+
+const DivineCelestialBackground = dynamic(
+  () => import('@/components/divine/DivineCelestialBackground').then(mod => mod.DivineCelestialBackground),
   { ssr: false }
 )
 
@@ -37,6 +43,15 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <>
+      {/* Immersive celestial backdrop — fixed, pointer-events-none, renders
+          on every desktop route. Hidden on /m/* mobile routes which have
+          their own shell. Deferred until after first paint to avoid blocking
+          navigation and content rendering. */}
+      {showDecorations && (
+        <MobileRouteGuard>
+          <DivineCelestialBackground />
+        </MobileRouteGuard>
+      )}
       {/* Decorative particles — deferred to avoid blocking navigation */}
       {showDecorations && <GodParticles count={20} />}
       {/* Page transition wrapper — animates content entrance without remounting */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,8 +16,9 @@ import dynamic from 'next/dynamic';
 import { useLanguage } from '@/hooks/useLanguage';
 import { springConfigs } from '@/lib/animations/spring-configs';
 
-// Dynamic imports for framer-motion components to reduce initial bundle size
-const DivineCelestialBackground = dynamic(() => import('@/components/divine/DivineCelestialBackground').then(mod => mod.DivineCelestialBackground), { ssr: false });
+// Dynamic imports for framer-motion components to reduce initial bundle size.
+// DivineCelestialBackground is now rendered globally from ClientLayout, so
+// it is no longer imported here.
 const DivineKrishnaPresence = dynamic(() => import('@/components/divine/DivineKrishnaPresence').then(mod => mod.DivineKrishnaPresence), { ssr: false });
 
 export default function Home() {
@@ -25,10 +26,7 @@ export default function Home() {
 
   return (
     <main className="relative min-h-screen overflow-hidden">
-      {/* Immersive celestial background — fixed, full-screen */}
-      <DivineCelestialBackground />
-
-      {/* Content layer — above the celestial backdrop */}
+      {/* Content layer — the celestial backdrop is rendered by ClientLayout */}
       <div className="relative z-10 mx-auto max-w-6xl space-y-section-lg pb-24 md:pb-16 px-page-x">
 
         {/* === DIVINE ENTRY: Krishna's Presence === */}

--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import dynamic from 'next/dynamic'
 import { motion, AnimatePresence } from 'framer-motion'
 import { BillingToggle, PricingCard, PaymentMethodSelector, type PricingTier, type PaymentMethod } from '@/components/pricing'
 import { Card, CardContent } from '@/components/ui'
@@ -13,10 +12,8 @@ import { useAuth } from '@/hooks/useAuth'
 import { apiFetch } from '@/lib/api'
 import { loadRazorpayScript, openRazorpayCheckout, type RazorpayPaymentResponse } from '@/lib/razorpay'
 
-const DivineCelestialBackground = dynamic(
-  () => import('@/components/divine/DivineCelestialBackground').then(mod => mod.DivineCelestialBackground),
-  { ssr: false }
-)
+// DivineCelestialBackground is now rendered globally from ClientLayout
+// and no longer imported per-page.
 
 // ─── Pricing tiers (same as /pricing page) ───────────────────────────────────
 
@@ -442,7 +439,7 @@ export default function StartPage() {
         className="relative flex min-h-[100dvh] flex-col items-center justify-center px-4 text-center"
         aria-label="Welcome"
       >
-        <DivineCelestialBackground />
+        {/* Celestial backdrop rendered globally by ClientLayout */}
 
         <div className="relative z-10 mx-auto max-w-3xl">
           <motion.div


### PR DESCRIPTION
## Summary

Phase 2 of the P3-E desktop canvas refactor. Moves the immersive celestial backdrop from per-page rendering into `ClientLayout` so it appears on **every desktop route** instead of only the homepage and `/start`.

Builds on Phase 1 (now merged via #1497) but only contains one commit — the Phase 1 CSS token work is already on main.

## What changed

**`app/ClientLayout.tsx`** — Added dynamic import for `DivineCelestialBackground` and render it wrapped in `MobileRouteGuard` so `/m/*` mobile routes (which have their own `MobileAppShell`) don't receive it. Gated behind the existing `showDecorations` state so it inherits the `requestIdleCallback` deferral alongside `GodParticles` — won't block first paint.

**`app/page.tsx`** — Removed the local `DivineCelestialBackground` dynamic import and the `<DivineCelestialBackground />` render. Kept the surrounding `<main className="relative min-h-screen overflow-hidden">` + `z-10` content wrapper so existing content continues to stack correctly above the layout-owned canvas.

**`app/start/page.tsx`** — Same cleanup: removed the import and render. Also removed the now-unused `import dynamic from 'next/dynamic'` since no other dynamic imports remained in the file.

## Why

Previously the celestial backdrop was present on only two routes (`/` and `/start`), leaving every other desktop route (`/features`, `/tools/*`, `/journeys`, `/sakha-chat`, `/sadhana`, `/flows/*`, etc.) with a flat background. The component is already deferred via `requestIdleCallback` and `fixed inset-0 pointer-events-none`, so moving it to the shared layout is essentially free and gives visual consistency across the whole desktop experience.

`GodParticles` was already rendered from `ClientLayout` — this PR brings `DivineCelestialBackground` in line with that pattern.

## Scope safety

- **Mobile routes untouched:** the `MobileRouteGuard` wrapper short-circuits to `null` on `/m/*` pathnames, so the mobile shell continues to own its own backdrop.
- **No bundle impact:** the canvas is still in its own dynamic chunk and loads once per session after first paint.
- **No API/backend changes:** pure UI composition move; no types, routes, fetches, or contracts touched.
- **Z-index preserved:** the canvas is `fixed inset-0` with no explicit z-index and comes first in DOM order inside `ClientLayout`. Later siblings (nav, content, footer) stack above it naturally via document order, which matches the prior behavior when pages rendered it inline.

## Test plan

- [x] `pnpm typecheck` — **pass** (0 errors)
- [x] `pnpm build` — **pass** (`Compiled successfully in 26.4s`)
- [x] `pnpm test` frontend — 582/585 passing (3 intentional skips; 1 observed flake in `tests/ui/tools/ToolPages.test.tsx > Karma Footprint Page > renders the page title correctly` is pre-existing, reproduces on clean `main`, caused by `waitFor(5000ms)` timing out under parallel load — not introduced by this PR)
- [x] Backend `pytest` — 76 passed, 1 skipped across `test_journey_engine_dashboard`, `test_journey_service`, `test_kiaan_voice_comprehensive` (only file that can't collect is `test_mobile_subscription.py` due to a missing `_cffi_backend` native extension in the sandbox — pre-existing environment issue)
- [ ] Manual smoke test: visit `/`, `/start`, `/features`, `/tools/emotional-reset`, `/sakha-chat` and confirm the celestial backdrop is visible on all of them
- [ ] Manual smoke test: visit `/m/` and `/m/emotional-reset` and confirm the celestial backdrop is **NOT** rendered (mobile shell takes over)

## Files changed

3 files, +22 / −12

https://claude.ai/code/session_01DMYNGajgb2y2KnPGbL7S2i