### PR TITLE
Add Resend email provider support with retry logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,16 +60,24 @@ API_URL=http://localhost:8000
 FRONTEND_URL=http://localhost:3000
 
 # ---------- Email & Verification ----------
-# Provider: "console" (dev, logs emails to stdout) or "smtp" (production, sends real emails)
+# Provider: "console" (dev), "resend" (recommended for production), or "smtp"
 # WARNING: In production, REQUIRE_EMAIL_VERIFICATION defaults to true.
 # If EMAIL_PROVIDER is "console" (default), no real emails are sent and users
-# will be locked out after signup. Configure SMTP before deploying to production.
+# will be locked out after signup. Configure Resend or SMTP before deploying.
 EMAIL_PROVIDER=console
+
+# --- Resend (recommended, https://resend.com) ---
+# Free tier: 100 emails/day. Get API key from https://resend.com/api-keys
+RESEND_API_KEY=
+
+# --- SMTP (alternative) ---
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=
 SMTP_PASSWORD=
 SMTP_USE_TLS=true
+
+# Shared settings (used by both resend and smtp)
 EMAIL_FROM_ADDRESS=noreply@kiaanverse.com
 EMAIL_FROM_NAME=Kiaanverse
 # Email verification enforcement (default: true in production, false in development)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -275,7 +275,7 @@ async def signup(request: Request, payload: SignupIn, db: AsyncSession = Depends
                 )
         else:
             logger.error(
-                "Email delivery not configured (EMAIL_PROVIDER != smtp) — "
+                "Email delivery not configured (can_send_email() = False) — "
                 "cannot send verification email for user %s. "
                 "User will remain unverified until email is configured "
                 "and they request a new verification link.",
@@ -838,7 +838,7 @@ async def forgot_password(
     if not can_send_email():
         logger.warning(
             "Password reset requested but email delivery not configured "
-            "(EMAIL_PROVIDER != smtp)"
+            "(can_send_email() = False)"
         )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -1180,7 +1180,7 @@ async def resend_verification(
     if not can_send_email():
         logger.warning(
             "Verification email resend requested but email delivery not configured "
-            "(EMAIL_PROVIDER != smtp)"
+            "(can_send_email() = False)"
         )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -1,6 +1,7 @@
 """Email service for transactional emails (verification, password reset).
 
 Supports multiple providers via a clean abstraction:
+- Resend (production — sends via Resend HTTP API, recommended)
 - SMTP (production — sends real emails via any SMTP provider)
 - Console (development — prints to logs instead of sending)
 
@@ -20,7 +21,8 @@ from email.mime.text import MIMEText
 logger = logging.getLogger(__name__)
 
 # Configuration from environment
-EMAIL_PROVIDER = os.getenv("EMAIL_PROVIDER", "console")  # console | smtp
+EMAIL_PROVIDER = os.getenv("EMAIL_PROVIDER", "console")  # console | resend | smtp
+RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 SMTP_HOST = os.getenv("SMTP_HOST", "localhost")
 SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
 SMTP_USER = os.getenv("SMTP_USER", "")
@@ -42,11 +44,11 @@ def can_send_email() -> bool:
     (e.g. mandatory email verification before login) because the user will
     never receive the email.
     """
-    if EMAIL_PROVIDER != "smtp":
-        return False
-    if not SMTP_HOST or SMTP_HOST == "localhost":
-        return False
-    return True
+    if EMAIL_PROVIDER == "resend":
+        return bool(RESEND_API_KEY)
+    if EMAIL_PROVIDER == "smtp":
+        return bool(SMTP_HOST and SMTP_HOST != "localhost")
+    return False
 
 
 def validate_email_config() -> list[str]:
@@ -79,6 +81,17 @@ def validate_email_config() -> list[str]:
             )
         else:
             warnings.append(msg)
+    elif EMAIL_PROVIDER == "resend":
+        if not RESEND_API_KEY:
+            warnings.append(
+                "EMAIL_PROVIDER=resend but RESEND_API_KEY is not set. "
+                "Get your API key from https://resend.com/api-keys"
+            )
+        if not EMAIL_FROM_ADDRESS or EMAIL_FROM_ADDRESS == "noreply@kiaanverse.com":
+            warnings.append(
+                "EMAIL_FROM_ADDRESS should use a domain verified in your Resend dashboard. "
+                "See https://resend.com/domains"
+            )
     elif EMAIL_PROVIDER == "smtp":
         if not SMTP_HOST or SMTP_HOST == "localhost":
             warnings.append(
@@ -91,7 +104,7 @@ def validate_email_config() -> list[str]:
                 "Most SMTP providers require authentication."
             )
     else:
-        warnings.append(f"Unknown EMAIL_PROVIDER '{EMAIL_PROVIDER}'. Use 'smtp' or 'console'.")
+        warnings.append(f"Unknown EMAIL_PROVIDER '{EMAIL_PROVIDER}'. Use 'resend', 'smtp', or 'console'.")
 
     return warnings
 
@@ -104,6 +117,8 @@ async def send_email(to: str, subject: str, html_body: str, text_body: str | Non
     """
     if EMAIL_PROVIDER == "console":
         return _send_console(to, subject, html_body, text_body)
+    elif EMAIL_PROVIDER == "resend":
+        return await _send_resend(to, subject, html_body, text_body)
     elif EMAIL_PROVIDER == "smtp":
         return _send_smtp(to, subject, html_body, text_body)
     else:
@@ -121,6 +136,83 @@ def _send_console(to: str, subject: str, html_body: str, text_body: str | None) 
     )
     # Return False so callers know the email was NOT actually delivered.
     # This prevents misleading "verification email sent" responses.
+    return False
+
+
+async def _send_resend(to: str, subject: str, html_body: str, text_body: str | None) -> bool:
+    """Production provider: sends via Resend HTTP API with retry on transient failures."""
+    import asyncio
+
+    import httpx
+
+    payload: dict = {
+        "from": f"{EMAIL_FROM_NAME} <{EMAIL_FROM_ADDRESS}>",
+        "to": [to],
+        "subject": subject,
+        "html": html_body,
+    }
+    if text_body:
+        payload["text"] = text_body
+
+    last_error: Exception | None = None
+    for attempt in range(1, _SMTP_MAX_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    "https://api.resend.com/emails",
+                    headers={
+                        "Authorization": f"Bearer {RESEND_API_KEY}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                if response.status_code == 200:
+                    data = response.json()
+                    logger.info("Email sent via Resend to %s: %s (id=%s)", to, subject, data.get("id"))
+                    return True
+                elif response.status_code == 429:
+                    last_error = Exception(f"Resend rate limit: {response.text}")
+                    logger.warning(
+                        "Resend rate limited sending to %s (attempt %d/%d)",
+                        to, attempt, _SMTP_MAX_RETRIES,
+                    )
+                elif 500 <= response.status_code < 600:
+                    last_error = Exception(f"Resend server error: {response.status_code} {response.text}")
+                    logger.warning(
+                        "Resend server error sending to %s (attempt %d/%d): %d %s",
+                        to, attempt, _SMTP_MAX_RETRIES, response.status_code, response.text,
+                    )
+                else:
+                    # 4xx client error (bad request, auth failure) — don't retry
+                    logger.error(
+                        "Resend client error sending to %s: %d %s",
+                        to, response.status_code, response.text,
+                    )
+                    return False
+        except httpx.TimeoutException as e:
+            last_error = e
+            logger.warning(
+                "Resend timeout sending to %s (attempt %d/%d): %s",
+                to, attempt, _SMTP_MAX_RETRIES, e,
+            )
+        except httpx.HTTPError as e:
+            last_error = e
+            logger.warning(
+                "Resend HTTP error sending to %s (attempt %d/%d): %s",
+                to, attempt, _SMTP_MAX_RETRIES, e,
+            )
+        except Exception as e:
+            logger.error("Unexpected error sending email via Resend to %s: %s", to, e)
+            return False
+
+        if attempt < _SMTP_MAX_RETRIES:
+            wait = _SMTP_RETRY_DELAY * (2 ** (attempt - 1))
+            await asyncio.sleep(wait)
+
+    logger.error(
+        "Failed to send email via Resend to %s after %d attempts. Last error: %s",
+        to, _SMTP_MAX_RETRIES, last_error,
+    )
     return False
 
 

--- a/render.yaml
+++ b/render.yaml
@@ -63,14 +63,16 @@ services:
       # Spiritual wellness data encryption key (must match MINDVIBE_REFLECTION_KEY)
       - key: MINDVIBE_REFLECTION_KEY
         generateValue: true
-      # Email provider: "console" logs emails (dev), "smtp" sends real emails.
-      # Set to "smtp" and configure SMTP_* vars in Render Dashboard to enable
-      # verification emails, password resets, etc.
+      # Email provider: "resend" (recommended), "smtp", or "console" (dev only).
+      # Set RESEND_API_KEY in Render Dashboard > Environment to enable email delivery.
       - key: EMAIL_PROVIDER
-        value: "console"
-      # Auto-disabled when EMAIL_PROVIDER != smtp to prevent user lockout
+        value: "resend"
+      # Email verification — enforced when email delivery is configured
       - key: REQUIRE_EMAIL_VERIFICATION
-        value: "false"
+        value: "true"
+      # Resend API key — set in Render Dashboard (not committed to repo)
+      - key: RESEND_API_KEY
+        value: ""
     healthCheckPath: /health
     # Autoscaling settings — scale to 10 instances for up to 1,000 concurrent users
     scaling:


### PR DESCRIPTION
## Summary

Add support for Resend as a production email provider alongside existing SMTP and console providers. Resend is now the recommended provider for production deployments due to its simplicity and reliability.

## Changes

### Backend Email Service (`backend/services/email_service.py`)
- Added `RESEND_API_KEY` environment variable configuration
- Implemented `_send_resend()` async function with:
  - HTTP API integration with Resend's `/emails` endpoint
  - Exponential backoff retry logic for transient failures (429, 5xx errors)
  - Proper error handling distinguishing retryable vs. non-retryable failures
  - Comprehensive logging for debugging
- Updated `can_send_email()` to support Resend provider validation
- Updated `validate_email_config()` to validate Resend-specific settings (API key, verified domain)
- Updated `send_email()` dispatcher to route to Resend provider

### Configuration Files
- **render.yaml**: Changed default `EMAIL_PROVIDER` from "console" to "resend" and set `REQUIRE_EMAIL_VERIFICATION` to "true" for production
- **.env.example**: Added Resend configuration section with API key placeholder and updated documentation to recommend Resend

### Auth Routes (`backend/routes/auth.py`)
- Updated error messages in `signup()`, `forgot_password()`, and `resend_verification()` to reference `can_send_email()` function instead of hardcoded provider check, making them provider-agnostic

## Why This Matters

Resend provides a simpler, more reliable alternative to SMTP configuration:
- No need to manage SMTP credentials or server configuration
- Built-in reliability with automatic retries
- Better deliverability and monitoring
- Free tier supports 100 emails/day (sufficient for most applications)
- Recommended as the default for new production deployments

## Checklist
- [x] CI passes (tests run successfully)
- [x] No private keys are committed (RESEND_API_KEY is empty string in config)
- [x] Documentation updated (.env.example, render.yaml comments)
- [x] Backward compatible (SMTP and console providers still fully functional)

## Testing

Verified locally:
- `can_send_email()` correctly validates Resend configuration
- `validate_email_config()` generates appropriate warnings for missing API key or unverified domain
- Resend provider routing in `send_email()` dispatcher works correctly
- Error messages in auth routes are provider-agnostic
- Existing SMTP and console providers remain unaffected

https://claude.ai/code/session_01367iauAPEdzkUjfhByeGSP