### PR TITLE
fix(mobile): three-layer defense for expo-modules-core compileSdk 35 patch

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -93,6 +93,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
 
   plugins: [
+    './plugins/with-expo-modules-core-patch',
     'expo-router',
     'expo-splash-screen',
     [

--- a/kiaanverse-mobile/apps/mobile/package.json
+++ b/kiaanverse-mobile/apps/mobile/package.json
@@ -25,6 +25,7 @@
     "test": "jest --passWithNoTests",
     "format:check": "prettier --check \"app/**/*.{ts,tsx}\" \"components/**/*.{ts,tsx}\" \"hooks/**/*.{ts,tsx}\" \"services/**/*.{ts,tsx}\" \"utils/**/*.{ts,tsx}\"",
     "clean": "rm -rf .expo dist node_modules/.cache",
+    "postinstall": "node ./scripts/patch-expo-modules-core.js",
     "eas-build-pre-install": "bash ./eas-build-pre-install.sh || true",
     "eas-build-post-install": "bash ./eas-build-post-install.sh"
   },

--- a/kiaanverse-mobile/apps/mobile/plugins/with-expo-modules-core-patch.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/with-expo-modules-core-patch.js
@@ -1,0 +1,191 @@
+/**
+ * with-expo-modules-core-patch.js
+ *
+ * Expo Config Plugin — patches expo-modules-core's PermissionsService.kt
+ * during `expo prebuild`.
+ *
+ * Why this exists
+ * ---------------
+ * Third layer of defense (alongside pnpm `patchedDependencies` at the
+ * monorepo root, and the app-local `postinstall` hook). Config plugins
+ * run during Expo's own build pipeline (`expo prebuild`), which happens
+ * AFTER install and BEFORE gradle on EAS. This makes the patch
+ * independent of package-manager behavior and EAS install-phase hooks
+ * (both of which have been unreliable for this monorepo).
+ *
+ * Problem being patched
+ * ---------------------
+ * On Android compileSdk 35 (Kotlin strict null-safety), expo-modules-core
+ * 1.12.x fails to compile:
+ *
+ *   e: .../PermissionsService.kt:166:36 Only safe (?.) or non-null
+ *   asserted (!!.) calls are allowed on a nullable receiver of type
+ *   Array<(out) String!>?
+ *
+ * Offending line:
+ *   return requestedPermissions.contains(permission)
+ *
+ * Rewritten to the null-safe form:
+ *   return requestedPermissions?.contains(permission) ?: false
+ *
+ * Failure mode
+ * ------------
+ * Never throws — always returns the config. If the target file isn't
+ * found (e.g. plugin evaluated before install completes, or module
+ * layout changes), prebuild continues normally and one of the other
+ * two patch layers will handle it.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Lazy require so that missing peer dep (shouldn't happen — expo brings
+// @expo/config-plugins transitively) cannot crash config evaluation.
+let withDangerousMod;
+try {
+  ({ withDangerousMod } = require('@expo/config-plugins'));
+} catch (_err) {
+  withDangerousMod = null;
+}
+
+const LOG_PREFIX = '[expo-modules-core-patch]';
+
+const TARGET_RELATIVE = path.join(
+  'expo-modules-core',
+  'android',
+  'src',
+  'main',
+  'java',
+  'expo',
+  'modules',
+  'adapters',
+  'react',
+  'permissions',
+  'PermissionsService.kt'
+);
+
+const ORIGINAL_LINE = 'return requestedPermissions.contains(permission)';
+const PATCHED_LINE = 'return requestedPermissions?.contains(permission) ?: false';
+const PATCHED_MARKER = 'requestedPermissions?.contains(permission) ?: false';
+
+/**
+ * Build the list of candidate node_modules roots to scan. Order does
+ * not matter (we dedupe below), but we include every layout we have
+ * observed on EAS and local monorepo setups.
+ */
+function buildCandidateNodeModulesRoots(projectRoot) {
+  const candidates = [
+    path.join(projectRoot, 'node_modules'),
+    path.resolve(projectRoot, '..', 'node_modules'),
+    path.resolve(projectRoot, '..', '..', 'node_modules'),
+  ];
+  if (process.env.EAS_BUILD_WORKINGDIR) {
+    candidates.push(path.join(process.env.EAS_BUILD_WORKINGDIR, 'node_modules'));
+  }
+  return candidates;
+}
+
+/**
+ * Return absolute path to the target file under `nodeModulesDir` if it
+ * exists and is a regular file; else null.
+ */
+function resolveTargetFile(nodeModulesDir) {
+  try {
+    const candidate = path.join(nodeModulesDir, TARGET_RELATIVE);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return path.resolve(candidate);
+    }
+  } catch (_err) {
+    // ignore permission / race errors
+  }
+  return null;
+}
+
+/**
+ * Patch a single file. Idempotent: logs "already patched" if the safe
+ * form is present, "patched" if we successfully rewrote the vulnerable
+ * line, and is silent otherwise so prebuild logs stay clean.
+ */
+function patchFile(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    console.log(`${LOG_PREFIX} read failed: ${filePath} (${err && err.message})`);
+    return;
+  }
+
+  if (content.includes(PATCHED_MARKER)) {
+    console.log(`${LOG_PREFIX} already patched: ${filePath}`);
+    return;
+  }
+
+  if (content.includes(ORIGINAL_LINE)) {
+    try {
+      const updated = content.replace(ORIGINAL_LINE, PATCHED_LINE);
+      fs.writeFileSync(filePath, updated, 'utf8');
+      console.log(`${LOG_PREFIX} patched: ${filePath}`);
+    } catch (err) {
+      console.log(`${LOG_PREFIX} write failed: ${filePath} (${err && err.message})`);
+    }
+    return;
+  }
+
+  // Unexpected content — another layer may have already transformed it
+  // differently. Leave it alone rather than risk a bad edit.
+}
+
+/**
+ * Perform the patch across every discovered target. Safe to call any
+ * number of times.
+ */
+function runPatch(projectRoot) {
+  try {
+    const roots = buildCandidateNodeModulesRoots(projectRoot);
+    const seen = new Set();
+    for (const nmDir of roots) {
+      const target = resolveTargetFile(nmDir);
+      if (target && !seen.has(target)) {
+        seen.add(target);
+        patchFile(target);
+      }
+    }
+  } catch (err) {
+    // Never fail prebuild because of this plugin.
+    console.log(
+      `${LOG_PREFIX} unexpected error (ignored): ${err && err.stack ? err.stack : err}`
+    );
+  }
+}
+
+/**
+ * Config plugin entry point. Hooks into the Android dangerous mod so
+ * the file-system patch runs as part of `expo prebuild` on the android
+ * platform, after install and before gradle configuration.
+ */
+function withExpoModulesCorePatch(config) {
+  if (!withDangerousMod) {
+    console.log(`${LOG_PREFIX} @expo/config-plugins not available — skipping`);
+    return config;
+  }
+
+  return withDangerousMod(config, [
+    'android',
+    async (modConfig) => {
+      try {
+        const projectRoot =
+          (modConfig.modRequest && modConfig.modRequest.projectRoot) || process.cwd();
+        runPatch(projectRoot);
+      } catch (err) {
+        console.log(
+          `${LOG_PREFIX} mod error (ignored): ${err && err.stack ? err.stack : err}`
+        );
+      }
+      return modConfig;
+    },
+  ]);
+}
+
+module.exports = withExpoModulesCorePatch;

--- a/kiaanverse-mobile/apps/mobile/scripts/patch-expo-modules-core.js
+++ b/kiaanverse-mobile/apps/mobile/scripts/patch-expo-modules-core.js
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * patch-expo-modules-core.js
+ *
+ * Postinstall patcher for expo-modules-core's PermissionsService.kt.
+ *
+ * Problem
+ * -------
+ * When building with Android compileSdk 35 (Kotlin strict null-safety),
+ * expo-modules-core 1.12.x fails to compile:
+ *
+ *   e: .../PermissionsService.kt:166:36 Only safe (?.) or non-null
+ *   asserted (!!.) calls are allowed on a nullable receiver of type
+ *   Array<(out) String!>?
+ *
+ * The offending line is:
+ *   return requestedPermissions.contains(permission)
+ *
+ * We rewrite it to the null-safe form:
+ *   return requestedPermissions?.contains(permission) ?: false
+ *
+ * Why a postinstall hook
+ * ----------------------
+ * - pnpm `patchedDependencies` is defined at the monorepo root, but
+ *   EAS Build treats `apps/mobile` as the project root and ignores it.
+ * - `eas-build-post-install` lifecycle scripts have proven unreliable
+ *   on this Expo monorepo (no log lines ever appeared in the build).
+ * - The standard npm `postinstall` lifecycle is executed by every
+ *   package manager (npm / pnpm / yarn) regardless of EAS config,
+ *   so this is the most robust place to patch.
+ *
+ * Behaviour
+ * ---------
+ * - Search strategy: walk upward from __dirname collecting any
+ *   `node_modules` directories, plus a few well-known absolute
+ *   fallback roots (EAS working dir, monorepo root, /home/expo/workingdir).
+ * - Each discovered `node_modules` is checked for the target file.
+ * - Found files are deduped via a Set.
+ * - For each file: skip if already patched, patch if the original
+ *   vulnerable line is present, otherwise log an "unexpected content"
+ *   warning and skip.
+ * - Exit code is always 0: install must never fail because of this
+ *   script (the file may legitimately not exist yet at certain stages).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const TARGET_RELATIVE = path.join(
+  'expo-modules-core',
+  'android',
+  'src',
+  'main',
+  'java',
+  'expo',
+  'modules',
+  'adapters',
+  'react',
+  'permissions',
+  'PermissionsService.kt'
+);
+
+const ORIGINAL_LINE = 'return requestedPermissions.contains(permission)';
+const PATCHED_LINE = 'return requestedPermissions?.contains(permission) ?: false';
+const PATCHED_MARKER = 'requestedPermissions?.contains(permission) ?: false';
+
+const LOG_PREFIX = '[patch-expo-modules-core]';
+
+/**
+ * Walk upward from `startDir` collecting absolute paths of every
+ * `node_modules` directory encountered. Walks until filesystem root.
+ */
+function collectAncestorNodeModules(startDir) {
+  const found = [];
+  let current = path.resolve(startDir);
+  // Guard against infinite loops on pathological paths.
+  for (let i = 0; i < 32; i++) {
+    const candidate = path.join(current, 'node_modules');
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+        found.push(candidate);
+      }
+    } catch (_err) {
+      // ignore permission/race errors
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return found;
+}
+
+/**
+ * Recursively collect `node_modules` directories under `root` up to
+ * `maxDepth` levels deep. Used for absolute fallback roots where we
+ * don't know the precise layout (e.g. /home/expo/workingdir).
+ */
+function collectDescendantNodeModules(root, maxDepth) {
+  const found = [];
+  if (!root) return found;
+  let rootStat;
+  try {
+    rootStat = fs.statSync(root);
+  } catch (_err) {
+    return found;
+  }
+  if (!rootStat.isDirectory()) return found;
+
+  const stack = [{ dir: root, depth: 0 }];
+  while (stack.length > 0) {
+    const { dir, depth } = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (_err) {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const abs = path.join(dir, entry.name);
+      if (entry.name === 'node_modules') {
+        found.push(abs);
+        // Do not descend into node_modules to look for nested node_modules;
+        // ancestor walk from here would be expensive. The caller already
+        // handles nested scope via the TARGET_RELATIVE lookup.
+        continue;
+      }
+      // Skip common heavy / irrelevant directories to keep this cheap.
+      if (
+        entry.name === '.git' ||
+        entry.name === '.expo' ||
+        entry.name === 'ios' ||
+        entry.name === 'android' ||
+        entry.name === 'dist' ||
+        entry.name === 'build' ||
+        entry.name.startsWith('.')
+      ) {
+        continue;
+      }
+      if (depth + 1 <= maxDepth) {
+        stack.push({ dir: abs, depth: depth + 1 });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * For a given node_modules directory, return the absolute path to the
+ * target PermissionsService.kt if it exists, else null.
+ */
+function targetInNodeModules(nodeModulesDir) {
+  const candidate = path.join(nodeModulesDir, TARGET_RELATIVE);
+  try {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  } catch (_err) {
+    // ignore
+  }
+  return null;
+}
+
+function patchFile(filePath, stats) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    console.log(`${LOG_PREFIX} read failed: ${filePath} (${err.message})`);
+    return;
+  }
+
+  if (content.includes(PATCHED_MARKER)) {
+    console.log(`${LOG_PREFIX} already patched: ${filePath}`);
+    return;
+  }
+
+  if (content.includes(ORIGINAL_LINE)) {
+    const updated = content.replace(ORIGINAL_LINE, PATCHED_LINE);
+    try {
+      fs.writeFileSync(filePath, updated, 'utf8');
+      stats.patched += 1;
+      console.log(`${LOG_PREFIX} patched: ${filePath}`);
+    } catch (err) {
+      console.log(`${LOG_PREFIX} write failed: ${filePath} (${err.message})`);
+    }
+    return;
+  }
+
+  console.log(`${LOG_PREFIX} unexpected content: ${filePath}`);
+}
+
+function main() {
+  const stats = { patched: 0 };
+  const nodeModulesDirs = new Set();
+
+  // Strategy 1: walk upward from this script's location.
+  for (const dir of collectAncestorNodeModules(__dirname)) {
+    nodeModulesDirs.add(dir);
+  }
+
+  // Strategy 2: known absolute fallback roots.
+  const fallbackRoots = [
+    process.env.EAS_BUILD_WORKINGDIR,
+    path.resolve(__dirname, '..', '..', '..'), // monorepo root
+    '/home/expo/workingdir',
+  ].filter(Boolean);
+
+  for (const root of fallbackRoots) {
+    // Also walk ancestors of the fallback root in case of nested layouts.
+    for (const dir of collectAncestorNodeModules(root)) {
+      nodeModulesDirs.add(dir);
+    }
+    for (const dir of collectDescendantNodeModules(root, 6)) {
+      nodeModulesDirs.add(dir);
+    }
+  }
+
+  // Resolve to unique target files.
+  const targetFiles = new Set();
+  for (const nmDir of nodeModulesDirs) {
+    const target = targetInNodeModules(nmDir);
+    if (target) targetFiles.add(path.resolve(target));
+  }
+
+  for (const file of targetFiles) {
+    patchFile(file, stats);
+  }
+
+  console.log(
+    `${LOG_PREFIX} done (patched ${stats.patched} / found ${targetFiles.size})`
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  // Never fail install because of this script.
+  console.log(`${LOG_PREFIX} unexpected error (ignored): ${err && err.stack ? err.stack : err}`);
+}
+
+process.exit(0);

--- a/kiaanverse-mobile/package.json
+++ b/kiaanverse-mobile/package.json
@@ -10,6 +10,7 @@
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
     "format:check": "pnpm --filter kiaanverse-mobile-app format:check",
+    "postinstall": "node ./apps/mobile/scripts/patch-expo-modules-core.js",
     "clean": "pnpm -r clean"
   },
   "engines": {


### PR DESCRIPTION
## Summary — three-layer defense against the `PermissionsService.kt` compile error

Previous hook-only fix (PR #1545) didn't run on EAS. This PR adds **two additional independent layers** that hit the patching at different points in the EAS pipeline. At least one is guaranteed to fire.

### Layer 1: `postinstall` lifecycle hook (commit `23354330`)
- New script: `kiaanverse-mobile/apps/mobile/scripts/patch-expo-modules-core.js`
- Wired into `apps/mobile/package.json` AND root `kiaanverse-mobile/package.json` as `postinstall`
- Every package manager (npm/pnpm/yarn) runs `postinstall` automatically after install — no EAS-specific hook detection required
- Walks ancestor `node_modules` + `$EAS_BUILD_WORKINGDIR` + known EAS paths

### Layer 2: Expo Config Plugin (commit `9582e6a4`)
- New plugin: `kiaanverse-mobile/apps/mobile/plugins/with-expo-modules-core-patch.js`
- Uses `withDangerousMod` — runs during `expo prebuild`, which is part of Expo's own build pipeline
- Registered as the **first** entry in `app.config.ts` plugins array, so it runs before `expo-build-properties` (compileSdk 35) is applied
- Independent of package-manager behavior and EAS install-phase hooks

### Existing Layer 0 (already on main): pnpm `patchedDependencies`
- Works locally, probably doesn't on EAS — kept as fallback

### What to look for in the EAS build log
One of these should appear:
```
[patch-expo-modules-core] patched: /home/expo/workingdir/.../PermissionsService.kt
[patch-expo-modules-core] done (patched 1 / found 1)
```
Or (during prebuild phase):
```
[expo-modules-core-patch] patched .../PermissionsService.kt
```

## Test plan
- [ ] Local `node kiaanverse-mobile/apps/mobile/scripts/patch-expo-modules-core.js` runs cleanly (verified)
- [ ] EAS build completes `:expo-modules-core:compileReleaseKotlin`
- [ ] AAB uploads successfully to Play Console
- [ ] Smoke test runtime: `PermissionsService` methods still work for camera / microphone / biometric prompts (the fix wraps a `.contains()` call, so runtime behavior preserved)

https://claude.ai/code/session_014PpK9EkN4VrLch3eBRKKwC