### PR TITLE
feat(brand): responsive Sakha symbol page + fix nav icon visibility

### DIFF
--- a/components/branding/SakhaSymbol.tsx
+++ b/components/branding/SakhaSymbol.tsx
@@ -46,13 +46,13 @@ export function SakhaSymbol({
   // Hooks must be called unconditionally (Rules of Hooks)
   const uid = React.useId().replace(/:/g, '')
 
-  // Micro: OM-only symbol (petals too small to render)
-  if (variant === 'micro' || resolvedSize <= 32) {
+  // Micro / small: OM-only symbol (petals too small to render at ≤48px)
+  if (variant === 'micro' || resolvedSize <= 48) {
     return (
       <svg
         width={resolvedSize}
         height={resolvedSize}
-        viewBox="0 0 360 360"
+        viewBox="0 0 100 100"
         className={className}
         aria-label="Sakha — The Divine Friend"
         role="img"
@@ -63,17 +63,31 @@ export function SakhaSymbol({
             <stop offset="0%" stopColor="#FDE68A" />
             <stop offset="100%" stopColor="#A8760A" />
           </radialGradient>
+          <radialGradient id={`${uid}-microAura`} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#D4A017" stopOpacity="0.25" />
+            <stop offset="100%" stopColor="#D4A017" stopOpacity="0" />
+          </radialGradient>
         </defs>
+        {/* Subtle outer aura */}
+        <circle cx="50" cy="50" r="48" fill={`url(#${uid}-microAura)`} />
+        {/* Gold border circle */}
         <circle
-          cx="180" cy="180" r="158"
-          fill="rgba(22,26,66,0.5)"
-          stroke="#D4A017" strokeWidth="2" strokeOpacity="0.7"
+          cx="50" cy="50" r="42"
+          fill="rgba(10,15,40,0.9)"
+          stroke="#D4A017" strokeWidth="2" strokeOpacity="0.85"
         />
+        {/* Inner ring accent */}
+        <circle
+          cx="50" cy="50" r="36"
+          fill="none"
+          stroke="#D4A017" strokeWidth="0.5" strokeOpacity="0.3"
+        />
+        {/* OM symbol — large and bold for visibility */}
         <text
-          x="180" y="192"
+          x="50" y="54"
           textAnchor="middle" dominantBaseline="middle"
-          fontFamily='"Cormorant Garamond", Georgia, serif'
-          fontSize="56" fontWeight="300"
+          fontFamily='"Noto Sans Devanagari", "Cormorant Garamond", Georgia, serif'
+          fontSize="38" fontWeight="400"
           fill={`url(#${uid}-microGold)`}
         >
           ॐ


### PR DESCRIPTION
## Summary

- **Redesigns homepage `DivineKrishnaPresence` symbol** to match the corrected `sakha-symbol.html` mandala — replaces the plain OM-in-glow with the full animated divine mandala (rotating outer ring with gold circles/stars/lotus/diamonds, counter-rotating inner Sri Yantra with Shiva/Shakti triangles, 3 vibration rings, 6 pulsing chakra dots, golden OM with breathing animation)
- **Redesigns homepage Sakha title/tagline** to use Cinzel Decorative font with gold shimmer animation, Cormorant Garamond italic tagline, Sanskrit text, and gold divider — matching the corrected HTML exactly
- **Fixes `SakhaSymbol` nav icon invisibility** — rewrites the compact renderer with a `100x100` viewBox, opaque dark fill, thick gold stroke, and large OM text so it's visible at 28-48px
- **Adds `public/sakha-symbol.html`** — fully responsive standalone showcase with 7 CSS breakpoints (320px-1920px), landscape layout, gyroscope/mouse parallax, reduced-motion support

## Before vs After

**Homepage symbol:**
| Before | After |
|---|---|
| Plain OM text in soft radial glow | Full animated mandala: rotating gold rings, Sri Yantra triangles, lotus petals, chakra dots, vibration rings, breathing OM |
| "Sakha" in bold sans-serif | "Sakha" in Cinzel Decorative with gold shimmer animation |
| "The Spiritual Companion" plain | "Your Divine Companion" italic + Sanskrit text |

**Nav icon:**
| Before | After |
|---|---|
| Invisible (360x360 viewBox at 36px = sub-pixel) | Visible gold OM circle (100x100 viewBox) |

## Test plan

- [ ] Homepage loads with full animated mandala — outer ring rotates clockwise, inner Sri Yantra rotates counter-clockwise
- [ ] Vibration rings pulse outward from OM center
- [ ] 6 teal chakra dots pulse on mandala edge
- [ ] "Sakha" title shimmers with gold gradient animation
- [ ] Sanskrit text `सखा — तव दिव्यः साथी` visible below tagline
- [ ] Nav bar shows visible gold OM circle next to "Sakha" text
- [ ] Mobile home page OM symbol visible at 28px
- [ ] `/sakha-symbol.html` responsive at 320px, 768px, 1440px, landscape
- [ ] `prefers-reduced-motion` stops all animations
- [ ] `npx next build` passes with zero errors

https://claude.ai/code/session_018HPtvgBecyxnWFfGe7zBXS