### PR TITLE
Add startup diagnostics, cross-dialect DB support, and timing metrics

### DIFF
--- a/backend/core/manual_migrations.py
+++ b/backend/core/manual_migrations.py
@@ -197,14 +197,22 @@ async def align_journal_entries_schema(engine: AsyncEngine) -> dict:
 async def run_manual_migrations(engine: AsyncEngine) -> dict:
     """
     Run all manual migrations in sequence.
-    
+
     Returns:
         dict with results for each migration
     """
     results = {}
-    
+
+    # Skip PostgreSQL-specific migrations when running on SQLite (local dev / tests)
+    _dialect = engine.dialect.name
+    if _dialect == "sqlite":
+        logger.info("Running manual migrations... (SQLite detected — skipping PG-specific steps)")
+        results['pg_trgm'] = {'success': True, 'message': 'Skipped (SQLite)', 'action': 'skipped'}
+        results['journal_alignment'] = {'success': True, 'message': 'Skipped (SQLite)', 'action': 'skipped'}
+        return results
+
     logger.info("Running manual migrations...")
-    
+
     # Enable pg_trgm extension
     results['pg_trgm'] = await enable_pg_trgm_extension(engine)
     logger.info(f"pg_trgm: {results['pg_trgm']['message']}")

--- a/backend/core/migrations.py
+++ b/backend/core/migrations.py
@@ -34,18 +34,25 @@ LATEST_MIGRATION_RESULT: MigrationResult | None = None
 
 async def _ensure_migrations_table(engine: AsyncEngine) -> None:
     """Create schema_migrations table if it does not exist."""
-    async with engine.begin() as conn:
-        await conn.execute(
-            text(
-                """
-                CREATE TABLE IF NOT EXISTS schema_migrations (
-                    id SERIAL PRIMARY KEY,
-                    filename TEXT UNIQUE NOT NULL,
-                    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )
-                """
+    _dialect = engine.dialect.name
+    if _dialect == "sqlite":
+        _ddl = """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT UNIQUE NOT NULL,
+                applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
-        )
+        """
+    else:
+        _ddl = """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                id SERIAL PRIMARY KEY,
+                filename TEXT UNIQUE NOT NULL,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """
+    async with engine.begin() as conn:
+        await conn.execute(text(_ddl))
 
 
 async def _fetch_applied(engine: AsyncEngine) -> set[str]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -318,6 +318,13 @@ async def _delayed_start(coro, delay_seconds: int, name: str):
 @app.on_event("startup")
 async def startup():
     try:
+        import time as _time
+
+        startup_logger.info("")
+        startup_logger.info("=" * 80)
+        startup_logger.info("🚀 STARTUP EVENT HANDLER RUNNING")
+        startup_logger.info("=" * 80)
+
         # Step 0: Initialize instance identity and Redis (foundation for scaling)
         import uuid as _uuid
 
@@ -327,6 +334,7 @@ async def startup():
             _settings.INSTANCE_ID = _uuid.uuid4().hex[:12]
         startup_logger.info(f"\n🆔 Instance ID: {_settings.INSTANCE_ID}")
 
+        _step_t0 = _time.monotonic()
         startup_logger.info("\n🔗 Initializing Redis...")
         import asyncio as _asyncio
 
@@ -393,6 +401,20 @@ async def startup():
             startup_logger.warning(
                 "⚠️ Redis not connected — falling back to in-memory (single-instance only)"
             )
+            # Actionable diagnostic when localhost Redis detected in production
+            if _is_production and (
+                "localhost" in (_settings.REDIS_URL or "")
+                or "127.0.0.1" in (_settings.REDIS_URL or "")
+            ):
+                startup_logger.warning(
+                    "⚠️ REDIS_URL points to localhost in production. "
+                    "This usually means the Render Redis service (mindvibe-redis) "
+                    "is not provisioned or REDIS_URL is not being injected. "
+                    "Fix: Render Dashboard → verify mindvibe-redis service exists, "
+                    "then check REDIS_URL env var uses 'fromService' in render.yaml."
+                )
+
+        startup_logger.info(f"   ⏱️ Redis init completed in {_time.monotonic() - _step_t0:.1f}s")
 
         # Start the background reconnect loop (handles both initial failures and
         # mid-run disconnections). Replaces the old 4-retry-then-give-up approach
@@ -448,6 +470,7 @@ async def startup():
         # must exist before SQL migrations that reference them with REFERENCES).
         # Wrapped in asyncio.wait_for to prevent indefinite hangs if the database
         # is slow/unreachable — Render kills containers after health check timeout.
+        _step_t0 = _time.monotonic()
         startup_logger.info("\n🔧 Ensuring ORM tables exist...")
         try:
             async with engine.begin() as conn:
@@ -455,7 +478,7 @@ async def startup():
                     conn.run_sync(Base.metadata.create_all),
                     timeout=_STARTUP_DB_TIMEOUT,
                 )
-            startup_logger.info("✅ Base database schema ready")
+            startup_logger.info(f"✅ Base database schema ready ({_time.monotonic() - _step_t0:.1f}s)")
             _startup_status["database_ready"] = True
         except _asyncio.TimeoutError:
             startup_logger.error(
@@ -472,6 +495,7 @@ async def startup():
         # On fresh databases, ORM create_all already sets up all tables,
         # so migration seed INSERTs may fail if columns differ. This is
         # non-fatal — the app works correctly with ORM-created tables.
+        _step_t0 = _time.monotonic()
         if RUN_MIGRATIONS_ON_STARTUP:
             try:
                 migration_result = await _asyncio.wait_for(
@@ -517,7 +541,10 @@ async def startup():
                     f"⚠️ Migration status check timed out after {_STARTUP_DB_TIMEOUT}s"
                 )
 
+        startup_logger.info(f"   ⏱️ Migrations completed in {_time.monotonic() - _step_t0:.1f}s")
+
         # Step 3: Run manual Python migrations
+        _step_t0 = _time.monotonic()
         startup_logger.info("\n🔧 Running manual migrations...")
         try:
             from backend.core.manual_migrations import run_manual_migrations
@@ -540,7 +567,7 @@ async def startup():
             startup_logger.info(f"⚠️ Manual migrations had issues: {manual_error}")
             # Don't fail startup - manual migrations are supplementary
 
-        startup_logger.info("✅ Database schema ready")
+        startup_logger.info(f"✅ Database schema ready ({_time.monotonic() - _step_t0:.1f}s)")
 
         # Step 3b: Validate email configuration (surface misconfig early)
         startup_logger.info("\n📧 Validating email configuration...")
@@ -766,6 +793,26 @@ async def startup():
             # Don't fail startup - enrichment is supplementary
 
         _startup_status["started"] = True
+
+        # Final startup status banner
+        startup_logger.info("")
+        startup_logger.info("=" * 80)
+        startup_logger.info("✅ MINDVIBE - STARTUP COMPLETE")
+        startup_logger.info("=" * 80)
+        startup_logger.info(
+            f"   Redis:    {'✅ CONNECTED' if _startup_status['redis_connected'] else '❌ NOT CONNECTED (in-memory fallback)'}"
+        )
+        startup_logger.info(
+            f"   Database: {'✅ READY' if _startup_status['database_ready'] else '❌ NOT READY'}"
+        )
+        startup_logger.info(
+            f"   Routes:   {_startup_status['routers_loaded']} registered"
+        )
+        startup_logger.info(
+            f"   KIAAN:    {'✅ OPERATIONAL' if kiaan_router_loaded else '❌ FAILED TO LOAD'}"
+        )
+        startup_logger.info("=" * 80)
+        startup_logger.info("")
 
     except Exception as exc:
         failed_meta = migrations_module.LATEST_MIGRATION_RESULT
@@ -2237,8 +2284,7 @@ startup_logger.info(
 )
 startup_logger.info(
     f"Registered routes: {len(_registered_routes)} | "
-    f"Redis: {'✅' if _startup_status['redis_connected'] else '❌'} | "
-    f"Database: {'✅' if _startup_status['database_ready'] else '⏳ (pending startup)'}"
+    f"Module loading complete — awaiting startup event for DB/Redis init"
 )
 startup_logger.info("=" * 80 + "\n")
 

--- a/backend/models/ai.py
+++ b/backend/models/ai.py
@@ -18,8 +18,12 @@ from sqlalchemy import (
     Text,
     func,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB as _PG_JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+
+# Use JSON with a PostgreSQL variant so the column uses JSONB (with GIN index
+# support) on PostgreSQL but falls back to plain JSON on SQLite / other dialects.
+_JSONB = JSON().with_variant(_PG_JSONB(), "postgresql")
 
 from backend.models.base import Base, SoftDeleteMixin
 
@@ -81,13 +85,13 @@ class LearnedWisdom(SoftDeleteMixin, Base):
     language: Mapped[str] = mapped_column(String(10), nullable=False, default="en", index=True)
 
     # Gita references (JSONB for GIN index support)
-    chapter_refs: Mapped[list[int]] = mapped_column(JSONB, nullable=False, default=list)
+    chapter_refs: Mapped[list[int]] = mapped_column(_JSONB, nullable=False, default=list)
     verse_refs: Mapped[list[list[int]]] = mapped_column(JSON, nullable=False, default=list)
 
     # Categorization (JSONB for GIN index support)
-    themes: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
-    shad_ripu_tags: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
-    keywords: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    themes: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
+    shad_ripu_tags: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
+    keywords: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
 
     # Spiritual wellness mapping (similar to GitaVerse)
     primary_domain: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
@@ -154,9 +158,9 @@ class UserQueryPattern(SoftDeleteMixin, Base):
     intent: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
 
     # Gita mappings (JSONB for GIN index support)
-    related_chapters: Mapped[list[int]] = mapped_column(JSONB, nullable=False, default=list)
+    related_chapters: Mapped[list[int]] = mapped_column(_JSONB, nullable=False, default=list)
     related_verses: Mapped[list[list[int]]] = mapped_column(JSON, nullable=False, default=list)
-    related_themes: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    related_themes: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
 
     # Response template (for AI-free responses)
     response_template: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/models/indian_wellness.py
+++ b/backend/models/indian_wellness.py
@@ -15,10 +15,15 @@ from sqlalchemy import (
     Text,
     func,
 )
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY as _PG_ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.models.base import Base, SoftDeleteMixin
+
+
+# Cross-dialect helpers: ARRAY(String(N)) on PostgreSQL, JSON on SQLite.
+def _array_of(size: int):
+    return JSON().with_variant(_PG_ARRAY(String(size)), "postgresql")
 
 
 class IndianDataSourceType(str, enum.Enum):
@@ -86,16 +91,16 @@ class IndianWisdomContent(SoftDeleteMixin, Base):
     content: Mapped[str] = mapped_column(Text)
     hindi_content: Mapped[str | None] = mapped_column(Text, nullable=True)
     sanskrit_terms: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(64)), nullable=True
+        _array_of(64), nullable=True
     )
     keywords: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(64)), nullable=True
+        _array_of(64), nullable=True
     )
     practices: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(128)), nullable=True
+        _array_of(128), nullable=True
     )
     benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     source_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
     source_organization: Mapped[str | None] = mapped_column(String(256), nullable=True)
@@ -132,22 +137,22 @@ class YogaAsanaDB(SoftDeleteMixin, Base):
     )  # beginner, intermediate, advanced
     description: Mapped[str] = mapped_column(Text)
     instructions: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(512)), nullable=True
+        _array_of(512), nullable=True
     )
     benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     mental_benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     contraindications: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     duration_seconds: Mapped[int] = mapped_column(Integer, default=30)
     breath_pattern: Mapped[str | None] = mapped_column(String(256), nullable=True)
     chakra_association: Mapped[str | None] = mapped_column(String(64), nullable=True)
     dosha_balance: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(16)), nullable=True
+        _array_of(16), nullable=True
     )  # vata, pitta, kapha
     created_at: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
@@ -173,16 +178,16 @@ class PranayamaTechniqueDB(SoftDeleteMixin, Base):
     hindi_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
     description: Mapped[str] = mapped_column(Text)
     instructions: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(512)), nullable=True
+        _array_of(512), nullable=True
     )
     benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     mental_benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     contraindications: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     duration_minutes: Mapped[int] = mapped_column(Integer, default=5)
     breath_ratio: Mapped[str | None] = mapped_column(
@@ -219,13 +224,13 @@ class MeditationPracticeDB(SoftDeleteMixin, Base):
     )  # Vedic, Buddhist, Jain, Tantric
     description: Mapped[str] = mapped_column(Text)
     instructions: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(512)), nullable=True
+        _array_of(512), nullable=True
     )
     benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     mental_benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     duration_minutes: Mapped[int] = mapped_column(Integer, default=15)
     posture: Mapped[str | None] = mapped_column(
@@ -262,13 +267,13 @@ class AyurvedicPracticeDB(SoftDeleteMixin, Base):
         String(64), nullable=True
     )  # dinacharya, ritucharya, therapy, body_care
     instructions: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(512)), nullable=True
+        _array_of(512), nullable=True
     )
     benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     mental_benefits: Mapped[list[str] | None] = mapped_column(
-        ARRAY(String(256)), nullable=True
+        _array_of(256), nullable=True
     )
     dosha_effects: Mapped[dict | None] = mapped_column(
         JSON, nullable=True

--- a/backend/models/journal.py
+++ b/backend/models/journal.py
@@ -14,8 +14,11 @@ from sqlalchemy import (
     Text,
     func,
 )
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY as _PG_ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
+
+# ARRAY(String) on PostgreSQL, JSON on SQLite / other dialects
+_ArrayOfStrings = JSON().with_variant(_PG_ARRAY(String), "postgresql")
 
 from backend.models.base import Base, SoftDeleteMixin
 
@@ -128,7 +131,7 @@ class JournalSearchIndex(SoftDeleteMixin, Base):
     user_id: Mapped[str] = mapped_column(
         String(255), ForeignKey("users.id", ondelete="CASCADE"), index=True
     )
-    token_hashes: Mapped[list[str]] = mapped_column(ARRAY(String), default=list)
+    token_hashes: Mapped[list[str]] = mapped_column(_ArrayOfStrings, default=list)
     created_at: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
     )

--- a/backend/models/self_sufficiency.py
+++ b/backend/models/self_sufficiency.py
@@ -24,8 +24,12 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB as _PG_JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+
+# Use JSON with a PostgreSQL variant so the column uses JSONB (with GIN index
+# support) on PostgreSQL but falls back to plain JSON on SQLite / other dialects.
+_JSONB = JSON().with_variant(_PG_JSONB(), "postgresql")
 
 from backend.models.base import Base, SoftDeleteMixin
 
@@ -70,11 +74,11 @@ class WisdomAtom(SoftDeleteMixin, Base):
     sub_category: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Context tags (JSONB for GIN index support)
-    mood_tags: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
-    topic_tags: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
-    intent_tags: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    mood_tags: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
+    topic_tags: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
+    intent_tags: Mapped[list[str]] = mapped_column(_JSONB, nullable=False, default=list)
     phase_tags: Mapped[list[str]] = mapped_column(
-        JSONB, nullable=False, default=list
+        _JSONB, nullable=False, default=list
     )  # connect, listen, guide, empower
 
     # Verse association (if this atom references Gita wisdom)


### PR DESCRIPTION
## Summary

This PR enhances startup observability, adds cross-database dialect support (PostgreSQL/SQLite), and improves diagnostic messaging for production troubleshooting.

### Key Changes

**Startup Diagnostics & Timing**
- Added startup event banner with clear visual markers (🚀 START / ✅ COMPLETE)
- Implemented per-step timing metrics for Redis, database schema, and migrations
- Added actionable diagnostic warning when Redis URL points to localhost in production (common Render misconfiguration)
- Final startup status summary showing Redis/Database/Routes/KIAAN health

**Cross-Dialect Database Support**
- Replaced PostgreSQL-specific `ARRAY()` and `JSONB` types with cross-dialect helpers:
  - `_array_of(size)`: Uses `ARRAY(String(N))` on PostgreSQL, `JSON` on SQLite
  - `_JSONB`: Uses `JSONB` on PostgreSQL, `JSON` on SQLite
- Updated `schema_migrations` table DDL to use dialect-appropriate syntax (SERIAL/AUTOINCREMENT, TIMESTAMPTZ/TIMESTAMP)
- Modified manual migrations to skip PostgreSQL-specific steps (pg_trgm extension) when running on SQLite

**Logging Improvements**
- Clearer module-load-time logging (distinguishes from startup event logging)
- Better separation of concerns in startup status reporting

### Files Modified
- `backend/main.py`: Startup event handler with diagnostics and timing
- `backend/models/indian_wellness.py`: Cross-dialect ARRAY support
- `backend/models/ai.py`: Cross-dialect JSONB support
- `backend/models/self_sufficiency.py`: Cross-dialect JSONB support
- `backend/models/journal.py`: Cross-dialect ARRAY support
- `backend/core/migrations.py`: Dialect-aware schema_migrations table creation
- `backend/core/manual_migrations.py`: SQLite detection and PG-specific step skipping

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing

Startup flow verified with timing output. Cross-dialect support tested by:
1. Running migrations on PostgreSQL (production path)
2. Running migrations on SQLite (local dev/test path)
3. Verifying diagnostic warnings appear when Redis misconfigured

Existing tests should pass; no new test files added as changes are primarily observability and dialect compatibility.

https://claude.ai/code/session_01W1oSRG6FdMCeLRd7HzbXW2