### PR TITLE
feat: desktop multi-panel layout with shared AppShell

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import SiteFooter from './components/SiteFooter'
 import SiteNav from './components/SiteNav'
 import Providers from './providers'
 import { MobileNav } from '@/components/navigation'
+import { AppShellFooterGuard } from '@/components/mobile/MobileRouteGuard'
 import { ServiceWorkerRegistration } from '@/components/ServiceWorkerRegistration'
 import { OfflineStatusBanner } from '@/components/OfflineStatusBanner'
 import { KiaanVoiceCompanionFooter } from '@/components/layout/KiaanVoiceCompanionFooter'
@@ -265,15 +266,19 @@ export default async function RootLayout({
             <MobileContentWrapper>
               {children}
             </MobileContentWrapper>
-            {/* Footer, nav, FABs - hidden on /m/* routes where MobileAppShell handles these */}
+            {/* Footer, nav, FABs - hidden on /m/* routes where MobileAppShell handles these.
+                Also hidden on desktop for app-shell routes (dashboard, kiaan) via
+                AppShellFooterGuard to prevent body scroll beneath the h-screen layout. */}
             <MobileRouteGuard>
-              <SiteFooter />
-              {/* Mobile bottom navigation (for standard non /m/* routes) */}
-              <MobileNav />
-              {/* OM floating chat widget */}
-              <ErrorBoundary fallback={null}>
-                <KiaanVoiceCompanionFooter />
-              </ErrorBoundary>
+              <AppShellFooterGuard>
+                <SiteFooter />
+                {/* Mobile bottom navigation (for standard non /m/* routes) */}
+                <MobileNav />
+                {/* OM floating chat widget */}
+                <ErrorBoundary fallback={null}>
+                  <KiaanVoiceCompanionFooter />
+                </ErrorBoundary>
+              </AppShellFooterGuard>
             </MobileRouteGuard>
             {/* BreadcrumbList structured data for SERP display */}
             <BreadcrumbSchema />

--- a/components/mobile/MobileRouteGuard.tsx
+++ b/components/mobile/MobileRouteGuard.tsx
@@ -28,6 +28,31 @@ export function MobileRouteGuard({ children }: MobileRouteGuardProps) {
 }
 
 /**
+ * AppShellFooterGuard
+ *
+ * Hides footer / bottom-bar children on desktop (lg:) when the current
+ * route uses the AppShell layout (dashboard, kiaan).  On mobile the
+ * children render normally because SiteFooter / MobileNav are still
+ * useful there.
+ *
+ * Why: the AppShell uses `lg:h-screen lg:overflow-hidden` on its <main>,
+ * but the footer sits OUTSIDE <main> as a sibling.  Without hiding it,
+ * the <body> is taller than the viewport and scrolls on desktop.
+ */
+export function AppShellFooterGuard({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const isAppShell =
+    pathname === '/dashboard' || pathname.startsWith('/dashboard/') ||
+    pathname === '/kiaan' || pathname.startsWith('/kiaan/')
+
+  if (isAppShell) {
+    return <div className="lg:hidden">{children}</div>
+  }
+
+  return <>{children}</>
+}
+
+/**
  * MobileContentWrapper
  *
  * On /m/* routes, renders children without the desktop <main> wrapper and its


### PR DESCRIPTION
## Summary

- **Desktop sidebar** (220px) with nav items + Sanskrit sub-labels + user section, hidden on mobile via CSS
- **Dashboard layout**: KIAAN card (2fr) + Sacred Instruments (3fr) side-by-side grid, tool shortcuts in 6-col row
- **KIAAN chat 3-panel layout**: center chat column (fills viewport height) + right panel (320px) with Verse of the Day, Recent Topics, Quick Responses, and disclaimer
- **Shared AppShell** component: Sidebar + Topbar (desktop-only, OM wordmark + SACRED badge) + content area + optional `rightPanel` prop — used by dashboard and kiaan layouts
- **Footer hidden on desktop** for app-shell routes: `AppShellFooterGuard` wraps SiteFooter/MobileNav in `lg:hidden` on `/dashboard` and `/kiaan` to prevent body scroll beneath the `h-screen` layout
- **No nested `<main>`**: AppShell uses `<div>` for its inner wrapper since root layout already provides the `<main>` landmark
- **Mobile layout completely unchanged** — all changes use `lg:` / `hidden lg:flex` CSS only

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 43 files, 582 passed, 0 failed
- [x] `npm run build` — 984 pages compiled successfully
- [x] Dev server: `/dashboard`, `/kiaan/chat`, `/`, `/pricing`, `/journeys`, `/sadhana` all return 200
- [x] API endpoints: `/api/health`, `/api/chat/health` return 200
- [x] No nested `<main>` HTML violations
- [x] No double-nav on mobile (Topbar is desktop-only)
- [x] Footer hidden on desktop for dashboard + chat (no page scroll)
- [ ] Visual verify at 1280px: sidebar visible, multi-column grids, chat fills viewport
- [ ] Visual verify at 390px: sidebar hidden, single column, footer visible, unchanged from before

https://claude.ai/code/session_01R5nBCpRgX9zC8JnZ7Z1KC4