### PR TITLE
fix(mobile): remove expo-speech config plugin causing EAS build failure

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -157,7 +157,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
           'Sakha uses your microphone for voice conversations.',
       },
     ],
-    'expo-speech',
     [
       'expo-camera',
       {


### PR DESCRIPTION
## Summary
- Remove `expo-speech` from `plugins` array in `app.config.ts`
- `expo-speech` doesn't export a config plugin (`app.plugin.js`), causing EAS build to crash
- The package still works as a regular import for text-to-speech — it just can't be listed under plugins

## Test plan
- [ ] Run `eas build --platform android --profile preview` — should no longer fail on config plugin resolution
- [ ] Verify speech functionality still works in the app (expo-speech is still installed, just not a plugin)

https://claude.ai/code/session_01T3xwADnM9MHDg1GuPeeMVT