### PR TITLE
feat(ui): sacred component library + motion system for mobile

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -211,39 +211,53 @@ function AppContent(): React.JSX.Element {
       <NotificationToast />
       <ToastContainer />
       <AuthGate>
-        <Stack screenOptions={{ headerShown: false, animation: 'none' }}>
+        {/* Every navigation is a darshan — fade, never slide. Modal presentations
+            still slide from the bottom to signal entering/exiting a ritual space. */}
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            animation: 'fade',
+            animationDuration: 320,
+          }}
+        >
           <Stack.Screen name="(auth)" />
           <Stack.Screen name="(tabs)" />
           <Stack.Screen name="onboarding" />
-          <Stack.Screen name="gita" options={{ animation: 'slide_from_right' }} />
-          <Stack.Screen name="wellness" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="gita" />
+          <Stack.Screen name="wellness" />
           <Stack.Screen name="chat" />
-          <Stack.Screen name="subscription" options={{ animation: 'slide_from_bottom', presentation: 'modal' }} />
+          <Stack.Screen
+            name="subscription"
+            options={{ animation: 'slide_from_bottom', presentation: 'modal', animationDuration: 350 }}
+          />
 
-          {/* Sacred Tools — full-screen modal stacks */}
-          <Stack.Screen name="tools" options={{ animation: 'slide_from_right' }} />
+          {/* Sacred Tools */}
+          <Stack.Screen name="tools" />
 
           {/* Sacred Journal */}
-          <Stack.Screen name="journal" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="journal" />
 
           {/* Daily Sadhana */}
-          <Stack.Screen name="sadhana" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="sadhana" />
 
           {/* Community & Wisdom Rooms */}
-          <Stack.Screen name="community" options={{ animation: 'slide_from_right' }} />
-          <Stack.Screen name="wisdom-rooms" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="community" />
+          <Stack.Screen name="wisdom-rooms" />
 
           {/* Karma Footprint */}
-          <Stack.Screen name="karma-footprint" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="karma-footprint" />
 
           {/* Analytics & Deep Insights */}
-          <Stack.Screen name="analytics" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="analytics" />
 
-          {/* KIAAN Vibe Player */}
-          <Stack.Screen name="vibe-player" options={{ animation: 'slide_from_bottom' }} />
+          {/* KIAAN Vibe Player — modal from bottom */}
+          <Stack.Screen
+            name="vibe-player"
+            options={{ animation: 'slide_from_bottom', animationDuration: 350 }}
+          />
 
           {/* Settings */}
-          <Stack.Screen name="settings" options={{ animation: 'slide_from_right' }} />
+          <Stack.Screen name="settings" />
         </Stack>
       </AuthGate>
     </View>

--- a/kiaanverse-mobile/packages/ui/src/index.ts
+++ b/kiaanverse-mobile/packages/ui/src/index.ts
@@ -122,3 +122,47 @@ export { SacredChip, type SacredChipProps } from './components/SacredChip';
 export { useAudioPlayer } from './hooks/useAudioPlayer';
 export { useSpeechOutput } from './hooks/useSpeechOutput';
 export { useVoiceRecorder, type TranscribeFn, type TranscriptionResult } from './hooks/useVoiceRecorder';
+
+// ---------------------------------------------------------------------------
+// Sacred motion — screen transitions, press feedback, milestone pulses.
+// ---------------------------------------------------------------------------
+export {
+  // Duration + geometry tokens
+  DIVINE,
+  NATURAL,
+  EXIT,
+  SWIFT,
+  MODAL,
+  PULSE,
+  TAB_CROSSFADE,
+  ENTRANCE_TRANSLATE_Y,
+  ENTER_SCALE_FROM,
+  EXIT_SCALE,
+  PRESS_SCALE,
+  PULSE_SCALE_FROM,
+  PULSE_SCALE_TO,
+  PULSE_OPACITY_FROM,
+  PULSE_RING_COUNT,
+  PULSE_RING_DELAY,
+  // Easing curves
+  easeDivineIn,
+  easeDivineOut,
+  easeLotusBloom,
+  easePeacockShimmer,
+  // Hooks
+  useDivineEntrance,
+  useSacredPress,
+  useGoldenPulse,
+  // Components
+  SacredScrollView,
+  // Types
+  type UseDivineEntranceOptions,
+  type UseDivineEntranceResult,
+  type UseSacredPressOptions,
+  type UseSacredPressResult,
+  type SacredPressHandlers,
+  type HapticStyle,
+  type UseGoldenPulseOptions,
+  type UseGoldenPulseResult,
+  type SacredScrollViewProps,
+} from './motion';

--- a/kiaanverse-mobile/packages/ui/src/motion/SacredScrollView.tsx
+++ b/kiaanverse-mobile/packages/ui/src/motion/SacredScrollView.tsx
@@ -1,0 +1,182 @@
+/**
+ * SacredScrollView — ScrollView with a custom gold right-side indicator.
+ *
+ * Web parity:
+ *   - Hides the default vertical scroll indicator.
+ *   - Renders a 2px-wide gold bar on the right edge, opacity 0.3.
+ *   - Indicator size + position track content offset and visible height
+ *     via Reanimated shared values (driven from `useAnimatedScrollHandler`).
+ *   - Android: `bounces={false}` (set by platform prop) — web doesn't bounce.
+ *
+ * The indicator fades in while the user scrolls and fades back out when
+ * scrolling stops (matches Framer Motion's subtle fade on the web).
+ */
+
+import React, { forwardRef, useState } from 'react';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+  type LayoutChangeEvent,
+  type ScrollViewProps,
+  type ViewStyle,
+} from 'react-native';
+import Animated, {
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { SWIFT, easeDivineOut } from './tokens';
+
+const INDICATOR_WIDTH = 2;
+const INDICATOR_COLOR = '#D4A017';
+const INDICATOR_OPACITY = 0.3;
+const INDICATOR_MIN_LENGTH = 24;
+const INDICATOR_INSET = 2;
+
+export interface SacredScrollViewProps extends ScrollViewProps {
+  /** When false, the custom gold indicator is hidden. @default true */
+  readonly showIndicator?: boolean;
+  /** Optional style for the gold indicator overlay track. */
+  readonly goldIndicatorStyle?: ViewStyle;
+}
+
+const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
+
+function SacredScrollViewInner(
+  {
+    children,
+    showIndicator = true,
+    goldIndicatorStyle,
+    style,
+    contentContainerStyle,
+    onScroll,
+    bounces,
+    ...rest
+  }: SacredScrollViewProps,
+  ref: React.ForwardedRef<ScrollView>,
+): React.JSX.Element {
+  const [containerHeight, setContainerHeight] = useState(0);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  const scrollY = useSharedValue(0);
+  const indicatorOpacity = useSharedValue(0);
+
+  const handleScroll = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      scrollY.value = event.contentOffset.y;
+      indicatorOpacity.value = withTiming(INDICATOR_OPACITY, {
+        duration: SWIFT,
+        easing: easeDivineOut,
+      });
+    },
+    onMomentumEnd: () => {
+      indicatorOpacity.value = withTiming(0, {
+        duration: SWIFT * 2,
+        easing: easeDivineOut,
+      });
+    },
+    onEndDrag: () => {
+      indicatorOpacity.value = withTiming(0, {
+        duration: SWIFT * 2,
+        easing: easeDivineOut,
+      });
+    },
+  });
+
+  const onLayoutContainer = (e: LayoutChangeEvent): void => {
+    setContainerHeight(e.nativeEvent.layout.height);
+  };
+
+  const onContentSizeChange = (_: number, h: number): void => {
+    setContentHeight(h);
+  };
+
+  const indicatorAnimatedStyle = useAnimatedStyle(() => {
+    // No-scroll case: indicator has zero height → hide.
+    if (contentHeight <= containerHeight || containerHeight === 0) {
+      return {
+        opacity: 0,
+        height: 0,
+        transform: [{ translateY: 0 }],
+      };
+    }
+
+    const visibleRatio = containerHeight / contentHeight;
+    const rawHeight = containerHeight * visibleRatio;
+    const indicatorHeight = Math.max(INDICATOR_MIN_LENGTH, rawHeight);
+    const maxScroll = contentHeight - containerHeight;
+    const maxIndicatorTop = containerHeight - indicatorHeight - INDICATOR_INSET * 2;
+    const progress = maxScroll > 0 ? scrollY.value / maxScroll : 0;
+    const clampedProgress = Math.max(0, Math.min(1, progress));
+    const translateY = clampedProgress * maxIndicatorTop;
+
+    return {
+      opacity: indicatorOpacity.value,
+      height: indicatorHeight,
+      transform: [{ translateY }],
+    };
+  });
+
+  // Android: web doesn't overscroll-bounce; iOS keeps its native bounce unless
+  // caller explicitly opts in via prop.
+  const resolvedBounces = bounces ?? Platform.OS !== 'android';
+
+  return (
+    <View style={[styles.wrap, style]} onLayout={onLayoutContainer}>
+      <AnimatedScrollView
+        ref={ref}
+        {...rest}
+        style={styles.inner}
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator={false}
+        bounces={resolvedBounces}
+        onScroll={onScroll ?? handleScroll}
+        scrollEventThrottle={16}
+        onContentSizeChange={onContentSizeChange}
+      >
+        {children}
+      </AnimatedScrollView>
+
+      {showIndicator ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.indicator,
+            {
+              top: INDICATOR_INSET,
+              right: INDICATOR_INSET,
+              width: INDICATOR_WIDTH,
+              backgroundColor: INDICATOR_COLOR,
+              borderRadius: INDICATOR_WIDTH / 2,
+            },
+            indicatorAnimatedStyle,
+            goldIndicatorStyle,
+          ]}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+/** ScrollView with a custom 2px gold indicator pinned to the right edge. */
+export const SacredScrollView = forwardRef<ScrollView, SacredScrollViewProps>(
+  SacredScrollViewInner,
+);
+
+SacredScrollView.displayName = 'SacredScrollView';
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    position: 'relative',
+  },
+  inner: {
+    flex: 1,
+  },
+  indicator: {
+    position: 'absolute',
+  },
+});

--- a/kiaanverse-mobile/packages/ui/src/motion/index.ts
+++ b/kiaanverse-mobile/packages/ui/src/motion/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Sacred Motion — unified public surface for all screen transitions,
+ * pressable feedback, milestone pulses, and custom scroll chrome.
+ *
+ * Everything here mirrors the motion language used on kiaanverse.com/m/
+ * (web styles/divine.css + Framer Motion configs). Components and screens
+ * should prefer these hooks to hand-rolled Reanimated fragments so that
+ * the motion vocabulary stays consistent across the app.
+ */
+
+export {
+  DIVINE,
+  NATURAL,
+  EXIT,
+  SWIFT,
+  MODAL,
+  PULSE,
+  TAB_CROSSFADE,
+  ENTRANCE_TRANSLATE_Y,
+  ENTER_SCALE_FROM,
+  EXIT_SCALE,
+  PRESS_SCALE,
+  PULSE_SCALE_FROM,
+  PULSE_SCALE_TO,
+  PULSE_OPACITY_FROM,
+  PULSE_RING_COUNT,
+  PULSE_RING_DELAY,
+  easeDivineIn,
+  easeDivineOut,
+  easeLotusBloom,
+  easePeacockShimmer,
+} from './tokens';
+
+export {
+  useDivineEntrance,
+  type UseDivineEntranceOptions,
+  type UseDivineEntranceResult,
+} from './useDivineEntrance';
+
+export {
+  useSacredPress,
+  type UseSacredPressOptions,
+  type UseSacredPressResult,
+  type SacredPressHandlers,
+  type HapticStyle,
+} from './useSacredPress';
+
+export {
+  useGoldenPulse,
+  type UseGoldenPulseOptions,
+  type UseGoldenPulseResult,
+} from './useGoldenPulse';
+
+export {
+  SacredScrollView,
+  type SacredScrollViewProps,
+} from './SacredScrollView';

--- a/kiaanverse-mobile/packages/ui/src/motion/tokens.ts
+++ b/kiaanverse-mobile/packages/ui/src/motion/tokens.ts
@@ -1,0 +1,92 @@
+/**
+ * Sacred Motion Tokens — 1:1 parity with styles/divine.css on the web.
+ *
+ * Every duration and easing used by the mobile motion layer lives here so
+ * that components never invent magic numbers. Names mirror the web
+ * cubic-bezier aliases exactly (ease-divine-in, ease-divine-out,
+ * lotus-bloom, peacock-shimmer).
+ *
+ * Reference (from web styles/divine.css):
+ *   --ease-divine-in:      cubic-bezier(0.0, 0.8, 0.2, 1.0);
+ *   --ease-divine-out:     cubic-bezier(0.16, 1.0, 0.3, 1.0);
+ *   --ease-lotus-bloom:    cubic-bezier(0.22, 1.0, 0.36, 1.0);
+ *   --ease-peacock:        cubic-bezier(0.33, 1.0, 0.68, 1.0);
+ */
+
+import { Easing } from 'react-native-reanimated';
+
+/**
+ * Reanimated 3 `Easing.bezier` returns an EasingFactoryFn (a thunk producing
+ * the easing function). `withTiming`/`withDelay` both accept factory + plain
+ * easing functions, so we preserve that type via ReturnType inference rather
+ * than naming a single exported type from reanimated.
+ */
+type SacredEasing = ReturnType<typeof Easing.bezier>;
+
+// ---------------------------------------------------------------------------
+// Duration tokens (ms) — web-parity names.
+// ---------------------------------------------------------------------------
+
+/** 180ms — swift feedback (button press, chip tap, ripple). */
+export const SWIFT = 180;
+
+/** 200ms — exit animations (page leave, modal dismiss). */
+export const EXIT = 200;
+
+/** 320ms — divine entrance (screen + card enter). */
+export const DIVINE = 320;
+
+/** 320ms — natural card/element entrance (lotus-bloom easing). */
+export const NATURAL = 320;
+
+/** 350ms — modal slide-from-bottom (web parity). */
+export const MODAL = 350;
+
+/** 800ms — golden pulse expansion on milestones. */
+export const PULSE = 800;
+
+/** 180ms — tab crossfade. */
+export const TAB_CROSSFADE = 180;
+
+// ---------------------------------------------------------------------------
+// Easing curves — worklet-safe cubic-bezier functions.
+// ---------------------------------------------------------------------------
+
+/** ease-divine-in — soft start, confident finish. */
+export const easeDivineIn: SacredEasing = Easing.bezier(0.0, 0.8, 0.2, 1.0);
+
+/** ease-divine-out — snappy start, rounded landing. */
+export const easeDivineOut: SacredEasing = Easing.bezier(0.16, 1.0, 0.3, 1.0);
+
+/** lotus-bloom — organic expansion, slightly overshoots feel. */
+export const easeLotusBloom: SacredEasing = Easing.bezier(0.22, 1.0, 0.36, 1.0);
+
+/** peacock-shimmer — smooth iridescent travel for golden pulse. */
+export const easePeacockShimmer: SacredEasing = Easing.bezier(0.33, 1.0, 0.68, 1.0);
+
+// ---------------------------------------------------------------------------
+// Geometry constants referenced by motion hooks.
+// ---------------------------------------------------------------------------
+
+/** Translate distance (px) for page / card entrances. */
+export const ENTRANCE_TRANSLATE_Y = 16;
+
+/** Exit scale target for page leave (opacity 1→0, scale 1.0→1.03). */
+export const EXIT_SCALE = 1.03;
+
+/** Entrance scale start for page enter (opacity 0→1, scale 0.97→1.0). */
+export const ENTER_SCALE_FROM = 0.97;
+
+/** Scale-down on press (1.0 → 0.96). */
+export const PRESS_SCALE = 0.96;
+
+/** Golden pulse — scale range 0.5 → 2.0. */
+export const PULSE_SCALE_FROM = 0.5;
+export const PULSE_SCALE_TO = 2.0;
+
+/** Golden pulse — opacity peak 0.6 → 0. */
+export const PULSE_OPACITY_FROM = 0.6;
+
+/** Golden pulse — ring count and delay between rings (ms). */
+export const PULSE_RING_COUNT = 3;
+export const PULSE_RING_DELAY = 120;

--- a/kiaanverse-mobile/packages/ui/src/motion/useDivineEntrance.ts
+++ b/kiaanverse-mobile/packages/ui/src/motion/useDivineEntrance.ts
@@ -1,0 +1,111 @@
+/**
+ * useDivineEntrance — Screen/card entrance hook.
+ *
+ * Web parity:
+ *   opacity: 0 → 1
+ *   translateY: 16 → 0
+ *   Duration: DIVINE (320ms) for screens, NATURAL (320ms) for cards.
+ *   Easing: lotus-bloom.
+ *
+ * Supports an optional delay for stagger sequences (e.g., list of cards
+ * each offset by 60–80ms). Respects AccessibilityInfo.isReduceMotionEnabled
+ * — if enabled, the final resting state is applied instantly.
+ *
+ * Usage:
+ *   const { animatedStyle } = useDivineEntrance({ delay: index * 60 });
+ *   return <Animated.View style={animatedStyle}>...</Animated.View>;
+ */
+
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+import {
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+  type AnimatedStyle,
+} from 'react-native-reanimated';
+import type { ViewStyle } from 'react-native';
+import {
+  DIVINE,
+  ENTRANCE_TRANSLATE_Y,
+  easeLotusBloom,
+} from './tokens';
+
+export interface UseDivineEntranceOptions {
+  /** Delay (ms) before the entrance begins — used for staggered lists. @default 0 */
+  readonly delay?: number;
+  /** Override duration (ms). @default DIVINE (320ms) */
+  readonly duration?: number;
+  /** Starting translateY offset (px). @default 16 */
+  readonly translateY?: number;
+  /** Disable the entrance and render at rest immediately. @default false */
+  readonly disabled?: boolean;
+}
+
+export interface UseDivineEntranceResult {
+  /** Style to apply to the Animated.View wrapper. */
+  readonly animatedStyle: AnimatedStyle<ViewStyle>;
+}
+
+export function useDivineEntrance(
+  options: UseDivineEntranceOptions = {},
+): UseDivineEntranceResult {
+  const {
+    delay = 0,
+    duration = DIVINE,
+    translateY: translateFrom = ENTRANCE_TRANSLATE_Y,
+    disabled = false,
+  } = options;
+
+  const opacity = useSharedValue(disabled ? 1 : 0);
+  const translateY = useSharedValue(disabled ? 0 : translateFrom);
+
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (alive) setReduceMotion(enabled);
+      })
+      .catch(() => {
+        // Platform query failed — assume animations allowed.
+      });
+    const sub = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      setReduceMotion,
+    );
+    return () => {
+      alive = false;
+      sub.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (disabled || reduceMotion) {
+      opacity.value = 1;
+      translateY.value = 0;
+      return;
+    }
+
+    opacity.value = 0;
+    translateY.value = translateFrom;
+
+    opacity.value = withDelay(
+      delay,
+      withTiming(1, { duration, easing: easeLotusBloom }),
+    );
+    translateY.value = withDelay(
+      delay,
+      withTiming(0, { duration, easing: easeLotusBloom }),
+    );
+  }, [delay, disabled, duration, opacity, reduceMotion, translateFrom, translateY]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return { animatedStyle };
+}

--- a/kiaanverse-mobile/packages/ui/src/motion/useGoldenPulse.tsx
+++ b/kiaanverse-mobile/packages/ui/src/motion/useGoldenPulse.tsx
@@ -1,0 +1,219 @@
+/**
+ * useGoldenPulse — Three-ring radial gold pulse for milestones.
+ *
+ * Web parity:
+ *   - 3 rings fire in sequence, 120ms apart.
+ *   - Each ring: scale 0.5 → 2.0, opacity 0.6 → 0.
+ *   - Duration per ring: 800ms, peacock-shimmer easing.
+ *
+ * The hook returns:
+ *   - `pulseElement`: a ready-to-render View to place behind the target
+ *     (absolutely positioned; pointer events disabled so taps pass through).
+ *   - `triggerPulse`: a function the caller invokes on milestone events
+ *     (e.g., verse reveal complete, SAKHA message sent, streak unlocked).
+ *
+ * Usage:
+ *   const { pulseElement, triggerPulse } = useGoldenPulse();
+ *   return (
+ *     <View>
+ *       {pulseElement}
+ *       <Button title="Send" onPress={() => { triggerPulse(); send(); }} />
+ *     </View>
+ *   );
+ */
+
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+  type AnimatedStyle,
+} from 'react-native-reanimated';
+import type { ViewStyle } from 'react-native';
+import {
+  PULSE,
+  PULSE_OPACITY_FROM,
+  PULSE_RING_COUNT,
+  PULSE_RING_DELAY,
+  PULSE_SCALE_FROM,
+  PULSE_SCALE_TO,
+  easePeacockShimmer,
+} from './tokens';
+
+const GOLD = '#D4A017';
+
+export interface UseGoldenPulseOptions {
+  /** Diameter of each ring at rest (px). @default 64 */
+  readonly size?: number;
+  /** Override ring color. @default gold (#D4A017) */
+  readonly color?: string;
+  /** Ring stroke width. @default 2 */
+  readonly strokeWidth?: number;
+}
+
+export interface UseGoldenPulseResult {
+  /** A ready-to-place absolute element that renders the three pulse rings. */
+  readonly pulseElement: React.ReactElement;
+  /** Fire the pulse. Safe to call repeatedly (state resets each trigger). */
+  readonly triggerPulse: () => void;
+  /** Raw style for composing the primary ring if not using `pulseElement`. */
+  readonly pulseStyle: AnimatedStyle<ViewStyle>;
+}
+
+interface RingProps {
+  readonly size: number;
+  readonly color: string;
+  readonly strokeWidth: number;
+  readonly scale: ReturnType<typeof useSharedValue<number>>;
+  readonly opacity: ReturnType<typeof useSharedValue<number>>;
+}
+
+function PulseRing({
+  size,
+  color,
+  strokeWidth,
+  scale,
+  opacity,
+}: RingProps): React.JSX.Element {
+  const style = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.ring,
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          borderColor: color,
+          borderWidth: strokeWidth,
+          marginLeft: -size / 2,
+          marginTop: -size / 2,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+export function useGoldenPulse(
+  options: UseGoldenPulseOptions = {},
+): UseGoldenPulseResult {
+  const {
+    size = 64,
+    color = GOLD,
+    strokeWidth = 2,
+  } = options;
+
+  // Three independent ring pairs (scale + opacity) — one per ring.
+  const scale0 = useSharedValue(PULSE_SCALE_FROM);
+  const scale1 = useSharedValue(PULSE_SCALE_FROM);
+  const scale2 = useSharedValue(PULSE_SCALE_FROM);
+  const opacity0 = useSharedValue(0);
+  const opacity1 = useSharedValue(0);
+  const opacity2 = useSharedValue(0);
+
+  const firePair = useCallback(
+    (
+      scale: ReturnType<typeof useSharedValue<number>>,
+      opacity: ReturnType<typeof useSharedValue<number>>,
+      delayMs: number,
+    ) => {
+      // Reset to starting state before firing (handles repeat triggers).
+      scale.value = PULSE_SCALE_FROM;
+      opacity.value = 0;
+
+      scale.value = withDelay(
+        delayMs,
+        withTiming(PULSE_SCALE_TO, {
+          duration: PULSE,
+          easing: easePeacockShimmer,
+        }),
+      );
+
+      // Opacity ramps up briefly, then falls to 0 — emulate withSequence
+      // via a single withTiming since withSequence would double the duration.
+      opacity.value = withDelay(
+        delayMs,
+        withTiming(PULSE_OPACITY_FROM, {
+          duration: PULSE * 0.15,
+          easing: easePeacockShimmer,
+        }),
+      );
+      opacity.value = withDelay(
+        delayMs + PULSE * 0.15,
+        withTiming(0, {
+          duration: PULSE * 0.85,
+          easing: easePeacockShimmer,
+        }),
+      );
+    },
+    [],
+  );
+
+  const triggerPulse = useCallback(() => {
+    firePair(scale0, opacity0, 0);
+    firePair(scale1, opacity1, PULSE_RING_DELAY);
+    firePair(scale2, opacity2, PULSE_RING_DELAY * 2);
+  }, [firePair, scale0, scale1, scale2, opacity0, opacity1, opacity2]);
+
+  const pulseStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale0.value }],
+    opacity: opacity0.value,
+  }));
+
+  // Element is pre-composed so callers can drop it in without juggling refs.
+  const pulseElement = (
+    <View pointerEvents="none" style={styles.anchor}>
+      {PULSE_RING_COUNT >= 1 ? (
+        <PulseRing
+          size={size}
+          color={color}
+          strokeWidth={strokeWidth}
+          scale={scale0}
+          opacity={opacity0}
+        />
+      ) : null}
+      {PULSE_RING_COUNT >= 2 ? (
+        <PulseRing
+          size={size}
+          color={color}
+          strokeWidth={strokeWidth}
+          scale={scale1}
+          opacity={opacity1}
+        />
+      ) : null}
+      {PULSE_RING_COUNT >= 3 ? (
+        <PulseRing
+          size={size}
+          color={color}
+          strokeWidth={strokeWidth}
+          scale={scale2}
+          opacity={opacity2}
+        />
+      ) : null}
+    </View>
+  );
+
+  return { pulseElement, triggerPulse, pulseStyle };
+}
+
+const styles = StyleSheet.create({
+  anchor: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ring: {
+    position: 'absolute',
+    left: '50%',
+    top: '50%',
+    backgroundColor: 'transparent',
+  },
+});

--- a/kiaanverse-mobile/packages/ui/src/motion/useSacredPress.ts
+++ b/kiaanverse-mobile/packages/ui/src/motion/useSacredPress.ts
@@ -1,0 +1,118 @@
+/**
+ * useSacredPress — Unified Pressable animation + haptic feedback.
+ *
+ * Web parity:
+ *   scale: 1.0 → 0.96 on press-in, back to 1.0 on press-out.
+ *   Duration: SWIFT (180ms).
+ *   Easing in:  ease-divine-in (soft attack).
+ *   Easing out: ease-divine-out (rounded release).
+ *   Haptic: ImpactFeedbackStyle.Light fires on press start.
+ *
+ * Returns an `animatedStyle` to apply to the pressable target and a
+ * `pressHandlers` object to spread onto a Pressable or a custom
+ * gesture-driven wrapper.
+ *
+ * Usage:
+ *   const { animatedStyle, pressHandlers } = useSacredPress();
+ *   return (
+ *     <AnimatedPressable {...pressHandlers} style={animatedStyle}>
+ *       ...
+ *     </AnimatedPressable>
+ *   );
+ */
+
+import { useCallback } from 'react';
+import {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  type AnimatedStyle,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+import type { ViewStyle } from 'react-native';
+import {
+  PRESS_SCALE,
+  SWIFT,
+  easeDivineIn,
+  easeDivineOut,
+} from './tokens';
+
+export type HapticStyle =
+  | 'Light'
+  | 'Medium'
+  | 'Heavy'
+  | 'None';
+
+export interface UseSacredPressOptions {
+  /** Haptic intensity on press start. @default 'Light' */
+  readonly haptic?: HapticStyle;
+  /** Target scale at press-in. @default 0.96 */
+  readonly pressScale?: number;
+  /** Disable haptic + scale interaction. @default false */
+  readonly disabled?: boolean;
+}
+
+export interface SacredPressHandlers {
+  readonly onPressIn: () => void;
+  readonly onPressOut: () => void;
+}
+
+export interface UseSacredPressResult {
+  readonly animatedStyle: AnimatedStyle<ViewStyle>;
+  readonly pressHandlers: SacredPressHandlers;
+}
+
+function mapImpact(style: HapticStyle): Haptics.ImpactFeedbackStyle | null {
+  switch (style) {
+    case 'Light':
+      return Haptics.ImpactFeedbackStyle.Light;
+    case 'Medium':
+      return Haptics.ImpactFeedbackStyle.Medium;
+    case 'Heavy':
+      return Haptics.ImpactFeedbackStyle.Heavy;
+    case 'None':
+      return null;
+  }
+}
+
+export function useSacredPress(
+  options: UseSacredPressOptions = {},
+): UseSacredPressResult {
+  const {
+    haptic = 'Light',
+    pressScale = PRESS_SCALE,
+    disabled = false,
+  } = options;
+
+  const scale = useSharedValue(1);
+
+  const onPressIn = useCallback(() => {
+    if (disabled) return;
+    scale.value = withTiming(pressScale, {
+      duration: SWIFT,
+      easing: easeDivineIn,
+    });
+    const impact = mapImpact(haptic);
+    if (impact !== null) {
+      void Haptics.impactAsync(impact).catch(() => {
+        // Haptics unavailable (tests, web) — ignore.
+      });
+    }
+  }, [disabled, haptic, pressScale, scale]);
+
+  const onPressOut = useCallback(() => {
+    scale.value = withTiming(1, {
+      duration: SWIFT,
+      easing: easeDivineOut,
+    });
+  }, [scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return {
+    animatedStyle,
+    pressHandlers: { onPressIn, onPressOut },
+  };
+}


### PR DESCRIPTION
## Summary

Ports the Kiaanverse web design system to React Native with 1:1 parity.
Two concerns land together so the component library ships with a usable
motion vocabulary out of the box.

**1. Sacred component library (12 components)** —
`kiaanverse-mobile/packages/ui/src/components/`
- `SacredCard` — indigo body + gold top shimmer (un-clipped sibling) + divine shadow, optional glow, pressable scale 0.97→1.0
- `DivineButton` — Krishna Aura gradient pill (52×26 radius), haptic + 180ms divine-out press, secondary/ghost variants
- `SacredInput` — animated gold focus border + outer glow, italic placeholder, 320ms transition
- `GoldenDivider` — 5-stop gold gradient rule with optional centered `✦`
- `VerseRevelation` — word-by-word Sanskrit reveal, 80ms stagger, respects reduce-motion
- `OmLoader` — rotating ring + pulsing ॐ glyph, replaces `ActivityIndicator`
- `SakhaMandala` — 4 independently rotating Sri Yantra layers (outer circle 60s, hexagram 45s, 8-petal lotus 90s, stationary OM) + aura underlay; `active` speeds rotations 1.5×
- `DivinePresenceIndicator` — 3-layer breathing aura, 4s cycle, 2× opacity when responding
- `SacredProgressRing` — gold gradient SVG arc (0→progress over 800ms lotus-bloom) + streak center + completion pulse
- `ShlokaCard` — Sanskrit reveal + transliteration + meaning + chapter ref
- `SacredBadge` — gold-bordered pill with 5 semantic tones
- `SacredChip` — compact italic pressable chip with haptic + scale

**2. Sacred motion primitives** — `kiaanverse-mobile/packages/ui/src/motion/`
- `tokens.ts` — DIVINE (320), NATURAL (320), EXIT (200), SWIFT (180), MODAL (350), PULSE (800), TAB_CROSSFADE (180) durations + `easeDivineIn`, `easeDivineOut`, `easeLotusBloom`, `easePeacockShimmer` cubic-bezier easings (1:1 with `styles/divine.css`)
- `useDivineEntrance` — opacity 0→1 + translateY 16→0, lotus-bloom, stagger delay, reduce-motion aware
- `useSacredPress` — scale 1.0↔0.96 over SWIFT, divine-in on press / divine-out on release, Light haptic
- `useGoldenPulse` — 3 concentric rings cascading 0.5→2.0 scale + 0.6→0 opacity over 800ms peacock-shimmer, 120ms apart; returns `{pulseElement, triggerPulse}`
- `SacredScrollView` — hides native scrollbar, renders 2px right-edge gold indicator at 0.3 opacity driven by `useAnimatedScrollHandler`; Android bounce disabled

**3. Expo Router transitions** — `apps/mobile/app/_layout.tsx`
- Default `screenOptions.animation: 'fade'` at 320ms — Android no longer slides from right
- Modal screens (`subscription`, `vibe-player`) keep `slide_from_bottom` at 350ms
- Hardware back fades out instead of sliding

## Test plan

- [x] `pnpm --filter @kiaanverse/ui typecheck` — all 18 new files clean (32 pre-existing errors in untouched files are unchanged)
- [x] `pnpm --filter @kiaanverse/ui test` — 22 existing jest tests still pass
- [ ] Smoke test screen navigation on Android build — confirm fade transition (not slide)
- [ ] Smoke test back navigation — confirm fade-out
- [ ] Smoke test modal screens (`/subscription`, `/vibe-player`) — confirm slide-from-bottom still works
- [ ] Verify `OmLoader` renders at 64px default and rotates continuously
- [ ] Verify `SakhaMandala` four rotation layers all move independently
- [ ] Verify `SacredScrollView` indicator appears on scroll and fades out on release

https://claude.ai/code/session_01RuBHBNMKCCCXQwoPaPvxdu