### PR TITLE
refactor(layout): P3-E Phase 5 — 2-column desktop layouts for dashboard, journeys, kiaan/chat

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -555,6 +555,10 @@ export default function DashboardClient() {
             />
           </motion.div>
 
+          {/* ─── Main card group: 2-column responsive grid
+                display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px;
+                Collapses to 1 column below 1024px via lg: breakpoint. ─── */}
+          <div className="lg:grid lg:gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
           {/* ─── Speak to KIAAN (SECONDARY) ─── */}
           <motion.div variants={itemVariants}>
             <Link
@@ -779,6 +783,8 @@ export default function DashboardClient() {
               <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-[#d4a44c]/20 to-transparent" />
             </div>
           </motion.div>
+          </div>
+          {/* ─── /Main card group grid ─── */}
 
         </motion.div>
       </FadeIn>

--- a/app/journeys/JourneysPageClient.tsx
+++ b/app/journeys/JourneysPageClient.tsx
@@ -736,7 +736,10 @@ export default function JourneysPageClient() {
             {templates.length > 0 && (
               <div className="mt-8">
                 <h2 className="text-base font-semibold mb-4">Available Journeys</h2>
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {/* ─── Templates grid: 2-column responsive grid
+                     display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px;
+                     Collapses to 1 column below 1024px via lg: breakpoint. ─── */}
+                <div className="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
                   {templates.slice(0, 6).map((template) => (
                     <TemplateCard
                       key={template.id}
@@ -1073,10 +1076,12 @@ export default function JourneysPageClient() {
                   <EnemyFilter selected={selectedEnemy} onSelect={setSelectedEnemy} />
                 </div>
 
-                {/* Templates grid */}
+                {/* Templates grid: 2-column responsive grid (sacred pattern)
+                     display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px;
+                     Collapses to 1 column below 1024px via lg: breakpoint. */}
                 {templates.length > 0 ? (
                   <>
-                    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    <div className="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
                       {templates.map((template) => (
                         <TemplateCard
                           key={template.id}

--- a/app/kiaan/chat/page.tsx
+++ b/app/kiaan/chat/page.tsx
@@ -232,8 +232,20 @@ function KiaanChatPageInner() {
     handleSendMessage(prompt);
   };
 
+  // ─── Recent topics: derived from themeCounts store (no new fetches) ───
+  const recentTopics = useMemo(() => {
+    return Object.entries(themeCounts)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5)
+      .map(([theme]) => theme)
+  }, [themeCounts])
+
   return (
-    <main className="mx-auto max-w-5xl space-y-4 sm:space-y-6 p-3 sm:p-4 pb-28 sm:pb-24 md:p-8">
+    <main className="mx-auto max-w-5xl p-3 sm:p-4 pb-28 sm:pb-24 md:p-8">
+      {/* ─── Phase 5 layout: 2-column flex — chat panel flex:1 left, context sidebar 320px right.
+           Collapses to 1 column (flex-col) below 1024px. ─── */}
+      <div className="flex flex-col gap-4 lg:flex-row">
+      <div className="flex-1 min-w-0 space-y-4 sm:space-y-6">
       {/* Header */}
       <div
         className="relative z-10 space-y-3 sm:space-y-4 p-4 sm:p-6 shadow-[0_30px_120px_rgba(212,164,76,0.08)] md:p-8"
@@ -483,6 +495,80 @@ function KiaanChatPageInner() {
         <p className="mt-1 text-sm leading-relaxed text-[#e8dcc8]/55 font-sacred">
           {t('kiaan.chat.disclaimer', 'KIAAN is your spiritual companion, sharing reflections drawn from the Bhagavad Gita and ancient wisdom. This is a sacred space for inner peace and self-discovery. For matters beyond the spiritual path, always seek guidance from qualified professionals.')}
         </p>
+      </div>
+      </div>
+      {/* ─── Context sidebar: Verse of the day + Recent topics.
+           width: 320px on desktop, full width below 1024px.
+           Data sources: hardcoded canonical verse (BG 2.47) and themeCounts
+           from useNextStepStore — zero new fetches, zero new API calls. ─── */}
+      <aside className="lg:w-[320px] lg:flex-shrink-0 space-y-4">
+        {/* Verse of the Day — BG 2.47 (canonical, already used as Viyoga reference) */}
+        <div
+          className="p-5"
+          style={{
+            background: 'linear-gradient(145deg, rgba(22,26,66,0.95), rgba(17,20,53,0.98))',
+            border: '1px solid rgba(212,160,23,0.1)',
+            borderTop: '2px solid rgba(212,160,23,0.45)',
+            borderRadius: '18px',
+            backdropFilter: 'blur(24px) saturate(120%)',
+            WebkitBackdropFilter: 'blur(24px) saturate(120%)',
+          }}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-base">🕉️</span>
+            <span className="font-ui uppercase" style={{ fontSize: '10px', color: '#D4A017', letterSpacing: '0.14em', fontWeight: 600 }}>
+              {t('kiaan.chat.sidebar.verseOfDay', 'Verse of the Day')}
+            </span>
+          </div>
+          <p className="font-sacred text-sm leading-relaxed text-[#e8dcc8]/85 mb-2" lang="sa">
+            कर्मण्येवाधिकारस्ते मा फलेषु कदाचन ।
+            मा कर्मफलहेतुर्भूर्मा ते सङ्गोऽस्तु अकर्मणि ॥
+          </p>
+          <p className="text-xs leading-relaxed text-[#e8dcc8]/65 italic font-sacred">
+            {t('kiaan.chat.sidebar.verseTranslation', 'You have the right to perform your prescribed duty, but not to the fruits of action. Never consider yourself the cause of the results, nor be attached to inaction.')}
+          </p>
+          <p className="mt-3 text-[11px] text-[#d4a44c]/55 font-mono tracking-widest uppercase">
+            {t('kiaan.chat.sidebar.verseRef', 'Bhagavad Gita 2.47')}
+          </p>
+        </div>
+
+        {/* Recent Topics — derived from themeCounts (zero new fetches) */}
+        <div
+          className="p-5"
+          style={{
+            background: 'linear-gradient(145deg, rgba(22,26,66,0.95), rgba(17,20,53,0.98))',
+            border: '1px solid rgba(212,160,23,0.1)',
+            borderTop: '2px solid rgba(212,160,23,0.45)',
+            borderRadius: '18px',
+            backdropFilter: 'blur(24px) saturate(120%)',
+            WebkitBackdropFilter: 'blur(24px) saturate(120%)',
+          }}
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-base">💭</span>
+            <span className="font-ui uppercase" style={{ fontSize: '10px', color: '#D4A017', letterSpacing: '0.14em', fontWeight: 600 }}>
+              {t('kiaan.chat.sidebar.recentTopics', 'Recent Topics')}
+            </span>
+          </div>
+          {recentTopics.length > 0 ? (
+            <ul className="space-y-2">
+              {recentTopics.map((topic) => (
+                <li
+                  key={topic}
+                  className="flex items-center gap-2 text-xs text-[#e8dcc8]/75"
+                >
+                  <span className="text-[#d4a44c]/50">·</span>
+                  <span className="capitalize">{topic}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-[#e8dcc8]/45 italic font-sacred">
+              {t('kiaan.chat.sidebar.noTopics', 'Start chatting to see topics here.')}
+            </p>
+          )}
+        </div>
+      </aside>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Phase 5 of the P3-E desktop redesign — 2-column responsive layouts for the three most interactive pages. Introduces the sacred grid pattern:

```
display: grid;
grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
gap: 16px;
```

Collapses to 1 column below 1024px via the Tailwind `lg:` breakpoint (equivalent to `@media (max-width: 1024px)`).

Single commit: `00b2e45` — 3 files, +101 / −4.

## Changes by file

### `app/dashboard/DashboardClient.tsx`
Wrapped the main card group (**Speak to KIAAN** secondary card + **Sacred Spiritual Toolkit**) in a new responsive grid `<div>`. On desktop (≥ 1024px) the two cards sit side-by-side; below 1024px they stack naturally (grid with no column template defaults to 1 column). Divine Presence hero banner and Subscription Upsell remain full-width above the grid.

> **Note:** The Phase 5 brief described *"left column: journey stats + karma; right column: KIAAN quota + daily wisdom"* — **none of those sections exist on the current dashboard**. The actual dashboard has Sacred Greeting → Divine Presence Banner (hero) → Subscription Upsell → Speak to KIAAN → Sacred Spiritual Toolkit. I applied the grid pattern to the closest equivalent: the two main hub cards after the hero. Flag if you wanted a different pairing.

### `app/journeys/JourneysPageClient.tsx`
Replaced **both** TemplateCard grid wrappers (unauthed preview at line 739 and authed view at line 1079) with the sacred auto-fit pattern. Previously each used its own Tailwind breakpoint (`sm:grid-cols-2 lg:grid-cols-3` and `sm:grid-cols-2 xl:grid-cols-3`); now they share the unified responsive grid. Gap bumped from 12px (`gap-3`) → 16px (`gap-4`) per the sacred spec.

### `app/kiaan/chat/page.tsx`
- **Layout wrapper:** Removed `space-y-*` from `<main>`, added a `flex flex-col gap-4 lg:flex-row` wrapper. Left panel = `flex-1 min-w-0` with the original `space-y-4 sm:space-y-6` preserved. Right `<aside>` = `lg:w-[320px] lg:flex-shrink-0`.
- **Context sidebar — zero new fetches:**
  - **Verse of the Day** — hardcoded inline **BG 2.47** (कर्मण्येवाधिकारस्ते...), the most canonical Bhagavad Gita verse, already referenced as the Viyoga verse metadata in `DashboardClient.tsx:66`. Pure JSX literal — zero fetches, zero new imports, zero new data layer.
  - **Recent Topics** — derived via `useMemo` from `themeCounts`, which was already in the component via `useNextStepStore` (line 191 of the pre-change file). Sorts top 5 by occurrence count. Shows a "Start chatting to see topics here" placeholder when `themeCounts` is empty.
- Both sidebar cards use the Phase 4 sacred card pattern for visual consistency (same gradient, gold borders, 18px radius, `backdrop-filter: blur(24px) saturate(120%)`).
- On mobile/tablet (< 1024px) the sidebar stacks below the chat panel as a second row in the `flex-col` container.

## Rules respected

- ✅ **Zero `/m/` files touched** — verified via `git diff --name-only` → 0 matches
- ✅ **Zero new API calls / fetches / data fetching** — verified via grep on added diff lines for `fetch(`, `axios`, `apiCall(`, `useSWR`, `useQuery` → 0 matches
- ✅ **Zero card component internals modified** — only layout wrappers added around existing cards. Every Phase 4 sacred card style on existing cards is preserved verbatim.
- ✅ **Zero new imports** in `/kiaan/chat` — the only new code uses already-imported hooks and primitives (`useMemo`, `themeCounts`, `t`)
- ✅ **framer-motion animation systems preserved** — stagger chains, `variants={itemVariants}`, `AnimatePresence` all untouched
- ✅ **Responsive collapse to 1 column below 1024px** via Tailwind `lg:` breakpoint (equivalent to `@media (max-width: 1024px)`)
- ✅ **Zero API routes, backend code, or types modified**

## Test plan — executed

### Static analysis

| Check | Result |
|---|---|
| `pnpm typecheck` (`tsc --noEmit`) | ✅ **0 errors** |
| `pnpm build` (Next.js 16 + Turbopack) | ✅ `✓ Compiled successfully in 23.5s` |
| `pnpm exec eslint` on the 3 Phase 5 files | ✅ **Exit 0, zero errors, zero warnings** |
| `git diff` grep for `fetch(` / `axios` / `apiCall(` / `useSWR` / `useQuery` | ✅ **Zero matches** |
| `git diff` file count in `/m/` paths | ✅ **Zero** |

### Runtime smoke test (dev server on localhost:3000)

Started `pnpm dev`, waited for ready, then hit each Phase 5 page and inspected both HTTP response and Next.js server log:

| Page | HTTP | Render time | Markers verified |
|---|---|---|---|
| `/` (baseline) | **200** | 72ms | — |
| `/dashboard` | **200** | 1.31s | `lg:grid` wrapper present in SSR HTML |
| `/journeys` | **200** | 1.25s | Renders initial loading state (templates load client-side); grid wrapper is in the bundle |
| `/kiaan/chat` | **200** | 3.22s | `<Suspense>` fallback renders on SSR (expected — `useSearchParams`); sidebar strings (`Verse of the Day`, `verseOfDay`, `recentTopics`) confirmed present in compiled SSR chunks (`.next/server/chunks/ssr/`) |

**Next.js dev server log — fully clean:** Every request returned 200. Zero errors, zero warnings, zero exceptions, zero unhandled promises. Repeated each page 5+ times with average render time ~70ms after the first compile.

### Test suites

| Suite | Result |
|---|---|
| `pnpm test` frontend (excl. flake) | ✅ 563/566 passing, 3 intentional skips |
| `pnpm test` `ToolPages.test.tsx` isolated | ✅ 19/19 |
| **Frontend total** | ✅ **582/585 passing, 0 failures** |
| Backend `pytest` (`test_journey_engine_dashboard`, `test_journey_service`, `test_kiaan_voice_comprehensive`) | ✅ **76 passed, 1 skipped** |

### Pre-existing issues (NOT caused by this PR, verified on clean `main`)

- 1 Turbopack NFT warning on `lib/viyoga/gitaCorpus.ts` — unchanged from main
- 1 flaky test `ToolPages > Karma Footprint Page > renders the page title correctly` under full-suite parallel load (passes 19/19 in isolation) — pre-existing, reproducible on clean main, unrelated to this PR
- `backend/tests/test_mobile_subscription.py` cannot collect due to missing `_cffi_backend` native extension in sandbox — pre-existing env issue, last touched 2026-04-01

## Known decisions to surface

1. **Dashboard — the described sections don't exist.** See note above. Applied to closest equivalent pairing.
2. **`/kiaan/chat` verse data source.** There was no verse data anywhere on the current page (`messages`, `quota`, `themeCounts`, `quickResponses`, `nextStepSuggestion` — none contain verses). Used a **hardcoded canonical BG 2.47** inline — zero fetches, consistent with the app's existing usage in `DashboardClient.tsx:66`. If you want a different verse or a client-side rotating array (e.g., 7 verses keyed by day-of-week), say the word and I'll follow up.
3. **`/journeys` had existing Tailwind grid classes.** Replaced (not wrapped) with the sacred pattern since the user said "using the same pattern" — implying one unified grid approach. This intentionally changes the breakpoint behavior: previously 3 cols at `xl:` (1280px+), now auto-fit based on available width.
4. **Tailwind `lg:` breakpoint = 1024px** is the exact inverse of `@media (max-width: 1024px)`: `lg:` applies at `>= 1024px`, so < 1024px gets the default 1-col layout. Semantically equivalent to the media query you described.

## Manual smoke test (recommended before merge)

- [ ] Load `/dashboard` on a desktop viewport (≥ 1024px) and confirm **Speak to KIAAN** + **Sacred Spiritual Toolkit** sit side-by-side with 16px gap
- [ ] Resize to < 1024px and confirm they stack into 1 column
- [ ] Load `/journeys` (authed) and confirm `TemplateCard`s reflow via auto-fit at different viewport widths
- [ ] Load `/kiaan/chat` and confirm:
  - Left panel has header, quota, chat interface, quick responses, sacred note
  - Right sidebar shows Verse of the Day with Sanskrit + English + "Bhagavad Gita 2.47" reference
  - Right sidebar shows Recent Topics (or placeholder if no messages yet)
  - Send a few messages mentioning keywords (anxiety, relationships, etc.) and confirm Recent Topics updates live from `themeCounts`
- [ ] Load `/m/` routes and verify nothing changed (mobile shell untouched)
- [ ] Confirm no console errors in browser devtools on any of the 3 pages

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `app/dashboard/DashboardClient.tsx` | +6 / −0 | Wrap main card group in responsive grid |
| `app/journeys/JourneysPageClient.tsx` | +9 / −2 | Replace 2 TemplateCard grids with sacred auto-fit |
| `app/kiaan/chat/page.tsx` | +86 / −2 | 2-column layout + context sidebar (Verse of the Day + Recent Topics) |

**Total: 3 files changed, +101 / −4**

## Relationship to other P3-E phases

| Phase | PR | Status |
|---|---|---|
| Phase 1 (CSS tokens) | #1497 | ✅ Merged |
| Phase 2 (global canvas) | #1498 | ✅ Merged |
| Phase 3 (nav restyle) | #1499 | ✅ Merged |
| Phase 4 (sacred cards) | #1500 | ✅ Merged |
| **Phase 5 (2-col layouts)** | **this PR** | 🟢 **Open, ready for review** |

Phase 5 is branched from `main` (which already contains Phases 1–4). After this lands, the P3-E desktop redesign is **complete**: unified tokens, global celestial backdrop, sacred nav, sacred cards everywhere, and proper side-by-side information density on the three most interactive pages. 🙏

https://claude.ai/code/session_01DMYNGajgb2y2KnPGbL7S2i