### PR TITLE
Add DivineTabBar custom bottom navigation with elevated KIAAN center tab

### DIFF
--- a/kiaanverse-mobile/apps/mobile/components/navigation/CenterKiaanTab.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/CenterKiaanTab.tsx
@@ -1,0 +1,323 @@
+/**
+ * CenterKiaanTab — Elevated center button of the DivineTabBar.
+ *
+ * A 64 px circular, golden-auraed button that sits above the tab bar
+ * baseline (marginTop: -20) and continuously "breathes" (scale 1.0 →
+ * 1.04 → 1.0, 3 s). The border slowly shifts hue between gold and
+ * peacock blue (4 s cycle). When pressed it dips to scale 0.92 and
+ * returns with ImpactFeedbackStyle.Medium haptic feedback.
+ *
+ * The inside houses the SakhaMandala (rendered via MandalaSpin, 40 px),
+ * which spins faster when the KIAAN tab is the active route.
+ *
+ * A soft radial-style aura (gold → blue → transparent) sits 80 px wide
+ * BEHIND the button so the elevation doesn't look clipped.
+ */
+
+import React, { useEffect } from 'react';
+import { Pressable, StyleSheet, View, Platform, Text } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+// Try to reuse the mobile mandala component from the UI package so we
+// match the rest of the sacred visual system. If consumers haven't yet
+// migrated, the fallback glyph keeps the center tab renderable.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let MandalaSpin: React.ComponentType<any> | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  MandalaSpin = require('@kiaanverse/ui').MandalaSpin ?? null;
+} catch {
+  MandalaSpin = null;
+}
+
+/** Gold accent for border, label, and aura highlights. */
+const GOLD = '#D4A017';
+/** Krishna-blue / peacock accent for aura and border cross-fade. */
+const KRISHNA_BLUE = '#1B4FBB';
+/** Outer button diameter. */
+const BUTTON_SIZE = 64;
+/** Border thickness (prompt spec: 2 px). */
+const BORDER_WIDTH = 2;
+/** Mandala size inside the button (prompt spec). */
+const MANDALA_SIZE = 40;
+/** Radial-style aura diameter (prompt spec: 80 px). */
+const AURA_SIZE = 80;
+/** Vertical elevation above the tab bar baseline (prompt spec). */
+const ELEVATION_OFFSET = 20;
+
+export interface CenterKiaanTabProps {
+  /** Whether KIAAN is the currently focused route. */
+  readonly isFocused: boolean;
+  /** Translated label (rendered below, visible only when active). */
+  readonly label: string;
+  /** Tap handler — navigates to the KIAAN chat screen. */
+  readonly onPress: () => void;
+  /** Long-press handler (tab lifecycle emit). */
+  readonly onLongPress?: () => void;
+  /** Test identifier for E2E testing. */
+  readonly testID?: string;
+}
+
+function CenterKiaanTabInner({
+  isFocused,
+  label,
+  onPress,
+  onLongPress,
+  testID,
+}: CenterKiaanTabProps): React.JSX.Element {
+  /** Ambient breathing scale — runs forever, even when inactive. */
+  const breathing = useSharedValue(1);
+  /** Ephemeral press scale — 0.92 on press, 1.0 released. */
+  const pressScale = useSharedValue(1);
+  /** 0 → 1 → 0 cycle (4 s) driving the border color cross-fade. */
+  const borderPhase = useSharedValue(0);
+  /** Focus state — 0 inactive, 1 active. */
+  const focus = useSharedValue(isFocused ? 1 : 0);
+
+  useEffect(() => {
+    // Always-on breathing cycle: 1.0 → 1.04 → 1.0 over 3000 ms.
+    breathing.value = withRepeat(
+      withSequence(
+        withTiming(1.04, { duration: 1500, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1.0, { duration: 1500, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+
+    // Slow border cross-fade: 0 → 1 over 2 s, 1 → 0 over 2 s = 4 s total.
+    borderPhase.value = withRepeat(
+      withSequence(
+        withTiming(1, { duration: 2000, easing: Easing.inOut(Easing.ease) }),
+        withTiming(0, { duration: 2000, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+  }, [breathing, borderPhase]);
+
+  useEffect(() => {
+    focus.value = withSpring(isFocused ? 1 : 0, {
+      damping: 18,
+      stiffness: 220,
+      mass: 0.8,
+    });
+  }, [isFocused, focus]);
+
+  const handlePressIn = React.useCallback(() => {
+    pressScale.value = withTiming(0.92, { duration: 80 });
+  }, [pressScale]);
+
+  const handlePressOut = React.useCallback(() => {
+    pressScale.value = withSpring(1.0, {
+      damping: 14,
+      stiffness: 260,
+      mass: 0.7,
+    });
+  }, [pressScale]);
+
+  const handlePress = React.useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    onPress();
+  }, [onPress]);
+
+  const buttonAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { scale: breathing.value * pressScale.value },
+    ],
+  }));
+
+  // Border cross-fades between gold and peacock by swapping two stacked
+  // gradient borders' opacities. `opacity` interpolates cleanly on the
+  // UI thread whereas borderColor between arbitrary named colors does not.
+  const goldBorderStyle = useAnimatedStyle(() => ({
+    opacity: 1 - borderPhase.value,
+  }));
+
+  const blueBorderStyle = useAnimatedStyle(() => ({
+    opacity: borderPhase.value,
+  }));
+
+  const labelAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: focus.value,
+  }));
+
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      {/* Radial-style aura behind button — gold → blue → transparent. */}
+      <View style={styles.auraWrap} pointerEvents="none">
+        <LinearGradient
+          colors={[
+            'rgba(212,160,23,0.3)',
+            'rgba(27,79,187,0.2)',
+            'transparent',
+          ]}
+          start={{ x: 0.5, y: 0.5 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.aura}
+        />
+      </View>
+
+      <Pressable
+        onPress={handlePress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        onLongPress={onLongPress}
+        accessibilityRole="tab"
+        accessibilityState={{ selected: isFocused }}
+        accessibilityLabel={label}
+        testID={testID ?? 'tab-sakha'}
+        hitSlop={8}
+      >
+        <Animated.View style={[styles.button, buttonAnimatedStyle]}>
+          {/* Fill — Krishna aura diagonal gradient (135°). */}
+          <LinearGradient
+            colors={[
+              'rgba(27,79,187,0.95)',
+              'rgba(66,41,155,0.90)',
+              'rgba(212,160,23,0.70)',
+            ]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={StyleSheet.absoluteFill}
+          />
+
+          {/* Border ring — gold layer. */}
+          <Animated.View
+            pointerEvents="none"
+            style={[styles.borderRing, { borderColor: GOLD }, goldBorderStyle]}
+          />
+          {/* Border ring — peacock blue layer (cross-fades with gold). */}
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              styles.borderRing,
+              { borderColor: KRISHNA_BLUE },
+              blueBorderStyle,
+            ]}
+          />
+
+          {/* Mandala — active=true when on KIAAN screen. */}
+          <View style={styles.mandalaWrap}>
+            {MandalaSpin ? (
+              <MandalaSpin
+                size={MANDALA_SIZE}
+                speed={isFocused ? 'fast' : 'slow'}
+                opacity={0.95}
+                color={GOLD}
+              />
+            ) : (
+              <Text style={styles.fallbackGlyph}>✦</Text>
+            )}
+          </View>
+        </Animated.View>
+      </Pressable>
+
+      {/* Gold label below the elevated button — only visible when active. */}
+      <View style={styles.labelSlot} pointerEvents="none">
+        <Animated.Text
+          numberOfLines={1}
+          style={[styles.label, labelAnimatedStyle]}
+        >
+          {label}
+        </Animated.Text>
+      </View>
+    </View>
+  );
+}
+
+/** Elevated center tab containing the Sakha mandala and golden aura. */
+export const CenterKiaanTab = React.memo(CenterKiaanTabInner);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    marginTop: -ELEVATION_OFFSET,
+    // No overflow: hidden — the button elevates above the bar and must
+    // be free to render beyond the container bounds.
+  },
+  auraWrap: {
+    position: 'absolute',
+    top: -((AURA_SIZE - BUTTON_SIZE) / 2),
+    width: AURA_SIZE,
+    height: AURA_SIZE,
+    borderRadius: AURA_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  aura: {
+    width: AURA_SIZE,
+    height: AURA_SIZE,
+    borderRadius: AURA_SIZE / 2,
+  },
+  button: {
+    width: BUTTON_SIZE,
+    height: BUTTON_SIZE,
+    borderRadius: BUTTON_SIZE / 2,
+    overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Subtle shadow so the elevation reads on light backgrounds.
+    ...Platform.select({
+      ios: {
+        shadowColor: GOLD,
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.45,
+        shadowRadius: 10,
+      },
+      android: {
+        elevation: 8,
+      },
+      default: {},
+    }),
+  },
+  borderRing: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRadius: BUTTON_SIZE / 2,
+    borderWidth: BORDER_WIDTH,
+  },
+  mandalaWrap: {
+    width: MANDALA_SIZE,
+    height: MANDALA_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fallbackGlyph: {
+    fontSize: 26,
+    color: GOLD,
+    fontWeight: '700',
+  },
+  labelSlot: {
+    height: 14,
+    marginTop: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    fontSize: 10,
+    fontFamily: Platform.select({
+      ios: 'Outfit-Medium',
+      android: 'Outfit-Medium',
+      default: 'Outfit-Medium',
+    }),
+    fontWeight: '500',
+    color: GOLD,
+    letterSpacing: 0.3,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
@@ -1,0 +1,218 @@
+/**
+ * DivineTabBar — Custom bottom tab bar for the Kiaanverse mobile app.
+ *
+ * Direct port of the web `components/navigation/MobileNav.tsx` — five
+ * sacred doorways: Home · Journeys · KIAAN (center) · Gita · Profile.
+ *
+ * Visual specification:
+ * - Height: 72 + safe-area bottom inset.
+ * - Background: rgba(5,7,20,0.95) — solid (expo-blur is unreliable on
+ *   Android; a semi-opaque navy keeps contrast + perf parity).
+ * - Top border: 1 px horizontal gradient (transparent → blue → gold →
+ *   blue → transparent) — echoes the web divine-threshold border.
+ * - Absolute-positioned at the screen bottom, overflow visible so the
+ *   elevated center KIAAN tab can extend above the bar.
+ * - Haptic feedback (ImpactFeedbackStyle.Light) on tab switches.
+ *
+ * Tab routing:
+ * - Compatible with expo-router's <Tabs tabBar={...} /> slot; consumes
+ *   the `BottomTabBarProps` passed by `@react-navigation/bottom-tabs`.
+ * - KIAAN tab is detected by route name 'sakha' (aligns with the
+ *   existing app router at app/(tabs)/sakha.tsx).
+ */
+
+import React, { useCallback } from 'react';
+import { StyleSheet, View, Platform } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Haptics from 'expo-haptics';
+import type { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+
+import { TabIcon, type TabRouteName } from './TabIcon';
+import { CenterKiaanTab } from './CenterKiaanTab';
+import { GopuramIcon } from './icons/GopuramIcon';
+import { ChakraColumnIcon } from './icons/ChakraColumnIcon';
+import { ManuscriptIcon } from './icons/ManuscriptIcon';
+import { MeditatorIcon } from './icons/MeditatorIcon';
+
+/** Base height of the tab bar content (safe-area inset is added on top). */
+const TAB_BAR_HEIGHT = 72;
+
+/** Route names that are eligible to render in the bar, in order. */
+const TAB_ORDER: ReadonlyArray<string> = [
+  'home',
+  'journey',
+  'sakha',
+  'gita',
+  'profile',
+];
+
+/** Non-center tab → icon component mapping. */
+const TAB_ICONS: Record<TabRouteName, React.ComponentType<{ size?: number; color?: string }>> = {
+  home: GopuramIcon,
+  journey: ChakraColumnIcon,
+  gita: ManuscriptIcon,
+  profile: MeditatorIcon,
+};
+
+/** Gradient color stops for the top divine-threshold border.
+ *  transparent → peacock → gold → peacock → transparent (matches web). */
+const TOP_BORDER_COLORS: readonly [string, string, string, string, string] = [
+  'transparent',
+  'rgba(27,79,187,0.4)',
+  'rgba(212,160,23,0.6)',
+  'rgba(27,79,187,0.4)',
+  'transparent',
+];
+
+/**
+ * Custom tab bar. Drop-in replacement for the default Expo Router bar:
+ *
+ * ```tsx
+ * <Tabs tabBar={(props) => <DivineTabBar {...props} />} ... />
+ * ```
+ */
+export function DivineTabBar({
+  state,
+  descriptors,
+  navigation,
+}: BottomTabBarProps): React.JSX.Element {
+  const insets = useSafeAreaInsets();
+
+  const handlePress = useCallback(
+    (route: { key: string; name: string }, isFocused: boolean) => {
+      const event = navigation.emit({
+        type: 'tabPress',
+        target: route.key,
+        canPreventDefault: true,
+      });
+      if (isFocused || event.defaultPrevented) return;
+
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      navigation.navigate(route.name);
+    },
+    [navigation],
+  );
+
+  const handleLongPress = useCallback(
+    (route: { key: string }) => {
+      navigation.emit({ type: 'tabLongPress', target: route.key });
+    },
+    [navigation],
+  );
+
+  // Filter the incoming route list down to the five sacred tabs and
+  // preserve the canonical order (expo-router can inject hidden routes
+  // which we drop here).
+  const visibleRoutes = state.routes.filter((r) => TAB_ORDER.includes(r.name));
+  const orderedRoutes = [...visibleRoutes].sort(
+    (a, b) => TAB_ORDER.indexOf(a.name) - TAB_ORDER.indexOf(b.name),
+  );
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          height: TAB_BAR_HEIGHT + insets.bottom,
+          paddingBottom: insets.bottom,
+        },
+      ]}
+      // Overflow visible so the center KIAAN tab can elevate above.
+      pointerEvents="box-none"
+      accessibilityRole="tablist"
+    >
+      {/* Divine-threshold top border: 1 px horizontal gradient. */}
+      <LinearGradient
+        colors={TOP_BORDER_COLORS as unknown as string[]}
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 1, y: 0.5 }}
+        style={styles.topBorder}
+      />
+
+      <View style={styles.row} pointerEvents="box-none">
+        {orderedRoutes.map((route) => {
+          const index = state.routes.findIndex((r) => r.key === route.key);
+          const isFocused = state.index === index;
+          const { options } = descriptors[route.key] ?? {};
+          const label =
+            typeof options?.tabBarLabel === 'string'
+              ? options.tabBarLabel
+              : typeof options?.title === 'string'
+                ? options.title
+                : route.name;
+
+          if (route.name === 'sakha') {
+            return (
+              <CenterKiaanTab
+                key={route.key}
+                isFocused={isFocused}
+                label={label}
+                onPress={() => handlePress(route, isFocused)}
+                onLongPress={() => handleLongPress(route)}
+              />
+            );
+          }
+
+          const routeName = route.name as TabRouteName;
+          const Icon = TAB_ICONS[routeName];
+          if (!Icon) return null;
+
+          return (
+            <TabIcon
+              key={route.key}
+              routeName={routeName}
+              label={label}
+              isFocused={isFocused}
+              onPress={() => handlePress(route, isFocused)}
+              onLongPress={() => handleLongPress(route)}
+              Icon={Icon}
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+export default DivineTabBar;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(5,7,20,0.95)',
+    // Overflow MUST stay visible so CenterKiaanTab can elevate above.
+    overflow: 'visible',
+    // Platform-specific depth to lift the bar above content.
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: -8 },
+        shadowOpacity: 0.5,
+        shadowRadius: 16,
+      },
+      android: {
+        elevation: 12,
+      },
+      default: {},
+    }),
+  },
+  topBorder: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 1,
+  },
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'space-evenly',
+    paddingHorizontal: 4,
+    paddingTop: 8,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/navigation/TabIcon.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/TabIcon.tsx
@@ -1,0 +1,185 @@
+/**
+ * TabIcon — Single non-center tab in the DivineTabBar.
+ *
+ * Renders one of the sacred SVG icons (Home / Journeys / Gita / Profile)
+ * plus a gold active indicator dot ABOVE the icon and a gold label below
+ * that is visible only in the active state.
+ *
+ * Active-state transitions (sacred-spring, ~180ms):
+ * - Icon color switches to #D4A017 (gold).
+ * - Icon scales 1.0 → 1.1 (divine breath — single cycle, settles at 1.0).
+ * - Indicator dot fades & scales 0 → 1 (6 px above the icon).
+ * - Label fades in (Outfit-Medium 10 px, gold).
+ *
+ * Inactive state: no dot, no label, icon rendered at opacity 0.4.
+ */
+
+import React, { useEffect } from 'react';
+import { Pressable, StyleSheet, View, Platform } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+/** Tab route identifier (one of the non-center tabs). */
+export type TabRouteName = 'home' | 'journey' | 'gita' | 'profile';
+
+/** Gold used for the active indicator, label, and icon stroke. */
+const ACTIVE_COLOR = '#D4A017';
+/** Matches MobileNav.tsx web `opacity: 0.4` for inactive icons. */
+const INACTIVE_COLOR = 'rgba(240,235,225,0.4)';
+/** Iconography stroke + fill render size (24×24 — matches SVG viewBox). */
+const ICON_SIZE = 24;
+/** Active indicator dot diameter. */
+const DOT_SIZE = 4;
+/** Distance between the dot's bottom edge and the icon's top edge. */
+const DOT_GAP = 6;
+/** Reserved vertical space for the dot row (dot + gap) — keeps layout stable. */
+const DOT_SLOT_HEIGHT = DOT_SIZE + DOT_GAP;
+
+export interface TabIconProps {
+  /** Which sacred icon to render. */
+  readonly routeName: TabRouteName;
+  /** Translated tab label — only shown when active. */
+  readonly label: string;
+  /** Whether this tab is the currently focused one. */
+  readonly isFocused: boolean;
+  /** Fired when the user taps this tab. */
+  readonly onPress: () => void;
+  /** Long-press handler (tab lifecycle emit). */
+  readonly onLongPress?: () => void;
+  /** Icon component to render (injected so TabIcon stays icon-agnostic). */
+  readonly Icon: React.ComponentType<{ size?: number; color?: string }>;
+  /** Test identifier for E2E testing. */
+  readonly testID?: string;
+}
+
+function TabIconInner({
+  routeName,
+  label,
+  isFocused,
+  onPress,
+  onLongPress,
+  Icon,
+  testID,
+}: TabIconProps): React.JSX.Element {
+  /** 0 = inactive, 1 = active — drives dot / label opacity + scale. */
+  const focus = useSharedValue(isFocused ? 1 : 0);
+  /** Scale driver for the icon (divine-breath cycle on activation). */
+  const iconScale = useSharedValue(1);
+
+  useEffect(() => {
+    // Sacred-spring for focus transition (~180ms).
+    focus.value = withSpring(isFocused ? 1 : 0, {
+      damping: 18,
+      stiffness: 220,
+      mass: 0.8,
+    });
+
+    if (isFocused) {
+      // Divine-breath: one cycle 1.0 → 1.1 → 1.0 over ~360ms.
+      iconScale.value = withSequence(
+        withTiming(1.1, { duration: 180, easing: Easing.out(Easing.quad) }),
+        withTiming(1.0, { duration: 180, easing: Easing.inOut(Easing.ease) }),
+      );
+    } else {
+      iconScale.value = withTiming(1.0, { duration: 120 });
+    }
+  }, [isFocused, focus, iconScale]);
+
+  const iconAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: iconScale.value }],
+  }));
+
+  const dotAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: focus.value,
+    transform: [{ scale: focus.value }],
+  }));
+
+  const labelAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: focus.value,
+  }));
+
+  // We swap stroke color on the JS thread (rgba→hex) because Reanimated
+  // cannot interpolate between rgba() and hex on the UI thread without
+  // the color plugin, and the focus-spring already carries the visual
+  // transition via dot + label fade-ins plus the icon breath cycle.
+  const iconColor = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onLongPress={onLongPress}
+      style={styles.container}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: isFocused }}
+      accessibilityLabel={label}
+      testID={testID ?? `tab-${routeName}`}
+      hitSlop={8}
+    >
+      {/* Reserved slot above the icon holds the gold dot (fixed height
+          keeps icon position stable across active/inactive states). */}
+      <View style={styles.dotSlot} pointerEvents="none">
+        <Animated.View style={[styles.dot, dotAnimatedStyle]} />
+      </View>
+
+      <Animated.View style={iconAnimatedStyle}>
+        <Icon size={ICON_SIZE} color={iconColor} />
+      </Animated.View>
+
+      {/* Label slot — fixed height so the tab doesn't resize on focus. */}
+      <View style={styles.labelSlot} pointerEvents="none">
+        <Animated.Text
+          numberOfLines={1}
+          style={[styles.label, labelAnimatedStyle]}
+        >
+          {label}
+        </Animated.Text>
+      </View>
+    </Pressable>
+  );
+}
+
+/** Single tab slot for the bottom navigation bar. */
+export const TabIcon = React.memo(TabIconInner);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 6,
+  },
+  dotSlot: {
+    height: DOT_SLOT_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    backgroundColor: ACTIVE_COLOR,
+  },
+  labelSlot: {
+    height: 14,
+    marginTop: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    fontSize: 10,
+    fontFamily: Platform.select({
+      ios: 'Outfit-Medium',
+      android: 'Outfit-Medium',
+      default: 'Outfit-Medium',
+    }),
+    fontWeight: '500',
+    color: ACTIVE_COLOR,
+    letterSpacing: 0.3,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/navigation/icons/ChakraColumnIcon.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/icons/ChakraColumnIcon.tsx
@@ -1,0 +1,59 @@
+/**
+ * ChakraColumnIcon — Ascending chakra column for the Journeys tab.
+ *
+ * Five circles stacked vertically with diameters increasing from bottom
+ * (root) to top (crown), echoing the spiritual journey upward through
+ * the chakras. Outline style, strokeWidth 1.5.
+ */
+
+import React from 'react';
+import Svg, { Circle } from 'react-native-svg';
+
+export interface ChakraColumnIconProps {
+  readonly size?: number;
+  readonly color?: string;
+}
+
+/**
+ * Chakra layout (top → bottom) tuned for a 24×24 viewBox:
+ * - Crown:     cy=3.25  r=2.25
+ * - Third-eye: cy=7.5   r=1.9
+ * - Throat:    cy=11.5  r=1.6
+ * - Heart:     cy=15    r=1.3
+ * - Root:      cy=18.25 r=1.0
+ *
+ * Each circle's vertical spacing is slightly greater than the next
+ * circle's diameter so they don't visually collide.
+ */
+const CHAKRAS: ReadonlyArray<{ cy: number; r: number }> = [
+  { cy: 3.25, r: 2.25 },
+  { cy: 7.5, r: 1.9 },
+  { cy: 11.5, r: 1.6 },
+  { cy: 15, r: 1.3 },
+  { cy: 18.25, r: 1.0 },
+];
+
+function ChakraColumnIconComponent({
+  size = 24,
+  color = 'currentColor',
+}: ChakraColumnIconProps): React.JSX.Element {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {CHAKRAS.map((c, i) => (
+        <Circle key={i} cx={12} cy={c.cy} r={c.r} />
+      ))}
+    </Svg>
+  );
+}
+
+/** Ascending chakra column icon for Journeys tab. */
+export const ChakraColumnIcon = React.memo(ChakraColumnIconComponent);

--- a/kiaanverse-mobile/apps/mobile/components/navigation/icons/GopuramIcon.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/icons/GopuramIcon.tsx
@@ -1,0 +1,58 @@
+/**
+ * GopuramIcon — South-Indian temple gopuram silhouette for the Home tab.
+ *
+ * Three-tiered curved roof layers above a rectangular base entrance,
+ * rendered as an outline with strokeWidth 1.5.
+ */
+
+import React from 'react';
+import Svg, { Path, Line } from 'react-native-svg';
+
+export interface GopuramIconProps {
+  readonly size?: number;
+  readonly color?: string;
+}
+
+function GopuramIconComponent({
+  size = 24,
+  color = 'currentColor',
+}: GopuramIconProps): React.JSX.Element {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Spire finial (kalasha) */}
+      <Path d="M12 1.75 V4" />
+      <Path d="M10.5 4 H13.5" />
+
+      {/* Top tier — narrow curved roof */}
+      <Path d="M9.5 4 Q12 6 14.5 4 L13.5 7 H10.5 Z" />
+
+      {/* Middle tier — wider curved roof */}
+      <Path d="M8 7.5 Q12 10 16 7.5 L14.5 11 H9.5 Z" />
+
+      {/* Base tier — widest curved roof */}
+      <Path d="M6 11.5 Q12 14 18 11.5 L16.5 15 H7.5 Z" />
+
+      {/* Temple base body */}
+      <Path d="M7 15 V22 H17 V15" />
+
+      {/* Entrance doorway (arched) */}
+      <Path d="M10 22 V18 Q12 16.5 14 18 V22" />
+
+      {/* Decorative horizontal band on base */}
+      <Line x1={7} y1={18.25} x2={10} y2={18.25} />
+      <Line x1={14} y1={18.25} x2={17} y2={18.25} />
+    </Svg>
+  );
+}
+
+/** Temple gopuram silhouette icon for Home tab. */
+export const GopuramIcon = React.memo(GopuramIconComponent);

--- a/kiaanverse-mobile/apps/mobile/components/navigation/icons/ManuscriptIcon.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/icons/ManuscriptIcon.tsx
@@ -1,0 +1,62 @@
+/**
+ * ManuscriptIcon — Open manuscript / scroll with lotus decoration
+ * for the Gita tab.
+ *
+ * A V-shaped open book with a central spine and a simple 5-petal
+ * lotus crowning the top center. Outline style, strokeWidth 1.5.
+ */
+
+import React from 'react';
+import Svg, { Path, Line } from 'react-native-svg';
+
+export interface ManuscriptIconProps {
+  readonly size?: number;
+  readonly color?: string;
+}
+
+function ManuscriptIconComponent({
+  size = 24,
+  color = 'currentColor',
+}: ManuscriptIconProps): React.JSX.Element {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Lotus atop the manuscript — 5 petals */}
+      {/* Center petal */}
+      <Path d="M12 1.5 Q11.25 3 12 4.5 Q12.75 3 12 1.5 Z" />
+      {/* Left outer petal */}
+      <Path d="M9.5 2.5 Q9.25 4 10.75 4.75 Q11 3.25 9.5 2.5 Z" />
+      {/* Right outer petal */}
+      <Path d="M14.5 2.5 Q14.75 4 13.25 4.75 Q13 3.25 14.5 2.5 Z" />
+      {/* Small base leaves */}
+      <Path d="M10 4.75 Q12 5.5 14 4.75" />
+
+      {/* Open book: left page */}
+      <Path d="M3.5 7 Q7.5 6.25 11.5 8 V21 Q7.5 19.25 3.5 20 Z" />
+
+      {/* Open book: right page */}
+      <Path d="M20.5 7 Q16.5 6.25 12.5 8 V21 Q16.5 19.25 20.5 20 Z" />
+
+      {/* Text lines on left page */}
+      <Line x1={5.25} y1={10} x2={9.75} y2={10.75} />
+      <Line x1={5.25} y1={12.5} x2={9.75} y2={13.25} />
+      <Line x1={5.25} y1={15} x2={9.75} y2={15.75} />
+
+      {/* Text lines on right page */}
+      <Line x1={14.25} y1={10.75} x2={18.75} y2={10} />
+      <Line x1={14.25} y1={13.25} x2={18.75} y2={12.5} />
+      <Line x1={14.25} y1={15.75} x2={18.75} y2={15} />
+    </Svg>
+  );
+}
+
+/** Open manuscript with lotus icon for Gita tab. */
+export const ManuscriptIcon = React.memo(ManuscriptIconComponent);

--- a/kiaanverse-mobile/apps/mobile/components/navigation/icons/MeditatorIcon.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/icons/MeditatorIcon.tsx
@@ -1,0 +1,56 @@
+/**
+ * MeditatorIcon — Seated meditator silhouette for the Profile tab.
+ *
+ * Simple figure in lotus pose (padmasana): circular head, torso with
+ * shoulders, crossed legs forming a base triangle, and hands resting
+ * in gyan mudra. Outline style, strokeWidth 1.5.
+ */
+
+import React from 'react';
+import Svg, { Circle, Path } from 'react-native-svg';
+
+export interface MeditatorIconProps {
+  readonly size?: number;
+  readonly color?: string;
+}
+
+function MeditatorIconComponent({
+  size = 24,
+  color = 'currentColor',
+}: MeditatorIconProps): React.JSX.Element {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Head */}
+      <Circle cx={12} cy={4.5} r={2.25} />
+
+      {/* Shoulders + torso: curves down from neck to hip line */}
+      <Path d="M8 10 Q12 7.75 16 10 L15 15 H9 Z" />
+
+      {/* Arms resting on knees (hands in mudra) */}
+      <Path d="M8.5 11.5 Q5.5 14 6.75 17" />
+      <Path d="M15.5 11.5 Q18.5 14 17.25 17" />
+
+      {/* Hands — small circles (gyan mudra) */}
+      <Circle cx={6.75} cy={17.25} r={0.85} />
+      <Circle cx={17.25} cy={17.25} r={0.85} />
+
+      {/* Crossed legs — lotus base triangle */}
+      <Path d="M9 15 L4 20.25 H20 L15 15" />
+
+      {/* Suggestion of crossed ankles at base center */}
+      <Path d="M10.5 20.25 Q12 18.75 13.5 20.25" />
+    </Svg>
+  );
+}
+
+/** Seated meditator silhouette icon for Profile tab. */
+export const MeditatorIcon = React.memo(MeditatorIconComponent);


### PR DESCRIPTION
## Summary

Implements a custom bottom tab bar (`DivineTabBar`) for the Kiaanverse mobile app with five sacred navigation tabs: Home, Journeys, KIAAN (center), Gita, and Profile. The KIAAN tab is an elevated, animated center button featuring the Sakha mandala, continuous breathing animation, and color-shifting border. Non-center tabs display sacred SVG icons (Gopuram, Chakra Column, Manuscript, Meditator) with active-state indicators and labels.

## Changes

### New Components

- **`DivineTabBar.tsx`**: Custom bottom tab bar compatible with expo-router's `<Tabs tabBar={...} />` slot. Features:
  - Semi-opaque navy background (`rgba(5,7,20,0.95)`)
  - Horizontal gradient top border (transparent → peacock → gold → peacock → transparent)
  - Absolute positioning with overflow visible to allow center tab elevation
  - Light haptic feedback on tab switches
  - Filters and orders routes to display only the five sacred tabs

- **`CenterKiaanTab.tsx`**: Elevated center button (64 px circular) with:
  - Continuous breathing animation (scale 1.0 → 1.04 → 1.0 over 3s)
  - Border color cross-fade between gold and peacock blue (4s cycle)
  - Press feedback (scale to 0.92 with Medium haptic)
  - Embedded Sakha mandala (40 px) that spins faster when active
  - Radial golden-blue aura behind the button (80 px)
  - Elevation offset of 20 px above the tab bar baseline

- **`TabIcon.tsx`**: Individual non-center tab component with:
  - Sacred-spring focus transition (~180ms)
  - Divine-breath icon scale cycle (1.0 → 1.1 → 1.0) on activation
  - Gold active indicator dot (4 px) above the icon
  - Gold label below icon (visible only when active)
  - Inactive state: 0.4 opacity icon, no dot/label

### Icon Components

Four new SVG icon components for the non-center tabs:
- **`GopuramIcon.tsx`**: South-Indian temple gopuram silhouette (Home tab)
- **`ChakraColumnIcon.tsx`**: Ascending chakra column (Journeys tab)
- **`ManuscriptIcon.tsx`**: Open manuscript with lotus decoration (Gita tab)
- **`MeditatorIcon.tsx`**: Seated meditator in lotus pose (Profile tab)

All icons use outline style with 1.5 px stroke width and support dynamic color/size props.

## Design Details

- **Colors**: Gold (`#D4A017`) for active states and accents; Peacock blue (`#1B4FBB`) for secondary accents
- **Typography**: Outfit-Medium 10 px for tab labels with 0.3 px letter spacing
- **Animations**: React Native Reanimated for all transitions (breathing, focus springs, press feedback)
- **Haptics**: Light impact on tab switches, Medium impact on center button press
- **Accessibility**: Proper ARIA roles, labels, and selected states for all tabs

## Checklist
- [x] CI passes (tests run successfully)
- [x] No private keys are committed
- [x] Code follows existing patterns and style conventions

## Testing

The implementation is ready for integration testing with the app router. Verify:
- Tab navigation works correctly with all five routes
- Center KIAAN tab elevates above the bar and animations run smoothly
- Active/inactive state transitions are fluid
- Haptic feedback triggers on tab presses
- Icons render correctly on both iOS and Android

https://claude.ai/code/session_01NCJtx1Kq9ztPk3B8ZZhLMQ