### PR TITLE
refactor(nav): P3-E Phase 3 — restyle desktop nav (SiteNav + DesktopNav) to Kiaanverse

### DIFF
--- a/app/components/SiteNav.tsx
+++ b/app/components/SiteNav.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation'
 import { useState, useMemo, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ThemeToggle } from '@/components/ui'
-import { MindVibeLockup } from '@/components/branding'
 import { springConfigs, animationVariants } from '@/lib/animations/spring-configs'
 import { useLanguage } from '@/hooks/useLanguage'
 import { LanguageSelector } from '@/components/navigation/LanguageSelector'
@@ -56,24 +55,38 @@ export default function SiteNav() {
 
   return (
     <motion.header
-      className="fixed inset-x-0 top-0 z-40 border-b border-[#d4a44c]/10 bg-[#050714]/95 shadow-lg shadow-black/30 backdrop-blur-xl"
+      className="fixed inset-x-0 top-0 z-40"
+      style={{
+        backgroundColor: 'rgba(5, 7, 20, 0.85)',
+        backdropFilter: 'blur(20px)',
+        WebkitBackdropFilter: 'blur(20px)',
+        borderBottom: '1px solid rgba(212, 160, 23, 0.1)',
+      }}
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={springConfigs.smooth}
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-2 px-4 py-3 pr-16 md:pr-4">
+        {/* Logo — Cormorant Garamond italic gold wordmark */}
         <Link
           href="/"
-          className="flex items-center gap-3 text-slate-100 transition hover:text-white"
+          className="font-divine italic transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D4A017]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(5,7,20,0.85)]"
+          style={{
+            color: '#D4A017',
+            fontSize: '28px',
+            fontWeight: 500,
+            letterSpacing: '0.02em',
+          }}
           aria-label="Sakha home"
         >
-          <motion.div
+          <motion.span
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             transition={springConfigs.snappy}
+            className="inline-block"
           >
-            <MindVibeLockup theme="sunrise" animated className="drop-shadow-[0_10px_40px_rgba(255,147,89,0.28)]" />
-          </motion.div>
+            Sakha
+          </motion.span>
         </Link>
 
         <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
@@ -91,19 +104,24 @@ export default function SiteNav() {
                 <Link
                   href={link.href}
                   aria-current={active ? 'page' : undefined}
-                  className={`block rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#d4a44c]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050714] ${
+                  className={`block rounded-full px-3 py-2 font-ui transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D4A017]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(5,7,20,0.85)] ${
                     active
                       ? isDivine
-                        ? 'border-2 border-[#d4a44c] text-[#e8b54a] shadow-lg shadow-[#d4a44c]/20'
+                        ? 'border-2 border-[#D4A017] text-[#F0C040] shadow-lg shadow-[#D4A017]/20'
                         : isHighlight
-                        ? 'border-2 border-[#d4a44c] text-[#e8b54a] shadow-lg shadow-[#d4a44c]/20'
-                        : 'bg-[#d4a44c]/10 text-white shadow-[0_0_16px_rgba(212,164,76,0.15)]'
+                        ? 'border-2 border-[#D4A017] text-[#F0C040] shadow-lg shadow-[#D4A017]/20'
+                        : 'text-[#D4A017]'
                       : isDivine
-                      ? 'border border-[#d4a44c]/40 text-[#d4a44c]/80 hover:border-[#d4a44c]/60 hover:text-[#e8b54a]'
+                      ? 'border border-[rgba(212,160,23,0.4)] text-[rgba(212,160,23,0.8)] hover:border-[#D4A017] hover:text-[#F0C040]'
                       : isHighlight
-                      ? 'border border-[#d4a44c]/40 text-[#d4a44c]/80 hover:border-[#d4a44c]/60 hover:text-[#e8b54a]'
-                      : 'text-white/60 hover:bg-white/5 hover:text-white/90'
+                      ? 'border border-[rgba(212,160,23,0.4)] text-[rgba(212,160,23,0.8)] hover:border-[#D4A017] hover:text-[#F0C040]'
+                      : 'text-[#B8AE98] hover:text-[#D4A017]'
                   }`}
+                  style={{
+                    fontSize: '13px',
+                    fontWeight: 500,
+                    letterSpacing: '0.02em',
+                  }}
                 >
                   <motion.span
                     whileHover={{ scale: 1.05 }}
@@ -122,9 +140,19 @@ export default function SiteNav() {
           {/* Language Selector - Always visible */}
           <LanguageSelector />
 
+          {/* CTA: Subscriptions — gold gradient button */}
           <Link
             href="/dashboard/subscription"
-            className="hidden rounded-full border border-[#d4a44c]/20 px-4 py-2 text-sm font-semibold text-white/70 transition hover:border-[#d4a44c]/40 hover:text-white sm:inline-flex"
+            className="hidden rounded-full font-ui transition-transform duration-200 sm:inline-flex focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D4A017]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(5,7,20,0.85)]"
+            style={{
+              background: 'linear-gradient(135deg, #D4A017 0%, #F0C040 50%, #D4A017 100%)',
+              color: '#050714',
+              fontSize: '13px',
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              padding: '9px 18px',
+              boxShadow: '0 4px 14px rgba(212, 160, 23, 0.35)',
+            }}
           >
             <motion.span whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
               {t('navigation.mainNav.pricing', 'Subscriptions')}
@@ -132,10 +160,15 @@ export default function SiteNav() {
           </Link>
           <motion.button
             onClick={() => setOpen(value => !value)}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-[#d4a44c]/20 bg-[#d4a44c]/5 text-white/70 md:hidden"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-xl md:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D4A017]/60"
+            style={{
+              border: '1px solid rgba(212, 160, 23, 0.3)',
+              backgroundColor: 'rgba(212, 160, 23, 0.05)',
+              color: '#B8AE98',
+            }}
             aria-expanded={open}
             aria-label={t('navigation.actions.toggleMenu', 'Toggle navigation menu')}
-            whileHover={{ scale: 1.05, backgroundColor: 'rgba(255,255,255,0.1)' }}
+            whileHover={{ scale: 1.05, backgroundColor: 'rgba(212, 160, 23, 0.12)' }}
             whileTap={{ scale: 0.95 }}
           >
             <motion.svg
@@ -179,9 +212,17 @@ export default function SiteNav() {
               onClick={() => setOpen(false)}
               aria-hidden="true"
             />
-            {/* Mobile menu */}
+            {/* Mobile menu — Kiaanverse dropdown: rgba(11,14,42,0.98) + blur + gold border */}
             <motion.div
-              className="fixed inset-x-0 top-[60px] z-40 max-h-[calc(100vh-60px)] overflow-y-auto border-t border-[#d4a44c]/10 bg-[#050714] px-4 py-4 shadow-xl md:hidden"
+              className="fixed inset-x-0 top-[60px] z-40 max-h-[calc(100vh-60px)] overflow-y-auto px-4 py-4 md:hidden"
+              style={{
+                backgroundColor: 'rgba(11, 14, 42, 0.98)',
+                backdropFilter: 'blur(20px)',
+                WebkitBackdropFilter: 'blur(20px)',
+                borderTop: '1px solid rgba(212, 160, 23, 0.3)',
+                borderBottom: '1px solid rgba(212, 160, 23, 0.3)',
+                boxShadow: '0 12px 40px rgba(0, 0, 0, 0.5)',
+              }}
               aria-label="Mobile navigation"
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}
@@ -215,23 +256,36 @@ export default function SiteNav() {
                         href={link.href}
                         onClick={() => setOpen(false)}
                         aria-current={active ? 'page' : undefined}
-                        className={`flex min-h-[48px] items-center rounded-xl px-4 py-3 text-base font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#d4a44c]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050714] ${
+                        className={`flex min-h-[48px] items-center rounded-xl px-4 py-3 font-ui transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D4A017]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(11,14,42,0.98)] ${
                           active
                             ? isDivine
-                              ? 'border-2 border-[#d4a44c] text-[#e8b54a] shadow-lg shadow-[#d4a44c]/20'
+                              ? 'border-2 border-[#D4A017] text-[#F0C040] shadow-lg shadow-[#D4A017]/20'
                               : isHighlight
-                              ? 'border-2 border-[#d4a44c] text-[#e8b54a] shadow-lg shadow-[#d4a44c]/20'
-                              : 'bg-[#d4a44c]/10 text-white'
+                              ? 'border-2 border-[#D4A017] text-[#F0C040] shadow-lg shadow-[#D4A017]/20'
+                              : 'text-[#D4A017]'
                             : isDivine
-                            ? 'border border-[#d4a44c]/40 text-[#d4a44c]/80 hover:border-[#d4a44c]/60 hover:text-[#e8b54a]'
+                            ? 'border border-[rgba(212,160,23,0.4)] text-[rgba(212,160,23,0.8)] hover:border-[#D4A017] hover:text-[#F0C040]'
                             : isHighlight
-                            ? 'border border-[#d4a44c]/40 text-[#d4a44c]/80 hover:border-[#d4a44c]/60 hover:text-[#e8b54a]'
-                            : 'text-white/70 hover:bg-white/5 hover:text-white'
+                            ? 'border border-[rgba(212,160,23,0.4)] text-[rgba(212,160,23,0.8)] hover:border-[#D4A017] hover:text-[#F0C040]'
+                            : 'text-[#B8AE98] hover:text-[#D4A017]'
                         }`}
+                        style={{
+                          fontSize: '13px',
+                          fontWeight: 500,
+                          letterSpacing: '0.02em',
+                        }}
                       >
                         {link.label}
                         {isHighlight && !active && (
-                          <span className="ml-auto rounded-full bg-[#d4a44c]/15 px-2 py-0.5 text-xs text-[#d4a44c]/80">
+                          <span
+                            className="ml-auto rounded-full px-2 py-0.5"
+                            style={{
+                              fontSize: '10px',
+                              fontWeight: 600,
+                              backgroundColor: 'rgba(212, 160, 23, 0.15)',
+                              color: 'rgba(212, 160, 23, 0.9)',
+                            }}
+                          >
                             AI
                           </span>
                         )}
@@ -241,23 +295,30 @@ export default function SiteNav() {
                 })}
 
                 <motion.div
-                  className="my-2 border-t border-white/10"
+                  className="my-2"
+                  style={{ borderTop: '1px solid rgba(212, 160, 23, 0.15)' }}
                   variants={animationVariants.slideUp}
                 />
 
                 <motion.div
-                  className="flex min-h-[48px] items-center justify-between rounded-xl bg-[#d4a44c]/5 px-4 py-3"
+                  className="flex min-h-[48px] items-center justify-between rounded-xl px-4 py-3"
+                  style={{ backgroundColor: 'rgba(212, 160, 23, 0.05)' }}
                   variants={animationVariants.slideUp}
                 >
-                  <span className="text-base font-medium text-white/80">{t('navigation.mainNav.theme', 'Theme')}</span>
+                  <span className="font-ui" style={{ fontSize: '13px', fontWeight: 500, color: '#B8AE98', letterSpacing: '0.02em' }}>
+                    {t('navigation.mainNav.theme', 'Theme')}
+                  </span>
                   <ThemeToggle />
                 </motion.div>
 
                 <motion.div
-                  className="flex min-h-[48px] items-center justify-between rounded-xl bg-[#d4a44c]/5 px-4 py-3"
+                  className="flex min-h-[48px] items-center justify-between rounded-xl px-4 py-3"
+                  style={{ backgroundColor: 'rgba(212, 160, 23, 0.05)' }}
                   variants={animationVariants.slideUp}
                 >
-                  <span className="text-base font-medium text-white/80">{t('navigation.mainNav.language', 'Language')}</span>
+                  <span className="font-ui" style={{ fontSize: '13px', fontWeight: 500, color: '#B8AE98', letterSpacing: '0.02em' }}>
+                    {t('navigation.mainNav.language', 'Language')}
+                  </span>
                   <LanguageSelector variant="sheet" />
                 </motion.div>
 

--- a/components/navigation/DesktopNav.tsx
+++ b/components/navigation/DesktopNav.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState, useMemo } from 'react'
-import { MindVibeLockup } from '@/components/branding'
 import { ThemeToggle } from '@/components/ui'
 import { ToolsDropdown } from './ToolsDropdown'
 import { LanguageSelector } from './LanguageSelector'
@@ -16,14 +15,15 @@ export interface DesktopNavProps {
 }
 
 /**
- * DesktopNav component for desktop top navigation.
+ * DesktopNav — Kiaanverse desktop top navigation.
  *
- * Features:
- * - MindVibe logo (preserved, unaltered)
- * - Main nav links: Chat, Sacred Reflections, Wisdom, Insights
- * - Tools dropdown menu with all guidance engines
- * - User profile dropdown
- * - Proper active state indicators
+ * Styled per the P3-E Phase 3 spec:
+ *   - Header: rgba(5,7,20,0.85) with backdrop-filter: blur(20px), 1px gold
+ *     border-bottom rgba(212,160,23,0.1).
+ *   - Logo: "Sakha" in Cormorant Garamond italic, divine-gold (#D4A017).
+ *   - Nav links: Outfit 13px, #B8AE98 at rest, #D4A017 when active.
+ *   - CTA (Subscriptions): gold gradient button.
+ *   - Hamburger dropdown: rgba(11,14,42,0.98) + blur + gold border.
  */
 export function DesktopNav({ className = '' }: DesktopNavProps) {
   const pathname = usePathname()
@@ -31,58 +31,73 @@ export function DesktopNav({ className = '' }: DesktopNavProps) {
   const { t } = useLanguage()
 
   // Main navigation links with translations
-  const mainNavLinks = useMemo(() => [
-    { href: '/', label: t('navigation.mainNav.home', 'Home') },
-    { href: '/sadhana', label: t('navigation.features.sadhana', 'Sadhana') },
-    { href: '/kiaan/chat', label: t('navigation.features.kiaan', 'KIAAN'), purposeDescKey: 'kiaan' },
-    { href: '/companion', label: t('navigation.features.companion', 'Companion'), purposeDescKey: 'kiaan' },
-    { href: '/dashboard', label: t('navigation.mainNav.dashboard', 'Dashboard') },
-    { href: '/journeys', label: t('navigation.features.wisdomJourneys', 'Journeys'), premium: true, purposeDescKey: 'journey' },
-{ href: '/sacred-reflections', label: t('navigation.features.sacredReflections', 'Sacred Reflections') },
-    { href: '/tools/karmic-tree', label: t('navigation.features.karmicTree', 'Karmic Tree') },
-    { href: '/profile', label: t('navigation.mainNav.profile', 'Profile') },
-    { href: '/account', label: t('navigation.mainNav.account', 'Account') },
-  ], [t])
+  const mainNavLinks = useMemo(
+    () => [
+      { href: '/', label: t('navigation.mainNav.home', 'Home') },
+      { href: '/sadhana', label: t('navigation.features.sadhana', 'Sadhana') },
+      { href: '/kiaan/chat', label: t('navigation.features.kiaan', 'KIAAN'), purposeDescKey: 'kiaan' },
+      { href: '/companion', label: t('navigation.features.companion', 'Companion'), purposeDescKey: 'kiaan' },
+      { href: '/dashboard', label: t('navigation.mainNav.dashboard', 'Dashboard') },
+      {
+        href: '/journeys',
+        label: t('navigation.features.wisdomJourneys', 'Journeys'),
+        premium: true,
+        purposeDescKey: 'journey',
+      },
+      { href: '/sacred-reflections', label: t('navigation.features.sacredReflections', 'Sacred Reflections') },
+      { href: '/tools/karmic-tree', label: t('navigation.features.karmicTree', 'Karmic Tree') },
+      { href: '/profile', label: t('navigation.mainNav.profile', 'Profile') },
+      { href: '/account', label: t('navigation.mainNav.account', 'Account') },
+    ],
+    [t],
+  )
 
   // Get tools for mobile menu display
   const allTools = TOOLS_BY_CATEGORY.filter(
-    cat => cat.id === 'guidance' || cat.id === 'karma'
-  ).flatMap(cat => cat.tools)
+    (cat) => cat.id === 'guidance' || cat.id === 'karma',
+  ).flatMap((cat) => cat.tools)
 
   return (
     <header
-      className={`fixed inset-x-0 top-0 z-50 border-b border-white/5 bg-slate-950/95 shadow-lg shadow-black/20 backdrop-blur-xl ${className}`}
+      className={`fixed inset-x-0 top-0 z-50 ${className}`}
+      style={{
+        backgroundColor: 'rgba(5, 7, 20, 0.85)',
+        backdropFilter: 'blur(20px)',
+        WebkitBackdropFilter: 'blur(20px)',
+        borderBottom: '1px solid rgba(212, 160, 23, 0.1)',
+      }}
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
-        {/* Logo */}
+        {/* Logo — Cormorant Garamond italic gold wordmark */}
         <Link
           href="/"
-          className="flex items-center gap-3 text-slate-100 transition hover:text-white"
+          className="font-divine italic transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-[#D4A017] focus:ring-offset-2 focus:ring-offset-[rgba(5,7,20,0.85)]"
+          style={{
+            color: '#D4A017',
+            fontSize: '28px',
+            fontWeight: 500,
+            letterSpacing: '0.02em',
+          }}
           aria-label="Sakha home"
         >
-          <MindVibeLockup
-            theme="sunrise"
-            animated
-            className="drop-shadow-[0_10px_40px_rgba(255,147,89,0.28)]"
-          />
+          Sakha
         </Link>
 
         {/* Desktop Navigation */}
-        <nav
-          className="hidden items-center gap-1 md:flex"
-          aria-label="Primary"
-        >
+        <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
           {mainNavLinks.map((link) => {
             const active = pathname === link.href
             return (
               <Link
                 key={link.href}
                 href={link.href}
-                className={`rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-[#d4a44c] focus:ring-offset-2 focus:ring-offset-slate-900 flex items-center gap-1 ${
-                  active
-                    ? 'bg-white/10 text-white shadow-lg shadow-[#d4a44c]/20'
-                    : 'text-white/70 hover:bg-white/5 hover:text-white'
-                }`}
+                className="flex items-center gap-1 rounded-full px-3 py-2 font-ui transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#D4A017] focus:ring-offset-2 focus:ring-offset-[rgba(5,7,20,0.85)]"
+                style={{
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  letterSpacing: '0.02em',
+                  color: active ? '#D4A017' : '#B8AE98',
+                }}
               >
                 {link.label}
               </Link>
@@ -96,30 +111,53 @@ export function DesktopNav({ className = '' }: DesktopNavProps) {
           {/* Language Selector — dropdown on desktop, auto-hidden below sm */}
           <LanguageSelector variant="dropdown" className="hidden sm:block" />
 
+          {/* CTA: Subscriptions — gold gradient button */}
           <Link
             href="/dashboard/subscription"
-            className="hidden items-center gap-2 rounded-full border border-white/10 px-3 py-2 text-sm font-medium text-white/80 transition hover:bg-white/5 hover:text-white sm:inline-flex focus:outline-none focus:ring-2 focus:ring-[#d4a44c] focus:ring-offset-2 focus:ring-offset-slate-900"
+            className="hidden items-center gap-2 rounded-full font-ui transition-transform duration-200 hover:scale-[1.02] active:scale-[0.98] sm:inline-flex focus:outline-none focus:ring-2 focus:ring-[#D4A017] focus:ring-offset-2 focus:ring-offset-[rgba(5,7,20,0.85)]"
+            style={{
+              background: 'linear-gradient(135deg, #D4A017 0%, #F0C040 50%, #D4A017 100%)',
+              color: '#050714',
+              fontSize: '13px',
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              padding: '9px 18px',
+              boxShadow: '0 4px 14px rgba(212, 160, 23, 0.35)',
+            }}
           >
             {t('navigation.mainNav.pricing', 'Subscriptions')}
           </Link>
 
-          {/* Mobile menu button */}
+          {/* Hamburger menu button */}
           <button
             type="button"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            className="inline-flex items-center justify-center rounded-full border border-white/10 px-3 py-2 text-white/80 md:hidden"
+            className="inline-flex items-center justify-center rounded-full border px-3 py-2 font-ui transition-colors duration-200 md:hidden focus:outline-none focus:ring-2 focus:ring-[#D4A017]"
+            style={{
+              fontSize: '13px',
+              fontWeight: 500,
+              color: '#B8AE98',
+              borderColor: 'rgba(212, 160, 23, 0.3)',
+            }}
             aria-expanded={mobileMenuOpen}
             aria-label={t('navigation.actions.toggleMenu', 'Toggle navigation menu')}
           >
-            <span className="text-sm font-semibold">{t('navigation.actions.menu', 'Menu')}</span>
+            <span>{t('navigation.actions.menu', 'Menu')}</span>
           </button>
         </div>
       </div>
 
-      {/* Mobile menu */}
+      {/* Hamburger dropdown */}
       {mobileMenuOpen && (
         <div
-          className="border-t border-white/5 bg-slate-950/95 px-4 py-3 md:hidden"
+          className="px-4 py-3 md:hidden"
+          style={{
+            backgroundColor: 'rgba(11, 14, 42, 0.98)',
+            backdropFilter: 'blur(20px)',
+            WebkitBackdropFilter: 'blur(20px)',
+            borderTop: '1px solid rgba(212, 160, 23, 0.3)',
+            borderBottom: '1px solid rgba(212, 160, 23, 0.3)',
+          }}
           aria-label="Mobile navigation"
         >
           <div className="flex flex-col gap-2">
@@ -130,23 +168,39 @@ export function DesktopNav({ className = '' }: DesktopNavProps) {
                   key={link.href}
                   href={link.href}
                   onClick={() => setMobileMenuOpen(false)}
-                  className={`rounded-xl px-3 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-[#d4a44c] focus:ring-offset-2 focus:ring-offset-slate-900 ${
-                    active
-                      ? 'bg-white/10 text-white'
-                      : 'text-white/80 hover:bg-white/5'
-                  }`}
+                  className="rounded-xl px-3 py-2 font-ui transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#D4A017]"
+                  style={{
+                    fontSize: '13px',
+                    fontWeight: 500,
+                    letterSpacing: '0.02em',
+                    color: active ? '#D4A017' : '#B8AE98',
+                  }}
                 >
                   {link.label}
                   {'purposeDescKey' in link && link.purposeDescKey && (
-                    <span className="block text-[10px] font-normal text-white/70 truncate">
+                    <span
+                      className="block font-ui truncate"
+                      style={{ fontSize: '10px', color: 'rgba(184, 174, 152, 0.7)', fontWeight: 400 }}
+                    >
                       {t(`dashboard.tool_desc.${link.purposeDescKey}`, '')}
                     </span>
                   )}
                 </Link>
               )
             })}
-            <div className="border-t border-white/5 pt-2 mt-2">
-              <span className="px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white/70">
+            <div
+              className="pt-2 mt-2"
+              style={{ borderTop: '1px solid rgba(212, 160, 23, 0.15)' }}
+            >
+              <span
+                className="px-3 py-1 font-ui uppercase"
+                style={{
+                  fontSize: '11px',
+                  letterSpacing: '0.12em',
+                  fontWeight: 600,
+                  color: '#D4A017',
+                }}
+              >
                 {t('common.buttons.tools', 'Tools')}
               </span>
               {allTools.map((item: ToolConfig) => (
@@ -154,13 +208,17 @@ export function DesktopNav({ className = '' }: DesktopNavProps) {
                   key={item.id}
                   href={item.href}
                   onClick={() => setMobileMenuOpen(false)}
-                  className="flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-white/80 transition hover:bg-white/5"
+                  className="flex items-center gap-2 rounded-xl px-3 py-2 font-ui transition-colors duration-200"
+                  style={{ fontSize: '13px', color: '#B8AE98', fontWeight: 500 }}
                 >
                   <span className="text-base">{item.icon}</span>
                   <span className="min-w-0">
                     <span className="block">{t(`dashboard.tools.${item.id}.title`, item.title)}</span>
                     {item.purposeDescKey && (
-                      <span className="block text-[10px] text-white/70 truncate">
+                      <span
+                        className="block font-ui truncate"
+                        style={{ fontSize: '10px', color: 'rgba(184, 174, 152, 0.7)', fontWeight: 400 }}
+                      >
                         {t(`dashboard.tool_desc.${item.purposeDescKey}`, '')}
                       </span>
                     )}
@@ -168,12 +226,19 @@ export function DesktopNav({ className = '' }: DesktopNavProps) {
                 </Link>
               ))}
             </div>
-            <div className="flex items-center justify-between rounded-xl px-3 py-2 border-t border-white/5 mt-2 pt-2">
-              <span className="text-sm text-white/80">{t('navigation.mainNav.theme', 'Theme')}</span>
+            <div
+              className="flex items-center justify-between rounded-xl px-3 py-2 mt-2 pt-2"
+              style={{ borderTop: '1px solid rgba(212, 160, 23, 0.15)' }}
+            >
+              <span className="font-ui" style={{ fontSize: '13px', color: '#B8AE98', fontWeight: 500 }}>
+                {t('navigation.mainNav.theme', 'Theme')}
+              </span>
               <ThemeToggle />
             </div>
             <div className="flex items-center justify-between rounded-xl px-3 py-2">
-              <span className="text-sm text-white/80">{t('navigation.mainNav.language', 'Language')}</span>
+              <span className="font-ui" style={{ fontSize: '13px', color: '#B8AE98', fontWeight: 500 }}>
+                {t('navigation.mainNav.language', 'Language')}
+              </span>
               <LanguageSelector variant="sheet" />
             </div>
           </div>


### PR DESCRIPTION
## Summary

Phase 3 of the P3-E desktop redesign. Restyles the desktop top navigation to the Kiaanverse design language — **and** carries the exact same spec over to `app/components/SiteNav.tsx`, which is the nav actually rendered in the browser today.

Two commits:
1. **`66de8b9`** — `components/navigation/DesktopNav.tsx` restyle (as literally instructed by the Phase 3 brief)
2. **`12f95ad`** — `app/components/SiteNav.tsx` restyle (the Phase 3 follow-up "Option A")

The Phase 3 brief asked to restyle `DesktopNav.tsx`. During that work I discovered that `DesktopNav.tsx` is exported from the navigation barrel but not imported anywhere in the running app — the actual rendered desktop nav is `SiteNav.tsx`. I completed the literal instruction first (commit 1), surfaced the finding, and then applied the identical spec to `SiteNav.tsx` on user confirmation (commit 2).

## Design spec applied (both files)

| Element | Value |
|---|---|
| **Header bg** | `rgba(5, 7, 20, 0.85)` |
| **Header blur** | `backdrop-filter: blur(20px)` (+ `-webkit-` for Safari) |
| **Header border-bottom** | `1px solid rgba(212, 160, 23, 0.1)` |
| **Logo** | "Sakha" in `font-divine` italic (Cormorant Garamond), `#D4A017`, 28px / weight 500 / letter-spacing 0.02em |
| **Nav links (rest)** | `font-ui` (Outfit) 13px / 500 / 0.02em, color `#B8AE98` |
| **Nav links (active)** | color `#D4A017` |
| **CTA bg** | `linear-gradient(135deg, #D4A017 0%, #F0C040 50%, #D4A017 100%)` |
| **CTA text** | `#050714` on gold, weight 600, 13px |
| **CTA shadow** | `0 4px 14px rgba(212, 160, 23, 0.35)` |
| **Hamburger dropdown bg** | `rgba(11, 14, 42, 0.98)` |
| **Hamburger dropdown blur** | `backdrop-filter: blur(20px)` |
| **Hamburger dropdown border** | `1px solid rgba(212, 160, 23, 0.3)` top + bottom |

## SiteNav.tsx specifics

The user's follow-up explicitly said **"Do NOT touch the divine, highlight, or premium flag logic — only colours and fonts change."** SiteNav has richer conditional styling than DesktopNav: `divine` and `highlight` links render with a 2px gold border when active, a 1px muted-gold border at rest, and highlight links carry an "AI" badge in the mobile dropdown.

All of that structural logic is preserved byte-for-byte. Only the color and font tokens inside those branches were swapped:
- `#d4a44c` → `#D4A017` (gold primary)
- `#e8b54a` → `#F0C040` (gold bright)
- `text-white/60` (regular rest) → `#B8AE98`
- `text-white` (regular active) → `#D4A017`
- `text-sm font-semibold` → `font-ui 13px / 500 / 0.02em`

The framer-motion wrappers (`motion.header` entrance, per-link stagger, logo hover/tap, hamburger rotation, mobile menu `AnimatePresence`) are all retained unchanged.

## DesktopNav.tsx specifics

Similar translation, with a slightly simpler DOM — no `divine`/`highlight`/`premium` branching (DesktopNav never had it). The commit removed the now-unused `MindVibeLockup` import and replaced the lockup composite with the "Sakha" text wordmark.

## Scope safety

- ✅ **Zero `/m/` files touched** on either commit — verified with `git diff --name-only`: only `components/navigation/DesktopNav.tsx` and `app/components/SiteNav.tsx` modified.
- ✅ No API routes, backend code, types, or data-flow changes — pure presentational refactor.
- ✅ `divine` / `highlight` / `premium` flag logic preserved structurally; only color/font tokens inside those branches changed.
- ✅ `MobileRouteGuard` continues to hide `SiteNav` on `/m/*` routes (unchanged from main) — mobile shell is untouched.

## Test plan

- [x] `pnpm typecheck` after DesktopNav commit — **pass** (0 errors)
- [x] `pnpm build` after DesktopNav commit — **pass** (`Compiled in 39.9s`)
- [x] `pnpm typecheck` after SiteNav commit — **pass** (0 errors)
- [x] `pnpm build` after SiteNav commit — **pass** (`Compiled in 38.2s`)
- [x] `pnpm test` frontend — **582/585 passing**, 3 intentional skips. Split into `--exclude '**/ToolPages.test.tsx'` (563/566 pass) + `ToolPages.test.tsx` in isolation (19/19 pass). The pre-existing `ToolPages > Karma Footprint Page > renders the page title correctly` flake (`waitFor(5000ms)` timing out under full-suite parallel load) is reproducible on clean `main` and unrelated to this PR.
- [x] Backend `pytest` — **76 passed, 1 skipped** across `test_journey_engine_dashboard`, `test_journey_service`, `test_kiaan_voice_comprehensive`. (`test_mobile_subscription.py` cannot collect due to missing `_cffi_backend` native extension — pre-existing sandbox env issue, unrelated.)
- [ ] Manual smoke: load `/`, `/sadhana`, `/kiaan/chat`, `/dashboard`, `/tools/karmic-tree` and confirm header background, blur, gold border, Cormorant Sakha logo, gold CTA all render correctly across breakpoints.
- [ ] Manual smoke: open the hamburger menu on a narrow viewport and confirm the dropdown bg is `rgba(11,14,42,0.98)` with gold borders top and bottom.
- [ ] Manual smoke: navigate to a divine link (e.g., `/`, `/sadhana`) and a highlight link (`/kiaan/chat`) to confirm the 2px gold border active state still renders.
- [ ] Manual smoke: load `/m/` and confirm the new header is **NOT** visible (mobile shell takes over via `MobileRouteGuard` — unchanged).

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `components/navigation/DesktopNav.tsx` | +123 / −58 | Literal Phase 3 restyle |
| `app/components/SiteNav.tsx` | +92 / −31 | Phase 3 follow-up (Option A) — restyle rendered nav |

**Total:** 2 files, +215 / −89

https://claude.ai/code/session_01DMYNGajgb2y2KnPGbL7S2i