### PR TITLE
fix(mobile): target Android API level 35 + enable Proguard mapping

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -96,6 +96,15 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     'expo-router',
     'expo-splash-screen',
     [
+      'expo-build-properties',
+      {
+        android: {
+          targetSdkVersion: 35,
+          compileSdkVersion: 35,
+        },
+      },
+    ],
+    [
       'expo-notifications',
       {
         icon: './assets/notification-icon.png',

--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -101,6 +101,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         android: {
           targetSdkVersion: 35,
           compileSdkVersion: 35,
+          enableProguardInReleaseBuilds: true,
+          enableShrinkResourcesInReleaseBuilds: true,
         },
       },
     ],

--- a/kiaanverse-mobile/apps/mobile/package.json
+++ b/kiaanverse-mobile/apps/mobile/package.json
@@ -45,6 +45,7 @@
     "expo": "~51.0.0",
     "expo-av": "~14.0.0",
     "expo-background-fetch": "~12.0.0",
+    "expo-build-properties": "~0.12.0",
     "expo-camera": "~15.0.0",
     "expo-constants": "~16.0.0",
     "expo-crypto": "~13.0.0",


### PR DESCRIPTION
## Summary
- Adds `expo-build-properties` plugin to override Expo SDK 51 defaults and target Android **API level 35** (`targetSdkVersion` + `compileSdkVersion`), resolving the Play Console error that blocks uploads.
- Enables `enableProguardInReleaseBuilds` + `enableShrinkResourcesInReleaseBuilds`, so EAS produces a `mapping.txt` that Play Store auto-associates — fixes the "no deobfuscation file" warning and reduces app size.
- Adds `expo-build-properties ~0.12.0` to `kiaanverse-mobile/apps/mobile/package.json`.

## Why
Google Play now requires all apps to target API 35 (Android 15). The current AAB targets API 34 and is rejected. Separately, Play Console warned the bundle had no deobfuscation mapping for crash/ANR symbolication.

## Test plan
- [ ] `cd kiaanverse-mobile/apps/mobile && npm install` succeeds
- [ ] `eas build --platform android --profile production` completes
- [ ] Uploaded AAB passes Play Console API-level check
- [ ] `mapping.txt` is present in the AAB / Play Console shows "deobfuscation file uploaded"
- [ ] Smoke test release build: login, Sentry crash capture, deep links, notifications, native modules — verify Proguard didn't strip anything reflective. If something breaks, add `-keep` rules via `extraProguardRules`.

https://claude.ai/code/session_014PpK9EkN4VrLch3eBRKKwC