### PR TITLE
fix(mobile): canonical expo-font autolinking + CRLF guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
 path/to/largefile filter=lfs diff=lfs merge=lfs -text
+
+# Shell scripts MUST use LF line endings regardless of the checkout OS.
+# EAS Build tars the local working tree (not a git clone), so CRLF checkouts
+# on Windows would produce broken scripts like `set -eo pipefail\r` which
+# bash on Linux rejects with "invalid option name".
+*.sh              text eol=lf
+*.bash            text eol=lf
+
+# Other text files that break when CRLF reaches a Linux toolchain.
+*.yml             text eol=lf
+*.yaml            text eol=lf
+Dockerfile        text eol=lf
+.dockerignore     text eol=lf
+.gitignore        text eol=lf

--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -148,7 +148,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       projectId: '1f72d91b-2336-4b58-a641-5589317cc36c',
     },
     autolinking: {
-      exclude: ['expo-in-app-purchases', 'expo-font'],
+      exclude: ['expo-in-app-purchases'],
     },
   },
 });

--- a/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
@@ -1,117 +1,31 @@
 #!/bin/bash
-# Runs AFTER pnpm install on EAS. Purpose:
-#   1. Remove the excluded expo-in-app-purchases package (autolinking guard).
-#   2. Defensively patch expo-modules-core 1.12.26 PermissionsService.kt for
-#      the Kotlin null-safety compile error triggered by compileSdk 35, in
-#      case the pnpm patchedDependencies entry did not apply (e.g. on EAS
-#      where apps/mobile is treated as the project root and pnpm ignores
-#      the monorepo-root patchedDependencies key).
+# The PermissionsService.kt patch for compileSdk 35 is now applied by:
+#   - postinstall script:       ./scripts/patch-expo-modules-core.js
+#   - Expo config plugin:       ./plugins/with-expo-modules-core-patch.js
 #
-# Why multiple search roots?
-#   On EAS, $EAS_BUILD_WORKINGDIR is set to apps/mobile, so a find rooted
-#   there never traverses the hoisted node_modules at the pnpm workspace
-#   root. We therefore sweep:
-#     a) $EAS_BUILD_WORKINGDIR (when set) — covers local installs
-#     b) script dir walked up 2 levels — the kiaanverse-mobile monorepo
-#        root where pnpm hoists dependencies
-#     c) /home/expo/workingdir — the default EAS workspace root, as a
-#        final defensive sweep in case the checkout layout changes
-#
-# See: patches/expo-modules-core@1.12.26.patch (primary fix, local only).
-set -eo pipefail
+# This hook only purges the deprecated expo-in-app-purchases package, which
+# breaks Gradle 8.8 due to the removed `classifier` property. The script is
+# intentionally non-failing — we do NOT `set -e` so transient find/rm errors
+# can't fail the EAS build.
 
 log() { echo "[eas-post-install] $*"; }
 
-# ---- Build the list of candidate search roots ------------------------------
-# Use an array so we can dedupe and skip missing paths cleanly.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MONOREPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-
-CANDIDATE_ROOTS=()
-if [ -n "${EAS_BUILD_WORKINGDIR:-}" ] && [ -d "${EAS_BUILD_WORKINGDIR}" ]; then
-  CANDIDATE_ROOTS+=("${EAS_BUILD_WORKINGDIR}")
-fi
-if [ -d "${MONOREPO_ROOT}" ]; then
-  CANDIDATE_ROOTS+=("${MONOREPO_ROOT}")
-fi
-if [ -d "/home/expo/workingdir" ]; then
-  CANDIDATE_ROOTS+=("/home/expo/workingdir")
-fi
-
-# Dedupe (preserving order) — two candidates may resolve to the same path.
-SEARCH_ROOTS=()
-for root in "${CANDIDATE_ROOTS[@]}"; do
-  skip=0
-  for seen in "${SEARCH_ROOTS[@]:-}"; do
-    if [ "$root" = "$seen" ]; then
-      skip=1
-      break
-    fi
-  done
-  if [ "$skip" -eq 0 ]; then
-    SEARCH_ROOTS+=("$root")
-  fi
-done
-
-if [ "${#SEARCH_ROOTS[@]}" -eq 0 ]; then
-  log "No search roots resolved — nothing to do."
-  exit 0
-fi
-
-log "Search roots: ${SEARCH_ROOTS[*]}"
-
-# ---- 1. Purge expo-in-app-purchases everywhere it may have been hoisted ----
 log "Purging expo-in-app-purchases from all node_modules trees..."
-for root in "${SEARCH_ROOTS[@]}"; do
+
+# Resolve candidate search roots. Missing paths are silently skipped.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || SCRIPT_DIR="."
+CANDIDATES=(
+  "${EAS_BUILD_WORKINGDIR:-}"
+  "${SCRIPT_DIR}/../.."
+  "/home/expo/workingdir"
+)
+
+for root in "${CANDIDATES[@]}"; do
+  [ -n "$root" ] && [ -d "$root" ] || continue
   find "$root" \
     -type d -name "expo-in-app-purchases" -path "*/node_modules/*" \
     -exec rm -rf {} + 2>/dev/null || true
 done
 
-# ---- 2. Defensive patch for expo-modules-core PermissionsService.kt --------
-# Root cause: PackageInfo.requestedPermissions became @Nullable String[] in
-# compileSdk 35, so `requestedPermissions.contains(permission)` fails Kotlin
-# strict null checks with:
-#   Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable
-#   receiver of type Array<(out) String!>?
-PATCHED_COUNT=0
-SEEN_FILES=()
-
-for root in "${SEARCH_ROOTS[@]}"; do
-  # NUL-delimited iteration so paths with spaces never split incorrectly.
-  while IFS= read -r -d '' f; do
-    # Dedupe in case two roots see the same hoisted file.
-    already_seen=0
-    for seen in "${SEEN_FILES[@]:-}"; do
-      if [ "$f" = "$seen" ]; then
-        already_seen=1
-        break
-      fi
-    done
-    if [ "$already_seen" -eq 1 ]; then
-      continue
-    fi
-    SEEN_FILES+=("$f")
-
-    if grep -qF 'requestedPermissions?.contains(permission) ?: false' "$f"; then
-      log "Already patched: $f"
-      continue
-    fi
-    if grep -qF 'return requestedPermissions.contains(permission)' "$f"; then
-      log "Patching: $f"
-      # Pipe delimiter so slashes in indentation do not confuse sed.
-      sed -i.bak \
-        's|return requestedPermissions\.contains(permission)|return requestedPermissions?.contains(permission) ?: false|' \
-        "$f"
-      rm -f "${f}.bak"
-      PATCHED_COUNT=$((PATCHED_COUNT + 1))
-    else
-      log "Unexpected content in $f — skipping (upstream may already be fixed)."
-    fi
-  done < <(find "$root" \
-    -path "*/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt" \
-    -print0 2>/dev/null || true)
-done
-
-log "patched ${PATCHED_COUNT} file(s)"
 log "done"
+exit 0

--- a/kiaanverse-mobile/apps/mobile/expo-module.config.json
+++ b/kiaanverse-mobile/apps/mobile/expo-module.config.json
@@ -1,5 +1,5 @@
 {
   "autolinking": {
-    "exclude": ["expo-font", "expo-in-app-purchases"]
+    "exclude": ["expo-in-app-purchases"]
   }
 }

--- a/kiaanverse-mobile/apps/mobile/package.json
+++ b/kiaanverse-mobile/apps/mobile/package.json
@@ -6,8 +6,7 @@
   "expo": {
     "autolinking": {
       "exclude": [
-        "expo-in-app-purchases",
-        "expo-font"
+        "expo-in-app-purchases"
       ]
     },
     "install": {


### PR DESCRIPTION
## Summary
Three commits that landed on `claude/postinstall-patch-expo-modules-core` after PR #1546 was merged. They keep main in sync with what's actually being built on EAS.

### `f8c1d5a1` — canonical expo-font autolinking fix (the live one)
Build 9 still crashed with `Cannot find native module 'ExpoFontLoader'` despite removing `expo-font` from the exclude lists in `app.config.ts` and `package.json`. Root cause: `expo-module.config.json` is the canonical file Expo CLI reads for autolinking, and it still held the exclusion. This commit removes it from there.

### `3a28c30e` — initial expo-font autolinking attempt
Removed `expo-font` from `app.config.ts.extra.autolinking.exclude` and `package.json.expo.autolinking.exclude`. Necessary but not sufficient — see commit above.

### `bb563052` — CRLF + EAS hook simplification
- New `.gitattributes` enforces `eol=lf` for `*.sh`, `*.bash`, `*.yml`, `*.yaml`, Dockerfile, etc. so CRLF can never reach a Linux toolchain again.
- `eas-build-post-install.sh` stripped to a safe no-op (just purges `expo-in-app-purchases`); patching is now handled by the `postinstall` script + Expo config plugin from PR #1546.

## Test plan
- [ ] EAS build 10 with this branch checked out completes
- [ ] Install on Android 15 device → app opens past splash screen (no `ExpoFontLoader` crash)
- [ ] Logcat after 30s of app usage shows no `FATAL EXCEPTION` lines

https://claude.ai/code/session_014PpK9EkN4VrLch3eBRKKwC