### PR TITLE
Fix Kotlin null-safety compile error in expo-modules-core

### DIFF
--- a/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Runs AFTER pnpm install on EAS. Purpose:
+#   1. Remove the excluded expo-in-app-purchases package (autolinking guard).
+#   2. Defensively patch expo-modules-core 1.12.26 PermissionsService.kt for
+#      the Kotlin null-safety compile error triggered by compileSdk 35, in
+#      case the pnpm patchedDependencies entry did not apply (e.g. stale
+#      lockfile, cache mismatch, or phantom install path).
+#
+# See: patches/expo-modules-core@1.12.26.patch (primary fix).
+set -eo pipefail
+
+log() { echo "[eas-post-install] $*"; }
+
+# ---- 1. Purge expo-in-app-purchases everywhere it may have been hoisted ----
+log "Purging expo-in-app-purchases from all node_modules trees..."
+find "${EAS_BUILD_WORKINGDIR:-$(pwd)/../..}" \
+  -type d -name "expo-in-app-purchases" -path "*/node_modules/*" \
+  -exec rm -rf {} + 2>/dev/null || true
+
+# ---- 2. Defensive patch for expo-modules-core PermissionsService.kt ----
+# Root cause: PackageInfo.requestedPermissions became @Nullable String[] in
+# compileSdk 35, so `requestedPermissions.contains(permission)` fails Kotlin
+# strict null checks with:
+#   Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable
+#   receiver of type Array<(out) String!>?
+TARGETS=$(find "${EAS_BUILD_WORKINGDIR:-$(pwd)/../..}" \
+  -path "*/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt" \
+  2>/dev/null || true)
+
+if [ -z "$TARGETS" ]; then
+  log "No PermissionsService.kt found — skipping defensive patch."
+else
+  for f in $TARGETS; do
+    if grep -qF 'requestedPermissions?.contains(permission) ?: false' "$f"; then
+      log "Already patched: $f"
+      continue
+    fi
+    if grep -qF 'return requestedPermissions.contains(permission)' "$f"; then
+      log "Patching: $f"
+      # Use a pipe delimiter so the slashes in indentation do not confuse sed.
+      sed -i.bak \
+        's|return requestedPermissions\.contains(permission)|return requestedPermissions?.contains(permission) ?: false|' \
+        "$f"
+      rm -f "${f}.bak"
+    else
+      log "Unexpected content in $f — skipping (upstream may already be fixed)."
+    fi
+  done
+fi
+
+log "done"

--- a/kiaanverse-mobile/apps/mobile/package.json
+++ b/kiaanverse-mobile/apps/mobile/package.json
@@ -26,7 +26,7 @@
     "format:check": "prettier --check \"app/**/*.{ts,tsx}\" \"components/**/*.{ts,tsx}\" \"hooks/**/*.{ts,tsx}\" \"services/**/*.{ts,tsx}\" \"utils/**/*.{ts,tsx}\"",
     "clean": "rm -rf .expo dist node_modules/.cache",
     "eas-build-pre-install": "bash ./eas-build-pre-install.sh || true",
-    "eas-build-post-install": "find $(pwd)/../../node_modules -type d -name expo-in-app-purchases -exec rm -rf {} + 2>/dev/null; echo done"
+    "eas-build-post-install": "bash ./eas-build-post-install.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/kiaanverse-mobile/package.json
+++ b/kiaanverse-mobile/package.json
@@ -16,6 +16,11 @@
     "node": ">=20.0.0"
   },
   "packageManager": "pnpm@9.1.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "expo-modules-core@1.12.26": "patches/expo-modules-core@1.12.26.patch"
+    }
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/kiaanverse-mobile/patches/expo-modules-core@1.12.26.patch
+++ b/kiaanverse-mobile/patches/expo-modules-core@1.12.26.patch
@@ -1,0 +1,13 @@
+diff --git a/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt b/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+index 0000000..0000001 100644
+--- a/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
++++ b/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+@@ -163,7 +163,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permissions, LifecycleEventListener {
+   override fun isPermissionPresentInManifest(permission: String): Boolean {
+     try {
+       context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)?.run {
+-        return requestedPermissions.contains(permission)
++        return requestedPermissions?.contains(permission) ?: false
+       }
+       return false
+     } catch (e: PackageManager.NameNotFoundException) {


### PR DESCRIPTION
## Summary

Fixes a Kotlin null-safety compilation error in `expo-modules-core@1.12.26` that occurs when building with `compileSdk 35`. The `PackageInfo.requestedPermissions` field became nullable in Android SDK 35, causing strict null-check failures. This PR adds a defensive patch and post-install script to ensure the fix is applied even if pnpm's patchedDependencies mechanism doesn't apply it.

## Changes

1. **Added `patches/expo-modules-core@1.12.26.patch`**: Patches `PermissionsService.kt` to use safe navigation (`?.`) and Elvis operator (`?: false`) when checking if a permission is in the manifest.

2. **Added `apps/mobile/eas-build-post-install.sh`**: A post-install script that:
   - Removes the excluded `expo-in-app-purchases` package from all `node_modules` trees
   - Defensively applies the `PermissionsService.kt` patch if it wasn't already applied by pnpm (handles stale lockfiles, cache mismatches, etc.)

3. **Updated `package.json`**: Added `pnpm.patchedDependencies` configuration to declare the patch as the primary fix mechanism.

4. **Updated `apps/mobile/package.json`**: Replaced the inline `eas-build-post-install` script with a call to the new bash script for better maintainability.

## Testing

CI will validate that the EAS build post-install script runs successfully and that the patch is correctly applied. The defensive patching ensures compatibility even if the primary pnpm patch mechanism fails to apply.

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

https://claude.ai/code/session_014BRP1Vxpwu1vXVHRfWJqbc