### PR TITLE
Add journey template step seeding with phase-based content

### DIFF
--- a/backend/scripts/seed_journey_templates.py
+++ b/backend/scripts/seed_journey_templates.py
@@ -14,7 +14,7 @@ import asyncio
 import uuid
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from backend.models import Base
 from backend.models.journeys import JourneyTemplate, JourneyTemplateStep
@@ -108,6 +108,233 @@ TEMPLATES: list[dict] = [
         "color_theme": "#1D8FE1",
     },
 ]
+
+
+# ---------------------------------------------------------------------------
+# Step content helpers (CE-1) — adapted from scripts/seed_journey_templates.py
+# ---------------------------------------------------------------------------
+
+
+def _get_journey_phase(day: int, total_days: int) -> str:
+    """Return the journey phase name based on how far through the journey we are."""
+    progress = day / total_days
+    if progress <= 0.2:
+        return "awakening"
+    elif progress <= 0.4:
+        return "understanding"
+    elif progress <= 0.6:
+        return "practice"
+    elif progress <= 0.8:
+        return "integration"
+    else:
+        return "mastery"
+
+
+_ENEMY_STEP_CONTENT: dict[str, dict] = {
+    "kama": {
+        "titles": {
+            "awakening": "Recognizing Desire's Pull",
+            "understanding": "The Root of Craving",
+            "practice": "Cultivating Contentment",
+            "integration": "Freedom from Attachment",
+            "mastery": "Living in Sufficiency",
+        },
+        "teachings": {
+            "awakening": "Today we recognize how desire arises in the mind without judgment.",
+            "understanding": "Explore what underlying needs your desires are trying to fulfill.",
+            "practice": "Practice pausing between desire and action, creating space for wisdom.",
+            "integration": "Notice how contentment feels different from satisfaction of desire.",
+            "mastery": "Embody the teaching that true happiness comes from within, not from objects.",
+        },
+        "reflection": "What desires arose today? What would remain if they were fulfilled?",
+        "practice": "When desire arises, take 3 breaths and ask: 'Is this a true need or a passing want?'",
+        "verse_tags": ["desire", "craving", "detachment", "contentment"],
+        "day1_verse": {"chapter": 3, "verse": 37},
+    },
+    "krodha": {
+        "titles": {
+            "awakening": "The Fire Within",
+            "understanding": "Anger's Hidden Message",
+            "practice": "The Pause Before Response",
+            "integration": "Transforming Fire to Light",
+            "mastery": "Equanimity in Action",
+        },
+        "teachings": {
+            "awakening": "Today we observe anger as energy, without suppressing or acting on it.",
+            "understanding": "Explore what underlying hurt or fear triggers your anger responses.",
+            "practice": "Practice the sacred pause \u2014 the space between stimulus and response.",
+            "integration": "Learn to express boundaries firmly but without the fire of anger.",
+            "mastery": "Embody equanimity \u2014 responding wisely to all situations with clarity.",
+        },
+        "reflection": "When did anger arise today? What was it trying to protect?",
+        "practice": "When anger arises, ground through your feet and take 5 slow breaths before speaking.",
+        "verse_tags": ["anger", "peace", "patience", "equanimity"],
+        "day1_verse": {"chapter": 2, "verse": 63},
+        "safety_note": "If experiencing intense anger, practice grounding before reflection.",
+        "safety_days": 3,
+    },
+    "lobha": {
+        "titles": {
+            "awakening": "The Hunger for More",
+            "understanding": "Why Enough is Never Enough",
+            "practice": "The Art of Appreciation",
+            "integration": "Giving as Liberation",
+            "mastery": "Abundance in Simplicity",
+        },
+        "teachings": {
+            "awakening": "Today we observe the mind's tendency to accumulate and hold.",
+            "understanding": "Explore what insecurity or fear drives the need for more.",
+            "practice": "Practice gratitude for what you have before seeking what you don't.",
+            "integration": "Experience the joy of giving without expectation of return.",
+            "mastery": "Embody the truth that richness comes from appreciation, not accumulation.",
+        },
+        "reflection": "What felt like 'not enough' today? What would truly satisfy you?",
+        "practice": "List 10 things you're grateful for. Give something away today without keeping score.",
+        "verse_tags": ["greed", "contentment", "generosity", "giving"],
+        "day1_verse": {"chapter": 14, "verse": 17},
+    },
+    "moha": {
+        "titles": {
+            "awakening": "The Fog of Confusion",
+            "understanding": "What We Mistake for Truth",
+            "practice": "Cultivating Discernment",
+            "integration": "Seeing Clearly",
+            "mastery": "Wisdom in Action",
+        },
+        "teachings": {
+            "awakening": "Today we recognize where attachment clouds our perception.",
+            "understanding": "Explore what beliefs you hold that may not serve your highest good.",
+            "practice": "Practice viveka \u2014 distinguishing the real from the unreal, the eternal from the temporary.",
+            "integration": "Learn to see situations clearly, free from the lens of personal desire.",
+            "mastery": "Embody wisdom that sees beyond surface appearances to underlying truth.",
+        },
+        "reflection": "Where did confusion arise today? What clarity might you be avoiding?",
+        "practice": "Before making a decision, ask: 'Am I seeing this clearly, or through the lens of attachment?'",
+        "verse_tags": ["delusion", "clarity", "wisdom", "discernment"],
+        "day1_verse": {"chapter": 2, "verse": 52},
+        "safety_note": "This work can bring up challenging emotions. Be gentle with yourself.",
+        "safety_phase": "integration",
+    },
+    "mada": {
+        "titles": {
+            "awakening": "The Shield of Pride",
+            "understanding": "What Ego Protects",
+            "practice": "The Strength in Humility",
+            "integration": "Service as Medicine",
+            "mastery": "Confident Surrender",
+        },
+        "teachings": {
+            "awakening": "Today we observe how ego defends its sense of superiority or specialness.",
+            "understanding": "Explore what vulnerability ego is protecting you from feeling.",
+            "practice": "Practice asking for help and admitting 'I don't know' without shame.",
+            "integration": "Discover that serving others dissolves the isolation of self-centeredness.",
+            "mastery": "Embody the paradox: true confidence comes from surrender, not assertion.",
+        },
+        "reflection": "Where did ego show up today? What would happen if you let go of being right?",
+        "practice": "Today, ask for help with something. Notice the discomfort and stay with it.",
+        "verse_tags": ["pride", "ego", "humility", "surrender"],
+        "day1_verse": {"chapter": 16, "verse": 4},
+    },
+    "matsarya": {
+        "titles": {
+            "awakening": "The Pain of Comparison",
+            "understanding": "What Envy Reveals",
+            "practice": "Mudita \u2014 Sympathetic Joy",
+            "integration": "Celebrating Others",
+            "mastery": "One in All",
+        },
+        "teachings": {
+            "awakening": "Today we recognize envy as information about our own unfulfilled desires.",
+            "understanding": "Explore what you truly want that you see in others' success.",
+            "practice": "Practice mudita \u2014 genuinely celebrating others' joy and success.",
+            "integration": "Learn that another's gain doesn't diminish your own possibilities.",
+            "mastery": "Embody the understanding that we are all connected; their success is our success.",
+        },
+        "reflection": "Whose success triggered discomfort today? What does this teach you about your own desires?",
+        "practice": "When you feel envy, say: 'Their success shows what's possible. May they flourish.'",
+        "verse_tags": ["envy", "jealousy", "joy", "compassion"],
+        "day1_verse": {"chapter": 12, "verse": 13},
+    },
+}
+
+
+def _build_template_steps(
+    template_id: str, enemy_tag: str, duration_days: int
+) -> list[dict]:
+    """Generate step dicts for every day of a template."""
+    content = _ENEMY_STEP_CONTENT[enemy_tag]
+    steps: list[dict] = []
+    for day in range(1, duration_days + 1):
+        phase = _get_journey_phase(day, duration_days)
+
+        safety_notes = None
+        if "safety_days" in content and day <= content["safety_days"]:
+            safety_notes = content.get("safety_note")
+        elif "safety_phase" in content and phase == content["safety_phase"]:
+            safety_notes = content.get("safety_note")
+
+        steps.append(
+            {
+                "journey_template_id": template_id,
+                "day_index": day,
+                "step_title": f"Day {day}: {content['titles'].get(phase, 'Walking the Path')}",
+                "teaching_hint": content["teachings"].get(phase, "Continue your contemplation."),
+                "reflection_prompt": content["reflection"],
+                "practice_prompt": content["practice"],
+                "verse_selector": {
+                    "tags": content["verse_tags"],
+                    "max_verses": 2,
+                    "avoid_recent": 10,
+                },
+                "static_verse_refs": [content["day1_verse"]] if day == 1 else None,
+                "safety_notes": safety_notes,
+            }
+        )
+    return steps
+
+
+async def seed_journey_template_steps(db: AsyncSession) -> int:
+    """Idempotently upsert day-by-day step skeletons for each seeded template."""
+    stmt = select(JourneyTemplate).where(JourneyTemplate.deleted_at.is_(None))
+    templates = (await db.execute(stmt)).scalars().all()
+
+    count = 0
+    for template in templates:
+        tags = template.primary_enemy_tags or []
+        if not tags:
+            continue
+        enemy_tag = tags[0]
+        if enemy_tag not in _ENEMY_STEP_CONTENT:
+            print(f"⚠️  No step content for enemy '{enemy_tag}', skipping {template.slug}")
+            continue
+
+        steps_data = _build_template_steps(template.id, enemy_tag, template.duration_days)
+        for step_data in steps_data:
+            existing_step = (
+                await db.execute(
+                    select(JourneyTemplateStep).where(
+                        JourneyTemplateStep.journey_template_id == template.id,
+                        JourneyTemplateStep.day_index == step_data["day_index"],
+                        JourneyTemplateStep.deleted_at.is_(None),
+                    )
+                )
+            ).scalars().first()
+
+            if existing_step:
+                existing_step.step_title = step_data["step_title"]
+                existing_step.teaching_hint = step_data["teaching_hint"]
+                existing_step.reflection_prompt = step_data["reflection_prompt"]
+                existing_step.practice_prompt = step_data["practice_prompt"]
+                existing_step.verse_selector = step_data["verse_selector"]
+                existing_step.static_verse_refs = step_data["static_verse_refs"]
+                existing_step.safety_notes = step_data["safety_notes"]
+            else:
+                db.add(JourneyTemplateStep(id=str(uuid.uuid4()), **step_data))
+
+            count += 1
+
+    await db.commit()
+    return count
 
 
 async def seed_journey_templates(existing_engine: AsyncEngine) -> None:


### PR DESCRIPTION
## Summary

Add comprehensive step content generation for journey templates, including phase-based teachings, reflection prompts, and safety notes. Introduces helper functions to generate day-by-day step skeletons for each seeded template based on enemy tags (kama, krodha, lobha, moha, mada, matsarya).

## Changes

- **Import `AsyncSession`** from `sqlalchemy.ext.asyncio` for type hints
- **Add `_get_journey_phase()`** helper to determine journey phase (awakening → mastery) based on progress through template
- **Add `_ENEMY_STEP_CONTENT`** dictionary with structured content for each of the six enemy archetypes:
  - Phase-specific titles and teachings
  - Reflection and practice prompts
  - Verse tags and day-1 verse references
  - Optional safety notes with phase or day-based triggers
- **Add `_build_template_steps()`** to generate step dictionaries for every day of a template
- **Add `seed_journey_template_steps()`** async function to idempotently upsert step records:
  - Queries existing templates and generates steps based on primary enemy tags
  - Creates or updates `JourneyTemplateStep` records with teaching content
  - Handles safety notes conditionally based on phase or day count

## Testing

Existing tests pass. The seeding function follows the idempotent pattern of existing seed functions and integrates with the established template structure.

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

https://claude.ai/code/session_01BzHn3yVcshxLPNvmYLCxyA