### PR TITLE
Extract WebSocket reconnection logic into reusable hook

### DIFF
--- a/app/(mobile)/m/subscribe/page.tsx
+++ b/app/(mobile)/m/subscribe/page.tsx
@@ -16,6 +16,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PlanSelector } from '@/components/mobile/payment/PlanSelector'
 import { BillingToggle } from '@/components/mobile/payment/BillingToggle'
@@ -278,13 +279,13 @@ export default function SubscribePage() {
         <footer className="text-center pb-8 pt-2">
           <p className="text-[11px] text-[#6B6355] leading-snug" style={{ fontFamily: 'Outfit, system-ui, sans-serif' }}>
             By continuing, you agree to the{' '}
-            <a href="/terms" className="underline underline-offset-2 hover:text-[#B8AE98] transition-colors">
+            <Link href="/terms" className="underline underline-offset-2 hover:text-[#B8AE98] transition-colors">
               Terms of Service
-            </a>{' '}
+            </Link>{' '}
             and{' '}
-            <a href="/privacy" className="underline underline-offset-2 hover:text-[#B8AE98] transition-colors">
+            <Link href="/privacy" className="underline underline-offset-2 hover:text-[#B8AE98] transition-colors">
               Privacy Policy
-            </a>.
+            </Link>.
             <br />
             Subscriptions auto-renew. Cancel anytime in Settings.
             <br />

--- a/app/(mobile)/m/wisdom-rooms/page.tsx
+++ b/app/(mobile)/m/wisdom-rooms/page.tsx
@@ -11,7 +11,7 @@
  * - Offline graceful degradation
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useRouter } from 'next/navigation'
 import {
@@ -25,6 +25,7 @@ import { MobileAppShell } from '@/components/mobile/MobileAppShell'
 import { useAuth } from '@/hooks/useAuth'
 import { useHapticFeedback } from '@/hooks/useHapticFeedback'
 import { apiFetch } from '@/lib/api'
+import { useReconnectingWebSocket } from '@/hooks/useReconnectingWebSocket'
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || ''
 
@@ -67,9 +68,7 @@ export default function MobileWisdomRoomsPage() {
   const [roomMessages, setRoomMessages] = useState<Record<string, RoomMessage[]>>({})
   const [participants, setParticipants] = useState<Record<string, Participant[]>>({})
   const [message, setMessage] = useState('')
-  const [status, setStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected')
   const [alert, setAlert] = useState<string | null>(null)
-  const [socket, setSocket] = useState<WebSocket | null>(null)
   const [currentUserId, setCurrentUserId] = useState<string>('')
   const [showParticipants, setShowParticipants] = useState(false)
   const chatContainerRef = useRef<HTMLDivElement>(null)
@@ -117,62 +116,48 @@ export default function MobileWisdomRoomsPage() {
     loadRooms()
   }, [isAuthenticated])
 
-  // WebSocket connection
-  useEffect(() => {
-    if (!activeRoomId || !rooms.length || !isAuthenticated) return
-
+  // Derive the active room ID for WebSocket URL
+  const activeRoomConnectId = useMemo(() => {
+    if (!activeRoomId || !rooms.length || !isAuthenticated) return null
     const room = rooms.find(r => r.id === activeRoomId || r.slug === activeRoomId)
-    if (!room) {
-      setStatus('disconnected')
-      return
-    }
-
-    const roomId = room.id || room.slug
-    setStatus('connecting')
-    setAlert(null)
-
-    const wsUrl = `${apiUrl.replace(/^http/, 'ws')}/api/rooms/${roomId}/ws`
-    const ws = new WebSocket(wsUrl)
-
-    ws.onopen = () => {
-      setStatus('connected')
-      setAlert(null)
-    }
-
-    ws.onmessage = event => {
-      try {
-        const payload = JSON.parse(event.data)
-        if (payload.type === 'history') {
-          setRoomMessages(prev => ({ ...prev, [roomId]: payload.messages }))
-        }
-        if (payload.type === 'message') {
-          setRoomMessages(prev => ({
-            ...prev,
-            [roomId]: [...(prev[roomId] || []), payload],
-          }))
-        }
-        if (payload.type === 'participants') {
-          setParticipants(prev => ({ ...prev, [roomId]: payload.participants }))
-        }
-        if (payload.type === 'error') {
-          setAlert(payload.message || 'Unable to send message')
-        }
-      } catch (error) {
-        console.error('Failed to parse message', error)
-      }
-    }
-
-    ws.onclose = () => {
-      setStatus('disconnected')
-    }
-
-    setSocket(ws)
-
-    return () => {
-      ws.close()
-      setSocket(null)
-    }
+    return room ? (room.id || room.slug) : null
   }, [activeRoomId, rooms, isAuthenticated])
+
+  // Build the WebSocket URL (null when not ready to connect)
+  const wsUrl = useMemo(() => {
+    if (!activeRoomConnectId) return null
+    return `${apiUrl.replace(/^http/, 'ws')}/api/rooms/${activeRoomConnectId}/ws`
+  }, [activeRoomConnectId])
+
+  const handleWsMessage = useCallback((payload: unknown) => {
+    const data = payload as { type: string; messages?: RoomMessage[]; participants?: Participant[]; message?: string; [key: string]: unknown }
+    if (!activeRoomConnectId) return
+    if (data.type === 'history') {
+      setRoomMessages(prev => ({ ...prev, [activeRoomConnectId]: data.messages || [] }))
+    }
+    if (data.type === 'message') {
+      setRoomMessages(prev => ({
+        ...prev,
+        [activeRoomConnectId]: [...(prev[activeRoomConnectId] || []), data as unknown as RoomMessage],
+      }))
+    }
+    if (data.type === 'participants') {
+      setParticipants(prev => ({ ...prev, [activeRoomConnectId]: data.participants || [] }))
+    }
+    if (data.type === 'error') {
+      setAlert(data.message || 'Unable to send message')
+    }
+  }, [activeRoomConnectId])
+
+  const { send: wsSend, status } = useReconnectingWebSocket({
+    url: wsUrl,
+    onMessage: handleWsMessage,
+  })
+
+  // Clear alert when connected
+  useEffect(() => {
+    if (status === 'connected') setAlert(null)
+  }, [status])
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -190,15 +175,15 @@ export default function MobileWisdomRoomsPage() {
 
   const sendMessage = useCallback(() => {
     if (!message.trim()) return
-    if (status !== 'connected' || !socket) {
+    if (status !== 'connected') {
       setAlert('Not connected. Please wait while we reconnect.')
       return
     }
-    socket.send(JSON.stringify({ content: message.trim() }))
+    wsSend(JSON.stringify({ content: message.trim() }))
     setMessage('')
     triggerHaptic('light')
     inputRef.current?.focus()
-  }, [message, status, socket, triggerHaptic])
+  }, [message, status, wsSend, triggerHaptic])
 
   const handleRoomSwitch = (roomId: string) => {
     setActiveRoomId(roomId)

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,15 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-
-/** Detect chunk/module load failures caused by stale deployments. */
-function isChunkLoadError(error: Error): boolean {
-  return (
-    error.name === 'ChunkLoadError' ||
-    /loading chunk [\w.-]+ failed/i.test(error.message) ||
-    /failed to fetch dynamically imported module/i.test(error.message)
-  )
-}
+import { isChunkLoadError, attemptChunkRecovery } from '@/lib/chunk-recovery'
 
 export default function Error({
   error,
@@ -23,17 +15,7 @@ export default function Error({
 
     // Auto-recover from stale chunk errors (new deployment invalidated old chunks)
     if (isChunkLoadError(error)) {
-      try {
-        const KEY = '__chunk_reload'
-        if (!sessionStorage.getItem(KEY)) {
-          sessionStorage.setItem(KEY, '1')
-          window.location.reload()
-          return
-        }
-        sessionStorage.removeItem(KEY)
-      } catch {
-        // sessionStorage unavailable — show error UI
-      }
+      if (attemptChunkRecovery()) return
     }
   }, [error])
 

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,15 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-
-/** Detect chunk/module load failures caused by stale deployments. */
-function isChunkLoadError(error: Error): boolean {
-  return (
-    error.name === 'ChunkLoadError' ||
-    /loading chunk [\w.-]+ failed/i.test(error.message) ||
-    /failed to fetch dynamically imported module/i.test(error.message)
-  )
-}
+import { isChunkLoadError, attemptChunkRecovery } from '@/lib/chunk-recovery'
 
 export default function GlobalError({
   error,
@@ -21,17 +13,7 @@ export default function GlobalError({
   useEffect(() => {
     // Auto-recover from stale chunk errors (new deployment invalidated old chunks)
     if (isChunkLoadError(error)) {
-      try {
-        const KEY = '__chunk_reload'
-        if (!sessionStorage.getItem(KEY)) {
-          sessionStorage.setItem(KEY, '1')
-          window.location.reload()
-          return
-        }
-        sessionStorage.removeItem(KEY)
-      } catch {
-        // sessionStorage unavailable — show error UI
-      }
+      if (attemptChunkRecovery()) return
     }
   }, [error])
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -125,23 +125,43 @@ const languageScript = `
 // When Vercel deploys, old cached HTML references chunk hashes that no longer
 // exist on the CDN (404). This listener catches those script-load failures and
 // reloads the page once so the browser fetches fresh HTML with correct chunks.
-// A sessionStorage flag prevents infinite reload loops.
+// Uses a dual-guard strategy (sessionStorage + URL param) to prevent infinite
+// reload loops even when sessionStorage is unavailable (quota exceeded, etc.).
 const chunkErrorRecoveryScript = `
 (function() {
   try {
     var KEY = '__chunk_reload';
+    var PARAM = '__chunk_reloaded';
+
+    // Fallback guard: check URL parameter (survives sessionStorage failures)
+    var url = new URL(window.location.href);
+    if (url.searchParams.has(PARAM)) {
+      url.searchParams.delete(PARAM);
+      history.replaceState(null, '', url.pathname + url.search + url.hash);
+      return;
+    }
+
+    // Primary guard: check sessionStorage
     if (sessionStorage.getItem(KEY)) {
       sessionStorage.removeItem(KEY);
       return;
     }
+
     window.addEventListener('error', function(e) {
       var t = e.target;
       if (
         t && t.tagName === 'SCRIPT' &&
         t.src && t.src.indexOf('/_next/') !== -1
       ) {
-        sessionStorage.setItem(KEY, '1');
-        window.location.reload();
+        try {
+          sessionStorage.setItem(KEY, '1');
+          window.location.reload();
+        } catch (ex) {
+          // sessionStorage failed — use URL param fallback
+          var u = new URL(window.location.href);
+          u.searchParams.set(PARAM, '1');
+          window.location.assign(u.href);
+        }
       }
     }, true);
   } catch (e) {}

--- a/app/tools/emotional-reset/EmotionalResetClient.tsx
+++ b/app/tools/emotional-reset/EmotionalResetClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { EmotionalResetWizard } from '@/components/emotional-reset'
 import { ToolActionCard } from '@/components/tools'
 import { FadeIn } from '@/components/ui'
@@ -42,9 +43,9 @@ export default function EmotionalResetClient() {
           <p className="text-sm text-[#f5f0e8]/75 font-sacred leading-relaxed mb-2">
             A calming 7-step sacred flow to process emotions, find inner peace, and restore your spirit with gentle, divine guidance.
           </p>
-          <a href="/dashboard" className="text-xs text-[#d4a44c]/50 hover:text-[#d4a44c]/70 transition">
+          <Link href="/dashboard" className="text-xs text-[#d4a44c]/50 hover:text-[#d4a44c]/70 transition">
             &larr; Back to dashboard
-          </a>
+          </Link>
         </FadeIn>
 
         {/* Quick Actions — Sacred Paths */}

--- a/app/wisdom-rooms/page.tsx
+++ b/app/wisdom-rooms/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
 import Link from 'next/link'
 import { KiaanLogo } from '@/src/components/KiaanLogo'
 import { apiFetch } from '@/lib/api'
+import { useReconnectingWebSocket } from '@/hooks/useReconnectingWebSocket'
 
 /**
  * Derive the backend WebSocket URL at runtime.
@@ -52,9 +53,7 @@ export default function WisdomRoomsPage() {
   const [roomMessages, setRoomMessages] = useState<Record<string, RoomMessage[]>>({})
   const [participants, setParticipants] = useState<Record<string, Participant[]>>({})
   const [message, setMessage] = useState('')
-  const [status, setStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected')
   const [alert, setAlert] = useState<string | null>(null)
-  const [socket, setSocket] = useState<WebSocket | null>(null)
   const [currentUserId, setCurrentUserId] = useState<string>('')
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const chatContainerRef = useRef<HTMLDivElement>(null)
@@ -102,67 +101,49 @@ export default function WisdomRoomsPage() {
     loadRooms()
   }, [isAuthenticated])
 
-  useEffect(() => {
-    if (!activeRoomId || !rooms.length || !isAuthenticated) return
+  // Derive the active room ID for the WebSocket URL
+  const activeRoomConnectId = useMemo(() => {
+    if (!activeRoomId || !rooms.length || !isAuthenticated) return null
     const room = rooms.find(r => r.id === activeRoomId || r.slug === activeRoomId)
-    if (!room) {
-      setStatus('disconnected')
-      return
-    }
-
-    const roomId = room.id || room.slug
-    setStatus('connecting')
-    setAlert(null)
-
-    // Auth is handled via httpOnly cookies sent automatically during WebSocket upgrade
-    const wsBase = getBackendWsUrl()
-    const wsUrl = `${wsBase}/api/rooms/${roomId}/ws`
-    const ws = new WebSocket(wsUrl)
-
-    ws.onopen = () => {
-      setStatus('connected')
-      setAlert(null)
-    }
-
-    ws.onmessage = event => {
-      try {
-        const payload = JSON.parse(event.data)
-        if (payload.type === 'history') {
-          setRoomMessages(prev => ({ ...prev, [roomId]: payload.messages }))
-        }
-        if (payload.type === 'message') {
-          setRoomMessages(prev => ({
-            ...prev,
-            [roomId]: [...(prev[roomId] || []), payload]
-          }))
-        }
-        if (payload.type === 'participants') {
-          setParticipants(prev => ({ ...prev, [roomId]: payload.participants }))
-        }
-        if (payload.type === 'error') {
-          setAlert(payload.message || 'Unable to send message right now')
-        }
-      } catch (error) {
-        console.error('Failed to parse message', error)
-      }
-    }
-
-    ws.onerror = () => {
-      setStatus('disconnected')
-      setAlert('Connection error — trying to reconnect...')
-    }
-
-    ws.onclose = () => {
-      setStatus('disconnected')
-    }
-
-    setSocket(ws)
-
-    return () => {
-      ws.close()
-      setSocket(null)
-    }
+    return room ? (room.id || room.slug) : null
   }, [activeRoomId, rooms, isAuthenticated])
+
+  // Build the WebSocket URL (null when not ready to connect)
+  const wsUrl = useMemo(() => {
+    if (!activeRoomConnectId) return null
+    const wsBase = getBackendWsUrl()
+    return `${wsBase}/api/rooms/${activeRoomConnectId}/ws`
+  }, [activeRoomConnectId])
+
+  const handleWsMessage = useCallback((payload: unknown) => {
+    const data = payload as { type: string; messages?: RoomMessage[]; participants?: Participant[]; message?: string; [key: string]: unknown }
+    if (!activeRoomConnectId) return
+    if (data.type === 'history') {
+      setRoomMessages(prev => ({ ...prev, [activeRoomConnectId]: data.messages || [] }))
+    }
+    if (data.type === 'message') {
+      setRoomMessages(prev => ({
+        ...prev,
+        [activeRoomConnectId]: [...(prev[activeRoomConnectId] || []), data as unknown as RoomMessage]
+      }))
+    }
+    if (data.type === 'participants') {
+      setParticipants(prev => ({ ...prev, [activeRoomConnectId]: data.participants || [] }))
+    }
+    if (data.type === 'error') {
+      setAlert(data.message || 'Unable to send message right now')
+    }
+  }, [activeRoomConnectId])
+
+  const { send: wsSend, status, reconnect, retryAttempt, maxRetries: wsMaxRetries } = useReconnectingWebSocket({
+    url: wsUrl,
+    onMessage: handleWsMessage,
+  })
+
+  // Clear alert when connection is established
+  useEffect(() => {
+    if (status === 'connected') setAlert(null)
+  }, [status])
 
   useEffect(() => {
     if (chatContainerRef.current) {
@@ -179,13 +160,13 @@ export default function WisdomRoomsPage() {
   const activeMessages = activeRoom ? roomMessages[activeRoom.id || activeRoom.slug] || [] : []
   const activeParticipants = activeRoom ? participants[activeRoom.id || activeRoom.slug] || [] : []
 
-  async function sendMessage() {
+  function sendMessage() {
     if (!message.trim()) return
-    if (status !== 'connected' || !socket) {
+    if (status !== 'connected') {
       setAlert('You are not connected. Please wait while we reconnect to the room.')
       return
     }
-    socket.send(JSON.stringify({ content: message.trim() }))
+    wsSend(JSON.stringify({ content: message.trim() }))
     setMessage('')
   }
 

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -2,15 +2,7 @@
 
 import React, { Component, ReactNode } from 'react'
 import * as Sentry from '@sentry/nextjs'
-
-/** Detect chunk/module load failures caused by stale deployments. */
-function isChunkLoadError(error: Error): boolean {
-  return (
-    error.name === 'ChunkLoadError' ||
-    /loading chunk [\w.-]+ failed/i.test(error.message) ||
-    /failed to fetch dynamically imported module/i.test(error.message)
-  )
-}
+import { isChunkLoadError, attemptChunkRecovery } from '@/lib/chunk-recovery'
 
 interface Props {
   children: ReactNode
@@ -47,17 +39,7 @@ class ErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     // Auto-recover from stale chunk errors by reloading once
     if (isChunkLoadError(error)) {
-      try {
-        const KEY = '__chunk_reload'
-        if (!sessionStorage.getItem(KEY)) {
-          sessionStorage.setItem(KEY, '1')
-          window.location.reload()
-          return
-        }
-        sessionStorage.removeItem(KEY)
-      } catch {
-        // sessionStorage unavailable — fall through to normal error UI
-      }
+      if (attemptChunkRecovery()) return
     }
 
     // Report to Sentry for production monitoring

--- a/components/mobile/MobileErrorBoundary.tsx
+++ b/components/mobile/MobileErrorBoundary.tsx
@@ -10,6 +10,7 @@
 
 import React, { Component, ReactNode } from 'react'
 import { RefreshCw, Home, ArrowLeft } from 'lucide-react'
+import { isChunkLoadError, attemptChunkRecovery } from '@/lib/chunk-recovery'
 
 interface Props {
   children: ReactNode
@@ -36,6 +37,11 @@ export class MobileErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('MobileErrorBoundary caught error:', error, errorInfo)
+
+    // Auto-recover from stale chunk errors (new deployment invalidated old chunks)
+    if (isChunkLoadError(error)) {
+      if (attemptChunkRecovery()) return
+    }
   }
 
   componentDidUpdate(_prevProps: Props, prevState: State): void {

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { apiFetch } from '@/lib/api'
+import { apiFetch, tryRefreshToken } from '@/lib/api'
 
 export interface AuthUser {
   id: string
@@ -34,10 +34,8 @@ interface UseAuthResult {
 // Only store non-sensitive user profile data in localStorage (no tokens!)
 const AUTH_USER_KEY = 'mindvibe_auth_user'
 
-// Shared refresh promise to prevent concurrent refresh token requests.
-// If multiple components detect a 401 and call refreshSession() simultaneously,
-// only the first one makes the actual request; others await the same promise.
-let refreshPromise: Promise<void> | null = null
+// Token refresh is now handled by the shared tryRefreshToken() in lib/api.ts,
+// which uses a module-level promise to deduplicate concurrent refresh requests.
 
 function getStoredUser(): AuthUser | null {
   if (typeof window === 'undefined') return null
@@ -332,35 +330,14 @@ export function useAuth(): UseAuthResult {
   }, [])
 
   const refreshSession = useCallback(async () => {
-    // If a refresh is already in flight, reuse it to prevent race conditions.
-    // Multiple concurrent 401s all share the same refresh request.
-    if (refreshPromise) {
-      return refreshPromise
+    // Delegates to the shared tryRefreshToken() in lib/api.ts which uses a
+    // module-level promise to deduplicate concurrent refresh requests.
+    const success = await tryRefreshToken()
+    if (!success) {
+      clearAuthData()
+      setUser(null)
+      throw new Error('Session refresh failed')
     }
-
-    refreshPromise = (async () => {
-      try {
-        // httpOnly refresh_token cookie is sent automatically
-        const response = await apiFetch('/api/auth/refresh', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        })
-
-        if (!response.ok) {
-          throw new Error('Session refresh failed')
-        }
-        // Backend sets new httpOnly access_token cookie automatically
-      } catch (err) {
-        // Session refresh failed, user needs to re-login
-        clearAuthData()
-        setUser(null)
-        throw err
-      } finally {
-        refreshPromise = null
-      }
-    })()
-
-    return refreshPromise
   }, [])
 
   // Listen for storage changes (cross-tab sync of user profile)

--- a/hooks/useReconnectingWebSocket.ts
+++ b/hooks/useReconnectingWebSocket.ts
@@ -1,0 +1,178 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+
+export type WebSocketStatus = 'connecting' | 'connected' | 'disconnected'
+
+interface UseReconnectingWebSocketOptions {
+  /** WebSocket URL. Pass null to disable connection. */
+  url: string | null
+  /** Called with parsed JSON for each incoming message. */
+  onMessage: (data: unknown) => void
+  /** Max reconnection attempts before giving up (default: 5). */
+  maxRetries?: number
+  /** Base delay in ms for exponential backoff (default: 1000). */
+  baseDelay?: number
+  /** Maximum delay in ms between retries (default: 30000). */
+  maxDelay?: number
+}
+
+interface UseReconnectingWebSocketReturn {
+  /** Send a string message through the WebSocket. No-op if not connected. */
+  send: (data: string) => void
+  /** Current connection status. */
+  status: WebSocketStatus
+  /** Manually trigger a reconnection attempt (resets retry counter). */
+  reconnect: () => void
+  /** Current retry attempt number (0 when connected or idle). */
+  retryAttempt: number
+  /** Max retries configured. */
+  maxRetries: number
+}
+
+/**
+ * WebSocket hook with automatic reconnection using exponential backoff + jitter.
+ *
+ * Reconnects automatically on close/error up to maxRetries times.
+ * Listens for the browser `online` event to reconnect immediately when
+ * network is restored. Cleans up sockets and timers on unmount.
+ */
+export function useReconnectingWebSocket({
+  url,
+  onMessage,
+  maxRetries = 5,
+  baseDelay = 1000,
+  maxDelay = 30000,
+}: UseReconnectingWebSocketOptions): UseReconnectingWebSocketReturn {
+  const [status, setStatus] = useState<WebSocketStatus>('disconnected')
+  const [retryAttempt, setRetryAttempt] = useState(0)
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const retryCountRef = useRef(0)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onMessageRef = useRef(onMessage)
+  const intentionalCloseRef = useRef(false)
+
+  // Keep onMessage ref current without triggering reconnections
+  onMessageRef.current = onMessage
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current)
+      retryTimerRef.current = null
+    }
+  }, [])
+
+  const closeSocket = useCallback(() => {
+    intentionalCloseRef.current = true
+    clearRetryTimer()
+    if (wsRef.current) {
+      wsRef.current.close()
+      wsRef.current = null
+    }
+  }, [clearRetryTimer])
+
+  const connect = useCallback(() => {
+    if (!url) return
+
+    closeSocket()
+    intentionalCloseRef.current = false
+    setStatus('connecting')
+
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      retryCountRef.current = 0
+      setRetryAttempt(0)
+      setStatus('connected')
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        onMessageRef.current(data)
+      } catch (error) {
+        console.error('Failed to parse WebSocket message', error)
+      }
+    }
+
+    ws.onclose = () => {
+      wsRef.current = null
+      if (intentionalCloseRef.current) {
+        setStatus('disconnected')
+        return
+      }
+      scheduleReconnect()
+    }
+
+    ws.onerror = () => {
+      // onclose will fire after onerror, so reconnection is handled there
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, closeSocket])
+
+  const scheduleReconnect = useCallback(() => {
+    if (retryCountRef.current >= maxRetries) {
+      setStatus('disconnected')
+      return
+    }
+
+    setStatus('disconnected')
+    const attempt = retryCountRef.current
+    // Exponential backoff with random jitter (0-500ms) to prevent thundering herd
+    const delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay) + Math.random() * 500
+
+    retryCountRef.current = attempt + 1
+    setRetryAttempt(attempt + 1)
+
+    retryTimerRef.current = setTimeout(() => {
+      retryTimerRef.current = null
+      if (!intentionalCloseRef.current) {
+        connect()
+      }
+    }, delay)
+  }, [maxRetries, baseDelay, maxDelay, connect])
+
+  const send = useCallback((data: string) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(data)
+    }
+  }, [])
+
+  const reconnect = useCallback(() => {
+    retryCountRef.current = 0
+    setRetryAttempt(0)
+    connect()
+  }, [connect])
+
+  // Connect when URL changes
+  useEffect(() => {
+    if (url) {
+      connect()
+    } else {
+      closeSocket()
+      setStatus('disconnected')
+    }
+    return () => {
+      closeSocket()
+    }
+  }, [url, connect, closeSocket])
+
+  // Reconnect immediately when browser comes back online
+  useEffect(() => {
+    const handleOnline = () => {
+      if (url && wsRef.current?.readyState !== WebSocket.OPEN) {
+        retryCountRef.current = 0
+        setRetryAttempt(0)
+        clearRetryTimer()
+        connect()
+      }
+    }
+
+    window.addEventListener('online', handleOnline)
+    return () => window.removeEventListener('online', handleOnline)
+  }, [url, connect, clearRetryTimer])
+
+  return { send, status, reconnect, retryAttempt, maxRetries }
+}

--- a/hooks/useSubscription.ts
+++ b/hooks/useSubscription.ts
@@ -178,6 +178,8 @@ export function useSubscription(): UseSubscriptionResult {
 
   // Debounce ref to coalesce rapid event-driven fetches
   const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+  // Minimum interval between fetches to prevent cascading events from causing redundant API calls
+  const lastFetchRef = useRef<number>(0)
 
   const fetchSubscription = useCallback(async () => {
     setLoading(true)
@@ -222,11 +224,18 @@ export function useSubscription(): UseSubscriptionResult {
   }, [fetchSubscription])
 
   useEffect(() => {
-    // Debounced fetch — coalesces rapid events (auth-changed + storage + subscription-updated)
-    // into a single API call after 300ms of quiet.
+    // Debounced fetch with minimum interval — coalesces rapid cascading events
+    // (auth-changed + storage) into a single API call. The 2-second minimum
+    // interval prevents redundant fetches when multiple events fire in sequence
+    // (e.g. storage event + auth-changed from the same auth state change).
+    const MIN_FETCH_INTERVAL = 2000
+
     const debouncedFetch = () => {
       clearTimeout(debounceRef.current)
       debounceRef.current = setTimeout(() => {
+        const now = Date.now()
+        if (now - lastFetchRef.current < MIN_FETCH_INTERVAL) return
+        lastFetchRef.current = now
         if (mountedRef.current) fetchSubscription()
       }, 300)
     }
@@ -237,13 +246,14 @@ export function useSubscription(): UseSubscriptionResult {
       }
     }
 
-    window.addEventListener('subscription-updated', debouncedFetch)
+    // Note: subscription-updated listener removed — that event is dispatched by
+    // updateSubscription() which writes to localStorage (triggering storage events
+    // cross-tab). Same-tab callers should use refetch() directly instead.
     window.addEventListener('storage', handleStorage)
     window.addEventListener('auth-changed', debouncedFetch)
 
     return () => {
       clearTimeout(debounceRef.current)
-      window.removeEventListener('subscription-updated', debouncedFetch)
       window.removeEventListener('storage', handleStorage)
       window.removeEventListener('auth-changed', debouncedFetch)
     }

--- a/lib/chunk-recovery.ts
+++ b/lib/chunk-recovery.ts
@@ -1,0 +1,60 @@
+/**
+ * Chunk Recovery Utilities
+ *
+ * Shared helpers for detecting and recovering from stale Next.js chunk errors
+ * that occur after deployments (old cached HTML references chunk hashes that
+ * no longer exist on the CDN). Used by error boundaries and the inline
+ * recovery script in layout.tsx.
+ */
+
+const STORAGE_KEY = '__chunk_reload'
+const URL_PARAM = '__chunk_reloaded'
+
+/** Detect chunk/module load failures caused by stale deployments. */
+export function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === 'ChunkLoadError' ||
+    /loading chunk [\w.-]+ failed/i.test(error.message) ||
+    /failed to fetch dynamically imported module/i.test(error.message)
+  )
+}
+
+/**
+ * Attempt to recover from a chunk load error by reloading the page once.
+ *
+ * Uses a dual-guard strategy to prevent infinite reload loops:
+ *   1. Primary: sessionStorage flag (works in most browsers)
+ *   2. Fallback: URL search parameter (works when sessionStorage is unavailable,
+ *      e.g. storage quota exceeded)
+ *
+ * @returns true if a reload/redirect was initiated (caller should `return` immediately),
+ *          false if recovery was already attempted (caller should show error UI).
+ */
+export function attemptChunkRecovery(): boolean {
+  // Fallback guard: check URL parameter (survives sessionStorage failures)
+  const url = new URL(window.location.href)
+  if (url.searchParams.has(URL_PARAM)) {
+    // Already reloaded via URL fallback — clean the param and stop
+    url.searchParams.delete(URL_PARAM)
+    history.replaceState(null, '', url.pathname + url.search + url.hash)
+    return false
+  }
+
+  try {
+    // Primary guard: check sessionStorage
+    if (sessionStorage.getItem(STORAGE_KEY)) {
+      sessionStorage.removeItem(STORAGE_KEY)
+      return false // Already reloaded once — show error UI
+    }
+
+    sessionStorage.setItem(STORAGE_KEY, '1')
+    window.location.reload()
+    return true
+  } catch {
+    // sessionStorage unavailable (quota exceeded, private browsing edge case)
+    // Fall back to URL parameter approach
+    url.searchParams.set(URL_PARAM, '1')
+    window.location.assign(url.href)
+    return true
+  }
+}


### PR DESCRIPTION
## Summary

Refactors WebSocket connection management across wisdom rooms pages by extracting reconnection logic into a new `useReconnectingWebSocket` hook. This hook handles automatic reconnection with exponential backoff, browser online/offline detection, and proper cleanup. Also extracts chunk recovery utilities into a shared module to reduce duplication across error boundaries.

## Changes

### New Utilities
- **`hooks/useReconnectingWebSocket.ts`**: Custom hook that manages WebSocket lifecycle with:
  - Automatic reconnection using exponential backoff + jitter
  - Browser `online` event listener for immediate reconnection when network is restored
  - Configurable retry limits and delays
  - Proper cleanup of sockets and timers on unmount
  - JSON message parsing with error handling

- **`lib/chunk-recovery.ts`**: Shared utilities for detecting and recovering from stale Next.js chunk errors:
  - `isChunkLoadError()`: Detects chunk/module load failures
  - `attemptChunkRecovery()`: Dual-guard recovery strategy (sessionStorage + URL parameter) to prevent infinite reload loops even when sessionStorage is unavailable

### Refactored Pages
- **`app/wisdom-rooms/page.tsx`**: Replaced manual WebSocket management with `useReconnectingWebSocket` hook
- **`app/(mobile)/m/wisdom-rooms/page.tsx`**: Same refactoring for mobile version

### Updated Error Boundaries
- **`app/error.tsx`**, **`app/global-error.tsx`**, **`components/ErrorBoundary.tsx`**, **`components/mobile/MobileErrorBoundary.tsx`**: Now use shared `chunk-recovery` utilities instead of duplicated logic

### Other Improvements
- **`hooks/useAuth.ts`**: Delegates token refresh to shared `tryRefreshToken()` in `lib/api.ts` to deduplicate concurrent refresh requests
- **`hooks/useSubscription.ts`**: Added minimum fetch interval (2 seconds) to prevent redundant API calls from cascading events
- **`app/layout.tsx`**: Enhanced chunk error recovery script with URL parameter fallback when sessionStorage is unavailable
- **Mobile subscribe page**: Added missing `Link` import for terms/privacy links

## Testing

- Existing wisdom rooms functionality preserved; WebSocket message handling and room switching work as before
- Hook properly cleans up resources on unmount and when URL changes
- Chunk recovery utilities tested via existing error boundary tests
- CI passes with no new test failures

## Checklist
- [x] CI passes (tests run successfully)
- [x] No private keys are committed
- [x] Code follows existing patterns and conventions

https://claude.ai/code/session_01WGCfyJGnxgfNUn47wLZV77