### PR TITLE
fix(mobile): make expo-modules-core patch hook work on EAS

### DIFF
--- a/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
@@ -3,49 +3,115 @@
 #   1. Remove the excluded expo-in-app-purchases package (autolinking guard).
 #   2. Defensively patch expo-modules-core 1.12.26 PermissionsService.kt for
 #      the Kotlin null-safety compile error triggered by compileSdk 35, in
-#      case the pnpm patchedDependencies entry did not apply (e.g. stale
-#      lockfile, cache mismatch, or phantom install path).
+#      case the pnpm patchedDependencies entry did not apply (e.g. on EAS
+#      where apps/mobile is treated as the project root and pnpm ignores
+#      the monorepo-root patchedDependencies key).
 #
-# See: patches/expo-modules-core@1.12.26.patch (primary fix).
+# Why multiple search roots?
+#   On EAS, $EAS_BUILD_WORKINGDIR is set to apps/mobile, so a find rooted
+#   there never traverses the hoisted node_modules at the pnpm workspace
+#   root. We therefore sweep:
+#     a) $EAS_BUILD_WORKINGDIR (when set) — covers local installs
+#     b) script dir walked up 2 levels — the kiaanverse-mobile monorepo
+#        root where pnpm hoists dependencies
+#     c) /home/expo/workingdir — the default EAS workspace root, as a
+#        final defensive sweep in case the checkout layout changes
+#
+# See: patches/expo-modules-core@1.12.26.patch (primary fix, local only).
 set -eo pipefail
 
 log() { echo "[eas-post-install] $*"; }
 
+# ---- Build the list of candidate search roots ------------------------------
+# Use an array so we can dedupe and skip missing paths cleanly.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONOREPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CANDIDATE_ROOTS=()
+if [ -n "${EAS_BUILD_WORKINGDIR:-}" ] && [ -d "${EAS_BUILD_WORKINGDIR}" ]; then
+  CANDIDATE_ROOTS+=("${EAS_BUILD_WORKINGDIR}")
+fi
+if [ -d "${MONOREPO_ROOT}" ]; then
+  CANDIDATE_ROOTS+=("${MONOREPO_ROOT}")
+fi
+if [ -d "/home/expo/workingdir" ]; then
+  CANDIDATE_ROOTS+=("/home/expo/workingdir")
+fi
+
+# Dedupe (preserving order) — two candidates may resolve to the same path.
+SEARCH_ROOTS=()
+for root in "${CANDIDATE_ROOTS[@]}"; do
+  skip=0
+  for seen in "${SEARCH_ROOTS[@]:-}"; do
+    if [ "$root" = "$seen" ]; then
+      skip=1
+      break
+    fi
+  done
+  if [ "$skip" -eq 0 ]; then
+    SEARCH_ROOTS+=("$root")
+  fi
+done
+
+if [ "${#SEARCH_ROOTS[@]}" -eq 0 ]; then
+  log "No search roots resolved — nothing to do."
+  exit 0
+fi
+
+log "Search roots: ${SEARCH_ROOTS[*]}"
+
 # ---- 1. Purge expo-in-app-purchases everywhere it may have been hoisted ----
 log "Purging expo-in-app-purchases from all node_modules trees..."
-find "${EAS_BUILD_WORKINGDIR:-$(pwd)/../..}" \
-  -type d -name "expo-in-app-purchases" -path "*/node_modules/*" \
-  -exec rm -rf {} + 2>/dev/null || true
+for root in "${SEARCH_ROOTS[@]}"; do
+  find "$root" \
+    -type d -name "expo-in-app-purchases" -path "*/node_modules/*" \
+    -exec rm -rf {} + 2>/dev/null || true
+done
 
-# ---- 2. Defensive patch for expo-modules-core PermissionsService.kt ----
+# ---- 2. Defensive patch for expo-modules-core PermissionsService.kt --------
 # Root cause: PackageInfo.requestedPermissions became @Nullable String[] in
 # compileSdk 35, so `requestedPermissions.contains(permission)` fails Kotlin
 # strict null checks with:
 #   Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable
 #   receiver of type Array<(out) String!>?
-TARGETS=$(find "${EAS_BUILD_WORKINGDIR:-$(pwd)/../..}" \
-  -path "*/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt" \
-  2>/dev/null || true)
+PATCHED_COUNT=0
+SEEN_FILES=()
 
-if [ -z "$TARGETS" ]; then
-  log "No PermissionsService.kt found — skipping defensive patch."
-else
-  for f in $TARGETS; do
+for root in "${SEARCH_ROOTS[@]}"; do
+  # NUL-delimited iteration so paths with spaces never split incorrectly.
+  while IFS= read -r -d '' f; do
+    # Dedupe in case two roots see the same hoisted file.
+    already_seen=0
+    for seen in "${SEEN_FILES[@]:-}"; do
+      if [ "$f" = "$seen" ]; then
+        already_seen=1
+        break
+      fi
+    done
+    if [ "$already_seen" -eq 1 ]; then
+      continue
+    fi
+    SEEN_FILES+=("$f")
+
     if grep -qF 'requestedPermissions?.contains(permission) ?: false' "$f"; then
       log "Already patched: $f"
       continue
     fi
     if grep -qF 'return requestedPermissions.contains(permission)' "$f"; then
       log "Patching: $f"
-      # Use a pipe delimiter so the slashes in indentation do not confuse sed.
+      # Pipe delimiter so slashes in indentation do not confuse sed.
       sed -i.bak \
         's|return requestedPermissions\.contains(permission)|return requestedPermissions?.contains(permission) ?: false|' \
         "$f"
       rm -f "${f}.bak"
+      PATCHED_COUNT=$((PATCHED_COUNT + 1))
     else
       log "Unexpected content in $f — skipping (upstream may already be fixed)."
     fi
-  done
-fi
+  done < <(find "$root" \
+    -path "*/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt" \
+    -print0 2>/dev/null || true)
+done
 
+log "patched ${PATCHED_COUNT} file(s)"
 log "done"


### PR DESCRIPTION
## Summary
- Previous EAS post-install hook searched from `${EAS_BUILD_WORKINGDIR:-$(pwd)/../..}`. On EAS, `EAS_BUILD_WORKINGDIR` is set to `apps/mobile` (EAS's project root), so `find` never reached the hoisted `node_modules/expo-modules-core/...` at the monorepo root. The defensive sed silently patched zero files.
- Rewrites the hook to search **multiple roots** (script-derived monorepo root, `EAS_BUILD_WORKINGDIR`, `/home/expo/workingdir`) with de-duped file list.
- Logs `patched N file(s)` at end — makes hook firing visible in EAS build logs.

## Why
The `claude/gradle-android-release-tvGw9` build failed at `:expo-modules-core:compileReleaseKotlin` with `PermissionsService.kt:166:36` — the same error the patch was meant to fix — confirming the hook never patched the file on EAS.

## Test plan
- [ ] `bash -n kiaanverse-mobile/apps/mobile/eas-build-post-install.sh` passes (verified)
- [ ] EAS production build completes `:expo-modules-core:compileReleaseKotlin`
- [ ] EAS build log shows `[eas-post-install] patched 1 file(s)` (or more)
- [ ] If hook still can't find the file, log will show `[eas-post-install] No PermissionsService.kt found` — makes diagnosis obvious

https://claude.ai/code/session_014PpK9EkN4VrLch3eBRKKwC