### PR TITLE
fix(mobile): remove non-plugin packages from plugins array (EAS build fix)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -171,10 +171,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
           'Kiaanverse uses Face ID for secure, quick login.',
       },
     ],
-    'expo-secure-store',
-    'expo-task-manager',
-    'expo-crypto',
-    '@shopify/react-native-skia',
   ],
 
   experiments: {


### PR DESCRIPTION
## Summary
- Remove `expo-secure-store`, `expo-task-manager`, `expo-crypto`, and `@shopify/react-native-skia` from the `plugins` array in `app.config.ts`
- These packages don't export config plugins (no `app.plugin.js`), causing EAS build to crash
- They still work as regular imports — just can't be listed under plugins

## Test plan
- [ ] Run `eas build --platform android --profile preview` — should pass config plugin resolution
- [ ] Verify secure store, task manager, crypto, and Skia still work at runtime

https://claude.ai/code/session_01T3xwADnM9MHDg1GuPeeMVT