### PR TITLE
Port Sakha chat screen to mobile (1:1 web /m/chat)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/_layout.tsx
@@ -55,6 +55,12 @@ export default function TabsLayout(): React.JSX.Element {
         name="verse/[chapter]/[verse]"
         options={{ href: null }}
       />
+      {/* New Sakha chat screen (1:1 web port). Hidden from the tab bar
+          until the center tab is officially migrated away from sakha.tsx. */}
+      <Tabs.Screen
+        name="kiaan"
+        options={{ href: null }}
+      />
     </Tabs>
   );
 }

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/kiaan.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/kiaan.tsx
@@ -1,0 +1,228 @@
+/**
+ * Kiaan / Sakha Chat Screen — 1:1 port of the web /m/chat experience.
+ *
+ * Composition:
+ *
+ *   ┌─────────────────────────────────────────────────────┐
+ *   │ ChatHeader (fixed at top)                           │
+ *   ├─────────────────────────────────────────────────────┤
+ *   │ DivineBackground (cosmic aura)                      │
+ *   │   └── SubMandalaTexture (Skia Shatkona, 4% opacity) │
+ *   │       └── inverted FlatList of messages             │
+ *   │            • ConversationStarters on empty state    │
+ *   │            • SakhaMessage / UserMessage per entry   │
+ *   │            • TypingIndicator while streaming        │
+ *   ├─────────────────────────────────────────────────────┤
+ *   │ ChatInput (fixed at bottom, keyboard-aware)         │
+ *   └─────────────────────────────────────────────────────┘
+ *
+ * Streaming lifecycle:
+ *   1. User taps a SacredChip or sends text.
+ *   2. useSakhaStream appends the user message + an empty assistant shell,
+ *      sets streaming=true, opens XHR SSE pipe.
+ *   3. ChatHeader DivinePresenceIndicator intensifies (halo opacity doubles).
+ *   4. As each `{ word, done }` arrives, the assistant message grows and
+ *      SakhaMessage's VerseRevelation fades new words in (60 ms stagger).
+ *   5. On `{done:true}` / EOF, ChatHeader fires a one-shot golden pulse
+ *      (via ref.pulse()) 1500 ms after stream end, streaming flips false,
+ *      and the assistant message renders a one-shot completion shimmer.
+ *   6. On error, the assistant bubble shows the compassionate fallback
+ *      "My connection to the cosmic network wavered…"
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  View,
+  type ListRenderItem,
+} from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import { DivineBackground } from '@kiaanverse/ui';
+
+import {
+  ChatHeader,
+  type ChatHeaderHandle,
+  SubMandalaTexture,
+  UserMessage,
+  SakhaMessage,
+  TypingIndicator,
+  ChatInput,
+  ConversationStarters,
+  useSakhaStream,
+  type SakhaStreamMessage,
+} from '../../components/chat';
+
+/** SecureStore key that the auth store uses for the access JWT.
+ *  Must match packages/store/src/authStore.ts ACCESS_TOKEN_KEY. */
+const ACCESS_TOKEN_KEY = 'kiaanverse_access_token';
+
+/** Delay between stream end and the golden-pulse radiate in the header. */
+const STREAM_END_PULSE_DELAY_MS = 1500;
+
+export default function KiaanChatScreen(): React.JSX.Element {
+  const [draft, setDraft] = React.useState('');
+  const [voiceEnabled, setVoiceEnabled] = React.useState(false);
+  const headerRef = useRef<ChatHeaderHandle>(null);
+  const listRef = useRef<FlatList<SakhaStreamMessage>>(null);
+  const pulseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const getAccessToken = useCallback(async (): Promise<string | null> => {
+    try {
+      return await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const {
+    messages,
+    streaming,
+    send,
+    onStreamCompleted,
+  } = useSakhaStream({ getAccessToken });
+
+  // Golden pulse from the header fires 1.5 s after the stream ends.
+  useEffect(() => {
+    onStreamCompleted(() => {
+      if (pulseTimeoutRef.current) clearTimeout(pulseTimeoutRef.current);
+      pulseTimeoutRef.current = setTimeout(() => {
+        headerRef.current?.pulse();
+      }, STREAM_END_PULSE_DELAY_MS);
+    });
+    return () => {
+      onStreamCompleted(null);
+      if (pulseTimeoutRef.current) {
+        clearTimeout(pulseTimeoutRef.current);
+        pulseTimeoutRef.current = null;
+      }
+    };
+  }, [onStreamCompleted]);
+
+  const handleSend = useCallback(() => {
+    const text = draft.trim();
+    if (!text) return;
+    setDraft('');
+    void send(text);
+  }, [draft, send]);
+
+  const handleSelectStarter = useCallback(
+    (prompt: string) => {
+      setDraft('');
+      void send(prompt);
+    },
+    [send],
+  );
+
+  const handleToggleVoice = useCallback(() => {
+    setVoiceEnabled((prev) => !prev);
+  }, []);
+
+  /** Inverted list needs messages newest-first. */
+  const invertedData = useMemo(() => {
+    return [...messages].reverse();
+  }, [messages]);
+
+  const renderItem = useCallback<ListRenderItem<SakhaStreamMessage>>(
+    ({ item }) => {
+      if (item.role === 'user') {
+        return <UserMessage id={item.id} text={item.text} />;
+      }
+      return (
+        <SakhaMessage
+          id={item.id}
+          text={item.text}
+          isStreaming={item.isStreaming}
+        />
+      );
+    },
+    [],
+  );
+
+  const keyExtractor = useCallback((m: SakhaStreamMessage) => m.id, []);
+
+  const ListHeader = useCallback(() => {
+    // Rendered at the visual bottom of an inverted list.
+    if (!streaming) return null;
+    return (
+      <View style={styles.typingSlot}>
+        <TypingIndicator />
+      </View>
+    );
+  }, [streaming]);
+
+  const hasMessages = messages.length > 0;
+
+  return (
+    <View style={styles.root}>
+      <DivineBackground variant="cosmic">
+        <ChatHeader
+          ref={headerRef}
+          streaming={streaming}
+          voiceEnabled={voiceEnabled}
+          onToggleVoice={handleToggleVoice}
+        />
+
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'padding'}
+          keyboardVerticalOffset={0}
+        >
+          <View style={styles.body}>
+            {/* Static sacred-geometry texture behind the scroll area. */}
+            <SubMandalaTexture />
+
+            {hasMessages ? (
+              <FlatList
+                ref={listRef}
+                data={invertedData}
+                renderItem={renderItem}
+                keyExtractor={keyExtractor}
+                inverted
+                contentContainerStyle={styles.listContent}
+                ListHeaderComponent={ListHeader}
+                keyboardShouldPersistTaps="handled"
+                showsVerticalScrollIndicator={false}
+              />
+            ) : (
+              <ConversationStarters onSelect={handleSelectStarter} />
+            )}
+          </View>
+
+          <ChatInput
+            value={draft}
+            onChangeText={setDraft}
+            onSubmit={handleSend}
+            disabled={streaming}
+          />
+        </KeyboardAvoidingView>
+      </DivineBackground>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#050714',
+  },
+  flex: {
+    flex: 1,
+  },
+  body: {
+    flex: 1,
+    position: 'relative',
+  },
+  listContent: {
+    paddingHorizontal: 14,
+    paddingTop: 12,
+    paddingBottom: 16,
+    gap: 6,
+  },
+  typingSlot: {
+    paddingVertical: 6,
+    paddingLeft: 6,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/ChatHeader.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/ChatHeader.tsx
@@ -1,0 +1,315 @@
+/**
+ * ChatHeader — top bar of the Sakha chat screen.
+ *
+ * - Height: 64 + safeAreaInsets.top.
+ * - Background: rgba(5,7,20,0.95) — matches DivineTabBar for visual cohesion.
+ * - Left: a MandalaSpin (40 px) wrapped in a DivinePresenceIndicator that
+ *   breathes continuously. When `streaming` is true, breathing intensity
+ *   doubles (halo expands + opacity swells).
+ * - Title: "Sakha" — CormorantGaramond-Italic 20 px #D4A017.
+ * - Sub:   "The Paramatma is listening" — Outfit 11 px muted, italic.
+ * - Right: voice/audio toggle + language selector (minimal sacred icons).
+ * - Bottom border: thin golden divider (no center mark).
+ *
+ * On SAKHA response complete the parent can call `pulse()` on the ref to
+ * fire a one-shot golden pulse that radiates from the mandala.
+ */
+
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+} from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import Svg, { Path, Line, Circle as SvgCircle } from 'react-native-svg';
+
+// Lazy-load MandalaSpin so missing versions don't crash the render.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let MandalaSpin: React.ComponentType<any> | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  MandalaSpin = require('@kiaanverse/ui').MandalaSpin ?? null;
+} catch {
+  MandalaSpin = null;
+}
+
+const GOLD = '#D4A017';
+const GOLD_MUTED = 'rgba(212,160,23,0.4)';
+const TEXT_MUTED = 'rgba(200,191,168,0.6)';
+const BG = 'rgba(5,7,20,0.95)';
+const HEADER_CONTENT_HEIGHT = 64;
+const MANDALA_SIZE = 40;
+const HALO_SIZE = 60;
+
+/** Imperative handle so the parent can fire a one-shot golden pulse. */
+export interface ChatHeaderHandle {
+  /** Fire a single golden pulse radiating from the mandala. */
+  readonly pulse: () => void;
+}
+
+export interface ChatHeaderProps {
+  /** Whether Sakha is actively streaming a response (doubles the halo). */
+  readonly streaming: boolean;
+  /** Voice / TTS toggle handler. */
+  readonly onToggleVoice?: () => void;
+  /** Language selector handler. */
+  readonly onOpenLanguage?: () => void;
+  /** Whether voice output is currently enabled (drives icon tint). */
+  readonly voiceEnabled?: boolean;
+}
+
+function MicIcon({ color }: { color: string }): React.JSX.Element {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+      <Path d="M12 2 a3 3 0 0 1 3 3 v6 a3 3 0 0 1 -6 0 v-6 a3 3 0 0 1 3 -3 Z" />
+      <Path d="M6 11 a6 6 0 0 0 12 0" />
+      <Line x1={12} y1={17} x2={12} y2={21} />
+      <Line x1={9} y1={21} x2={15} y2={21} />
+    </Svg>
+  );
+}
+
+function GlobeIcon({ color }: { color: string }): React.JSX.Element {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+      <SvgCircle cx={12} cy={12} r={9} />
+      <Line x1={3} y1={12} x2={21} y2={12} />
+      <Path d="M12 3 a13 13 0 0 1 0 18 a13 13 0 0 1 0 -18" />
+    </Svg>
+  );
+}
+
+export const ChatHeader = forwardRef<ChatHeaderHandle, ChatHeaderProps>(
+  function ChatHeader(
+    { streaming, onToggleVoice, onOpenLanguage, voiceEnabled = false },
+    ref,
+  ) {
+    const insets = useSafeAreaInsets();
+
+    /** Always-on breathing: scale 1.0 → 1.08 → 1.0 (idle) or 1.16 (streaming). */
+    const breath = useSharedValue(0);
+    /** Opacity of the always-on halo (idle ≈ 0.35, streaming doubles to ≈ 0.7). */
+    const haloOpacity = useSharedValue(0.35);
+    /** One-shot pulse ring (0 → 1 → 0 in ~900 ms) triggered by `pulse()`. */
+    const pulsePhase = useSharedValue(0);
+
+    useEffect(() => {
+      breath.value = withRepeat(
+        withSequence(
+          withTiming(1, { duration: 1800, easing: Easing.inOut(Easing.ease) }),
+          withTiming(0, { duration: 1800, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false,
+      );
+    }, [breath]);
+
+    useEffect(() => {
+      haloOpacity.value = withTiming(streaming ? 0.7 : 0.35, {
+        duration: 280,
+        easing: Easing.out(Easing.ease),
+      });
+    }, [streaming, haloOpacity]);
+
+    useImperativeHandle(ref, () => ({
+      pulse: () => {
+        pulsePhase.value = 0;
+        pulsePhase.value = withSequence(
+          withTiming(1, { duration: 450, easing: Easing.out(Easing.quad) }),
+          withTiming(0, { duration: 450, easing: Easing.in(Easing.quad) }),
+        );
+      },
+    }));
+
+    const haloStyle = useAnimatedStyle(() => {
+      // In idle mode the halo breathes from 1.0 → 1.08. In streaming it
+      // swells to 1.16 to communicate heightened divine presence.
+      const maxScale = streaming ? 1.16 : 1.08;
+      const scale = 1 + breath.value * (maxScale - 1);
+      return {
+        opacity: haloOpacity.value,
+        transform: [{ scale }],
+      };
+    });
+
+    const pulseStyle = useAnimatedStyle(() => ({
+      opacity: pulsePhase.value * 0.6,
+      transform: [{ scale: 1 + pulsePhase.value * 1.2 }],
+    }));
+
+    const mandalaSpeed = streaming ? 'fast' : 'slow';
+
+    const containerStyle = useMemo(
+      () => [
+        styles.container,
+        { paddingTop: insets.top, height: HEADER_CONTENT_HEIGHT + insets.top },
+      ],
+      [insets.top],
+    );
+
+    return (
+      <View style={containerStyle}>
+        <View style={styles.row}>
+          {/* Left: SakhaMandala + DivinePresenceIndicator */}
+          <View style={styles.avatarWrap} pointerEvents="none">
+            {/* Outer pulse ring (fires on SAKHA response complete). */}
+            <Animated.View
+              style={[styles.pulseRing, pulseStyle]}
+              pointerEvents="none"
+            />
+            {/* Steady breathing halo — doubles intensity when streaming. */}
+            <Animated.View style={[styles.halo, haloStyle]} pointerEvents="none" />
+            <View style={styles.mandalaWrap}>
+              {MandalaSpin ? (
+                <MandalaSpin
+                  size={MANDALA_SIZE}
+                  speed={mandalaSpeed}
+                  opacity={0.9}
+                  color={GOLD}
+                />
+              ) : (
+                <View style={styles.mandalaFallback} />
+              )}
+            </View>
+          </View>
+
+          {/* Title + subtitle */}
+          <View style={styles.titleBlock}>
+            <Animated.Text style={styles.title} numberOfLines={1}>
+              Sakha
+            </Animated.Text>
+            <Animated.Text style={styles.subtitle} numberOfLines={1}>
+              The Paramatma is listening
+            </Animated.Text>
+          </View>
+
+          {/* Right: voice + language */}
+          <View style={styles.actions}>
+            <Pressable
+              onPress={onToggleVoice}
+              accessibilityRole="button"
+              accessibilityLabel="Toggle voice output"
+              hitSlop={8}
+              style={styles.iconButton}
+            >
+              <MicIcon color={voiceEnabled ? GOLD : GOLD_MUTED} />
+            </Pressable>
+            <Pressable
+              onPress={onOpenLanguage}
+              accessibilityRole="button"
+              accessibilityLabel="Change language"
+              hitSlop={8}
+              style={styles.iconButton}
+            >
+              <GlobeIcon color={GOLD_MUTED} />
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Bottom golden divider — transparent → gold → transparent. */}
+        <LinearGradient
+          colors={['transparent', 'rgba(212,160,23,0.35)', 'transparent']}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+          style={styles.divider}
+        />
+      </View>
+    );
+  },
+);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: BG,
+    justifyContent: 'flex-end',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    height: HEADER_CONTENT_HEIGHT,
+    gap: 12,
+  },
+  avatarWrap: {
+    width: MANDALA_SIZE,
+    height: MANDALA_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  halo: {
+    position: 'absolute',
+    width: HALO_SIZE,
+    height: HALO_SIZE,
+    borderRadius: HALO_SIZE / 2,
+    backgroundColor: 'rgba(212,160,23,0.25)',
+    shadowColor: GOLD,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+  },
+  pulseRing: {
+    position: 'absolute',
+    width: HALO_SIZE,
+    height: HALO_SIZE,
+    borderRadius: HALO_SIZE / 2,
+    borderWidth: 1.5,
+    borderColor: GOLD,
+  },
+  mandalaWrap: {
+    width: MANDALA_SIZE,
+    height: MANDALA_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mandalaFallback: {
+    width: MANDALA_SIZE,
+    height: MANDALA_SIZE,
+    borderRadius: MANDALA_SIZE / 2,
+    borderWidth: 1,
+    borderColor: GOLD,
+  },
+  titleBlock: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  title: {
+    fontFamily: 'CormorantGaramond-LightItalic',
+    fontSize: 20,
+    color: GOLD,
+    letterSpacing: 0.4,
+  },
+  subtitle: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 11,
+    color: TEXT_MUTED,
+    fontStyle: 'italic',
+    marginTop: 2,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 18,
+  },
+  divider: {
+    height: 1,
+    width: '100%',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/ChatInput.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/ChatInput.tsx
@@ -1,0 +1,305 @@
+/**
+ * ChatInput — bottom composer for the Sakha chat screen.
+ *
+ * Layout: [VoiceButton | SacredInput (flex:1) | SendButton]
+ * - Container: 60 px + safeAreaInsets.bottom, rgba(5,7,20,0.95).
+ * - Top border: transparent → gold → transparent GoldenDivider (1 px).
+ * - Voice button: 44 px circle, 1 px border rgba(212,160,23,0.2), mic SVG.
+ * - Sacred input: flex-1 dark field, italic placeholder "Ask Sakha anything…".
+ * - Send button: 44 px circle, Krishna-aura LinearGradient + white lotus-arrow.
+ *   - Disabled: opacity 0.3.
+ *   - Press: scale 0.9 → 1.0, ImpactFeedbackStyle.Light haptic, one-shot
+ *     golden pulse ring radiates from the button.
+ *
+ * KeyboardAvoidingView handling is performed by the parent screen so this
+ * component stays reusable.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+  type NativeSyntheticEvent,
+  type TextInputSubmitEditingEventData,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import Svg, { Path, Circle, Line } from 'react-native-svg';
+
+const GOLD = '#D4A017';
+const BG = 'rgba(5,7,20,0.95)';
+const FIELD_BG = 'rgba(19,26,61,0.6)';
+const TEXT_PRIMARY = '#F5F0E8';
+const TEXT_MUTED = 'rgba(200,191,168,0.5)';
+const INPUT_HEIGHT = 44;
+const ROW_HEIGHT = 60;
+
+const KRISHNA_AURA: readonly [string, string, string] = [
+  'rgba(27,79,187,0.95)',
+  'rgba(66,41,155,0.9)',
+  'rgba(212,160,23,0.75)',
+];
+
+function MicIcon({ color }: { color: string }): React.JSX.Element {
+  return (
+    <Svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+      <Path d="M12 2 a3 3 0 0 1 3 3 v6 a3 3 0 0 1 -6 0 v-6 a3 3 0 0 1 3 -3 Z" />
+      <Path d="M6 11 a6 6 0 0 0 12 0" />
+      <Line x1={12} y1={17} x2={12} y2={21} />
+      <Line x1={9} y1={21} x2={15} y2={21} />
+    </Svg>
+  );
+}
+
+/** Lotus-tipped arrow: a leaf-shaped head with two petal accents. */
+function LotusArrow({ color }: { color: string }): React.JSX.Element {
+  return (
+    <Svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+      {/* Stem */}
+      <Line x1={4} y1={20} x2={14} y2={10} />
+      {/* Arrowhead — leaf silhouette */}
+      <Path d="M20 4 L10 6 L14 10 L18 14 L20 4 Z" fill={color} />
+      {/* Lotus petals at the tail */}
+      <Circle cx={5} cy={19} r={1.2} fill={color} />
+    </Svg>
+  );
+}
+
+export interface ChatInputProps {
+  /** Current draft text. */
+  readonly value: string;
+  /** Text-change handler. */
+  readonly onChangeText: (text: string) => void;
+  /** Submit handler — called when the user taps send or submits the field. */
+  readonly onSubmit: () => void;
+  /** Voice-input handler (STT wiring lives in the parent). */
+  readonly onPressVoice?: () => void;
+  /** Externally disable sending (e.g. while streaming). */
+  readonly disabled?: boolean;
+  /** Placeholder override. @default 'Ask Sakha anything…' */
+  readonly placeholder?: string;
+}
+
+function ChatInputInner({
+  value,
+  onChangeText,
+  onSubmit,
+  onPressVoice,
+  disabled = false,
+  placeholder = 'Ask Sakha anything…',
+}: ChatInputProps): React.JSX.Element {
+  const insets = useSafeAreaInsets();
+  const [focused, setFocused] = useState(false);
+
+  const canSend = value.trim().length > 0 && !disabled;
+
+  const pressScale = useSharedValue(1);
+  /** 0 → 1 → 0 one-shot pulse fired on send. */
+  const pulse = useSharedValue(0);
+
+  const handlePressIn = useCallback(() => {
+    if (!canSend) return;
+    pressScale.value = withTiming(0.9, { duration: 80 });
+  }, [canSend, pressScale]);
+
+  const handlePressOut = useCallback(() => {
+    pressScale.value = withSpring(1.0, { damping: 14, stiffness: 260, mass: 0.7 });
+  }, [pressScale]);
+
+  const handleSend = useCallback(() => {
+    if (!canSend) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    pulse.value = 0;
+    pulse.value = withSequence(
+      withTiming(1, { duration: 220, easing: Easing.out(Easing.quad) }),
+      withTiming(0, { duration: 380, easing: Easing.in(Easing.quad) }),
+    );
+    onSubmit();
+  }, [canSend, onSubmit, pulse]);
+
+  const handleSubmitEditing = useCallback(
+    (_e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => handleSend(),
+    [handleSend],
+  );
+
+  const sendButtonStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pressScale.value }],
+    opacity: canSend ? 1 : 0.3,
+  }));
+
+  const pulseStyle = useAnimatedStyle(() => ({
+    opacity: pulse.value * 0.7,
+    transform: [{ scale: 1 + pulse.value * 0.9 }],
+  }));
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          paddingBottom: insets.bottom,
+          height: ROW_HEIGHT + insets.bottom,
+        },
+      ]}
+    >
+      {/* Top golden divider */}
+      <LinearGradient
+        colors={['transparent', 'rgba(212,160,23,0.35)', 'transparent']}
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 1, y: 0.5 }}
+        style={styles.divider}
+      />
+
+      <View style={styles.row}>
+        <Pressable
+          onPress={onPressVoice}
+          accessibilityRole="button"
+          accessibilityLabel="Voice input"
+          style={styles.voiceButton}
+          hitSlop={6}
+        >
+          <MicIcon color={GOLD} />
+        </Pressable>
+
+        <View style={[styles.inputWrap, focused && styles.inputWrapFocused]}>
+          <TextInput
+            value={value}
+            onChangeText={onChangeText}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            placeholder={placeholder}
+            placeholderTextColor={TEXT_MUTED}
+            style={styles.textInput}
+            multiline={false}
+            returnKeyType="send"
+            onSubmitEditing={handleSubmitEditing}
+            editable={!disabled}
+            maxLength={2000}
+            accessibilityLabel="Message Sakha"
+          />
+        </View>
+
+        <View style={styles.sendWrap}>
+          {/* Golden pulse ring (fires on send). */}
+          <Animated.View
+            pointerEvents="none"
+            style={[styles.sendPulse, pulseStyle]}
+          />
+
+          <Pressable
+            onPressIn={handlePressIn}
+            onPressOut={handlePressOut}
+            onPress={handleSend}
+            disabled={!canSend}
+            accessibilityRole="button"
+            accessibilityLabel="Send message"
+            accessibilityState={{ disabled: !canSend }}
+            hitSlop={6}
+          >
+            <Animated.View style={[styles.sendButton, sendButtonStyle]}>
+              <LinearGradient
+                colors={KRISHNA_AURA as unknown as string[]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={StyleSheet.absoluteFill}
+              />
+              <LotusArrow color="#FFFFFF" />
+            </Animated.View>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+/** Bottom composer with voice, text field, and send button. */
+export const ChatInput = React.memo(ChatInputInner);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: BG,
+  },
+  divider: {
+    height: 1,
+    width: '100%',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+    height: ROW_HEIGHT,
+  },
+  voiceButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(212,160,23,0.04)',
+  },
+  inputWrap: {
+    flex: 1,
+    height: INPUT_HEIGHT,
+    borderRadius: 22,
+    backgroundColor: FIELD_BG,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.12)',
+    paddingHorizontal: 14,
+    justifyContent: 'center',
+  },
+  inputWrapFocused: {
+    borderColor: 'rgba(212,160,23,0.35)',
+  },
+  textInput: {
+    flex: 1,
+    color: TEXT_PRIMARY,
+    fontFamily: 'Outfit-Regular',
+    fontSize: 15,
+    // iOS italic placeholder is controlled via fontStyle on the component;
+    // Android honors placeholderTextColor but not placeholder font style,
+    // so we leave the TextInput upright for both.
+    padding: 0,
+    ...Platform.select({
+      android: { textAlignVertical: 'center' },
+      default: {},
+    }),
+  },
+  sendWrap: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sendPulse: {
+    position: 'absolute',
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 2,
+    borderColor: GOLD,
+  },
+  sendButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/ConversationStarters.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/ConversationStarters.tsx
@@ -1,0 +1,148 @@
+/**
+ * ConversationStarters — empty-state entry points for the Sakha chat.
+ *
+ * A centered column of four SacredChip prompts (matches web copy exactly).
+ * Each chip enters with a 200 ms stagger using a "lotus-bloom" ease curve
+ * (ease-out cubic with a soft overshoot). Tapping a chip fires a Light
+ * haptic, then hands the prompt text to `onSelect` which the parent uses
+ * to fill the input and immediately submit.
+ */
+
+import React, { useEffect } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+
+const GOLD = '#D4A017';
+const TEXT_PRIMARY = '#F5F0E8';
+
+/** Exact web copy — do not localize without the matching i18n keys. */
+const STARTERS: readonly string[] = [
+  'What is my dharma in this moment?',
+  'I am afraid. What does Krishna say?',
+  'Explain the nature of the Atman',
+  'How do I find peace amidst chaos?',
+];
+
+/** Stagger between chips on entrance. */
+const STAGGER_MS = 200;
+
+export interface ConversationStartersProps {
+  /** Called with the chip text when the user taps a starter. */
+  readonly onSelect: (prompt: string) => void;
+}
+
+interface ChipProps {
+  readonly text: string;
+  readonly delay: number;
+  readonly onPress: () => void;
+}
+
+function SacredChip({ text, delay, onPress }: ChipProps): React.JSX.Element {
+  const opacity = useSharedValue(0);
+  const translateY = useSharedValue(12);
+  const scale = useSharedValue(0.96);
+
+  useEffect(() => {
+    // lotus-bloom: ease-out cubic with a mild overshoot via delayed scale.
+    opacity.value = withDelay(delay, withTiming(1, { duration: 360, easing: Easing.out(Easing.cubic) }));
+    translateY.value = withDelay(delay, withTiming(0, { duration: 360, easing: Easing.out(Easing.cubic) }));
+    scale.value = withDelay(delay, withTiming(1, { duration: 420, easing: Easing.out(Easing.cubic) }));
+  }, [delay, opacity, translateY, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value }, { scale: scale.value }],
+  }));
+
+  const handlePress = React.useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onPress();
+  }, [onPress]);
+
+  return (
+    <Animated.View style={[styles.chipWrap, animatedStyle]}>
+      <Pressable
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityLabel={text}
+        style={({ pressed }) => [styles.chip, pressed && styles.chipPressed]}
+      >
+        <LinearGradient
+          colors={[
+            'rgba(19,26,61,0.9)',
+            'rgba(27,79,187,0.35)',
+          ]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFill}
+        />
+        <Animated.Text style={styles.chipText}>{text}</Animated.Text>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+function ConversationStartersInner({
+  onSelect,
+}: ConversationStartersProps): React.JSX.Element {
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="menu"
+      accessibilityLabel="Conversation starters"
+    >
+      {STARTERS.map((prompt, i) => (
+        <SacredChip
+          key={prompt}
+          text={prompt}
+          delay={i * STAGGER_MS}
+          onPress={() => onSelect(prompt)}
+        />
+      ))}
+    </View>
+  );
+}
+
+/** Empty-state column of 4 SacredChip conversation starters. */
+export const ConversationStarters = React.memo(ConversationStartersInner);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  chipWrap: {
+    width: '100%',
+    maxWidth: 340,
+  },
+  chip: {
+    overflow: 'hidden',
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.25)',
+    paddingVertical: 14,
+    paddingHorizontal: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chipPressed: {
+    opacity: 0.85,
+  },
+  chipText: {
+    fontFamily: 'CrimsonText-Italic',
+    fontSize: 15,
+    color: TEXT_PRIMARY,
+    textAlign: 'center',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
@@ -1,0 +1,419 @@
+/**
+ * SakhaMessage — left-aligned SAKHA chat bubble with word-by-word reveal.
+ *
+ * Port of the web SakhaMessageBubble with VerseRevelation:
+ * - Layout: row [avatar column (28 px MandalaSpin) | bubble column].
+ * - Bubble: SacredCard-style dark surface, radius [4,20,20,20].
+ * - Left border accent: 2 px vertical LinearGradient Krishna-aura ribbon.
+ * - Text: CrimsonText-Regular 16 px, lineHeight 1.75, TEXT_PRIMARY.
+ * - Word-by-word: fade/slide in per word, 60 ms stagger.
+ * - Sanskrit (Devanagari) spans get NotoSansDevanagari-Regular 17 px #D4A017.
+ * - Streaming cursor: the last word gets a blinking `|` (600 ms loop).
+ * - Stream complete: a golden shimmer sweeps across the text via a gradient
+ *   overlay — simple, performant, no Skia clipping tricks required.
+ *
+ * Optional `shloka` prop renders a ShlokaCard inside the bubble below the
+ * prose (if provided).
+ */
+
+import React, { useEffect, useMemo } from 'react';
+import { StyleSheet, Text, View, useWindowDimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let MandalaSpin: React.ComponentType<any> | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+  MandalaSpin = require('@kiaanverse/ui').MandalaSpin ?? null;
+} catch {
+  MandalaSpin = null;
+}
+
+const GOLD = '#D4A017';
+const TEXT_PRIMARY = '#F5F0E8';
+const BUBBLE_BG = 'rgba(19,26,61,0.92)';
+const AVATAR_SIZE = 28;
+const WORD_STAGGER_MS = 60;
+const MAX_WIDTH_PERCENT = 0.82;
+
+/** Krishna-aura vertical gradient for the left border ribbon. */
+const KRISHNA_AURA: readonly [string, string, string] = [
+  'rgba(27,79,187,0.9)',
+  'rgba(66,41,155,0.9)',
+  'rgba(212,160,23,0.9)',
+];
+
+/** Optional shloka payload. */
+export interface SakhaMessageShloka {
+  readonly sanskrit?: string;
+  readonly transliteration?: string;
+  readonly meaning?: string;
+  readonly reference?: string;
+}
+
+export interface SakhaMessageProps {
+  /** Message text. Devanagari substrings are auto-highlighted in gold. */
+  readonly text: string;
+  /** Whether this message is still streaming (controls cursor + shimmer). */
+  readonly isStreaming?: boolean;
+  /** Optional shloka card rendered inline at the bottom of the bubble. */
+  readonly shloka?: SakhaMessageShloka;
+  /** Stable message id for keying. */
+  readonly id?: string;
+}
+
+/** Regex that splits text into whitespace vs. non-whitespace runs. */
+const TOKEN_SPLIT_RE = /(\s+)/;
+
+/** Matches a Devanagari run (Sanskrit). */
+const DEVANAGARI_RE = /[\u0900-\u097F]/;
+
+interface Token {
+  readonly key: string;
+  readonly text: string;
+  readonly isWhitespace: boolean;
+  readonly isDevanagari: boolean;
+}
+
+function tokenize(text: string): Token[] {
+  return text
+    .split(TOKEN_SPLIT_RE)
+    .filter((part) => part.length > 0)
+    .map((part, i) => ({
+      key: `t-${i}`,
+      text: part,
+      isWhitespace: /^\s+$/.test(part),
+      isDevanagari: DEVANAGARI_RE.test(part),
+    }));
+}
+
+/** A single word that fades in as the reveal reaches its index.
+ *
+ *  Only opacity is animated because `transform` is not supported on Text
+ *  nodes nested inside a parent Text on Android — slide-in would be a
+ *  no-op and falsely imply motion.
+ */
+interface WordProps {
+  readonly token: Token;
+  readonly index: number;
+  readonly revealIndex: number;
+}
+
+function Word({ token, index, revealIndex }: WordProps): React.JSX.Element {
+  const opacity = useSharedValue(0);
+  const hasRevealedRef = React.useRef(false);
+
+  useEffect(() => {
+    if (hasRevealedRef.current) return;
+    if (index > revealIndex) return;
+    hasRevealedRef.current = true;
+    // Stagger relative to the most recently revealed word so we don't
+    // pile up enormous delays on long responses.
+    const delay = Math.max(
+      0,
+      (index - Math.max(revealIndex - 6, 0)) * WORD_STAGGER_MS,
+    );
+    opacity.value = withDelay(
+      delay,
+      withTiming(1, { duration: 220, easing: Easing.out(Easing.quad) }),
+    );
+  }, [index, revealIndex, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  if (token.isWhitespace) {
+    // Whitespace preserved inline (collapses in Text node).
+    return <Text style={styles.bodyText}>{token.text}</Text>;
+  }
+
+  const textStyle = token.isDevanagari ? styles.sanskritText : styles.bodyText;
+
+  return (
+    <Animated.Text style={[textStyle, animatedStyle]}>
+      {token.text}
+    </Animated.Text>
+  );
+}
+
+/** Blinking streaming cursor: `|` that fades 0 ↔ 1 over 600 ms. */
+function StreamingCursor(): React.JSX.Element {
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0, { duration: 300, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1, { duration: 300, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+  }, [opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+  return (
+    <Animated.Text style={[styles.cursor, animatedStyle]}>|</Animated.Text>
+  );
+}
+
+/** Golden shimmer that sweeps across the bubble after streaming ends. */
+function CompletionShimmer(): React.JSX.Element {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = 0;
+    progress.value = withTiming(1, { duration: 900, easing: Easing.inOut(Easing.ease) });
+  }, [progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: progress.value < 1 ? 0.55 : 0,
+    transform: [
+      { translateX: -120 + progress.value * 360 },
+    ],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[styles.shimmerWrap, animatedStyle]}
+    >
+      <LinearGradient
+        colors={['transparent', 'rgba(240,192,64,0.45)', 'transparent']}
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 1, y: 0.5 }}
+        style={styles.shimmerFill}
+      />
+    </Animated.View>
+  );
+}
+
+function SakhaMessageInner({
+  text,
+  isStreaming,
+  shloka,
+  id,
+}: SakhaMessageProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  const maxWidth = Math.round(width * MAX_WIDTH_PERCENT);
+
+  const tokens = useMemo(() => tokenize(text), [text]);
+  const lastNonWhitespace = useMemo(() => {
+    for (let i = tokens.length - 1; i >= 0; i--) {
+      const tok = tokens[i];
+      if (tok && !tok.isWhitespace) return i;
+    }
+    return -1;
+  }, [tokens]);
+
+  // Reveal index grows as the text grows, so every new token fades in.
+  const revealIndex = tokens.length - 1;
+
+  // When streaming flips from true → false, render the shimmer once.
+  const [shimmerKey, setShimmerKey] = React.useState<number | null>(null);
+  const prevStreamingRef = React.useRef<boolean | undefined>(isStreaming);
+  useEffect(() => {
+    if (prevStreamingRef.current && !isStreaming) {
+      setShimmerKey(Date.now());
+    }
+    prevStreamingRef.current = isStreaming;
+  }, [isStreaming]);
+
+  return (
+    <View style={styles.outer} testID={id ? `sakha-msg-${id}` : undefined}>
+      {/* Avatar column */}
+      <View style={styles.avatarCol}>
+        <View style={styles.avatar}>
+          {MandalaSpin ? (
+            <MandalaSpin
+              size={AVATAR_SIZE}
+              speed={isStreaming ? 'fast' : 'slow'}
+              opacity={0.9}
+              color={GOLD}
+            />
+          ) : (
+            <View style={styles.avatarFallback} />
+          )}
+        </View>
+      </View>
+
+      {/* Bubble column */}
+      <View style={[styles.bubble, { maxWidth }]}>
+        {/* Left border accent — vertical Krishna-aura ribbon. */}
+        <LinearGradient
+          colors={KRISHNA_AURA as unknown as string[]}
+          start={{ x: 0.5, y: 0 }}
+          end={{ x: 0.5, y: 1 }}
+          style={styles.leftAccent}
+        />
+
+        <View style={styles.bubbleBody}>
+          <Text style={styles.bodyText}>
+            {tokens.map((token, i) => {
+              const isLastWord = i === lastNonWhitespace;
+              return (
+                <React.Fragment key={token.key}>
+                  <Word token={token} index={i} revealIndex={revealIndex} />
+                  {isStreaming && isLastWord ? <StreamingCursor /> : null}
+                </React.Fragment>
+              );
+            })}
+          </Text>
+
+          {/* Optional inline shloka card. */}
+          {shloka ? <InlineShloka shloka={shloka} /> : null}
+        </View>
+
+        {shimmerKey ? <CompletionShimmer key={shimmerKey} /> : null}
+      </View>
+    </View>
+  );
+}
+
+/** Lightweight inline shloka renderer — used inside SakhaMessage bubbles. */
+function InlineShloka({ shloka }: { shloka: SakhaMessageShloka }): React.JSX.Element {
+  return (
+    <View style={styles.shloka}>
+      {shloka.sanskrit ? (
+        <Text style={styles.shlokaSanskrit}>{shloka.sanskrit}</Text>
+      ) : null}
+      {shloka.transliteration ? (
+        <Text style={styles.shlokaTranslit}>{shloka.transliteration}</Text>
+      ) : null}
+      {shloka.meaning ? (
+        <Text style={styles.shlokaMeaning}>{shloka.meaning}</Text>
+      ) : null}
+      {shloka.reference ? (
+        <Text style={styles.shlokaRef}>Chapter {shloka.reference}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+/** Left-aligned SAKHA bubble with word-by-word reveal. */
+export const SakhaMessage = React.memo(SakhaMessageInner);
+
+const styles = StyleSheet.create({
+  outer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    width: '100%',
+    paddingVertical: 4,
+    gap: 8,
+  },
+  avatarCol: {
+    width: AVATAR_SIZE,
+    alignItems: 'center',
+    paddingTop: 8,
+  },
+  avatar: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarFallback: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: AVATAR_SIZE / 2,
+    borderWidth: 1,
+    borderColor: GOLD,
+  },
+  bubble: {
+    flexShrink: 1,
+    backgroundColor: BUBBLE_BG,
+    borderTopLeftRadius: 4,
+    borderTopRightRadius: 20,
+    borderBottomRightRadius: 20,
+    borderBottomLeftRadius: 20,
+    overflow: 'hidden',
+    paddingVertical: 12,
+    paddingLeft: 16,
+    paddingRight: 14,
+    // Elevation so the bubble reads above the sub-mandala texture.
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.15)',
+  },
+  leftAccent: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: 2,
+  },
+  bubbleBody: {
+    paddingLeft: 6,
+  },
+  bodyText: {
+    fontFamily: 'CrimsonText-Regular',
+    fontSize: 16,
+    lineHeight: 28, // 16 × 1.75 = 28
+    color: TEXT_PRIMARY,
+  },
+  sanskritText: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontSize: 17,
+    lineHeight: 30,
+    color: GOLD,
+  },
+  cursor: {
+    fontFamily: 'CrimsonText-Regular',
+    fontSize: 16,
+    lineHeight: 28,
+    color: GOLD,
+  },
+  shloka: {
+    marginTop: 12,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(212,160,23,0.18)',
+    gap: 6,
+  },
+  shlokaSanskrit: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontSize: 17,
+    lineHeight: 30,
+    color: GOLD,
+  },
+  shlokaTranslit: {
+    fontFamily: 'CrimsonText-Italic',
+    fontSize: 14,
+    lineHeight: 22,
+    color: 'rgba(200,191,168,0.9)',
+  },
+  shlokaMeaning: {
+    fontFamily: 'CrimsonText-Regular',
+    fontSize: 14,
+    lineHeight: 22,
+    color: TEXT_PRIMARY,
+  },
+  shlokaRef: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    color: GOLD,
+    textAlign: 'right',
+    letterSpacing: 0.4,
+  },
+  shimmerWrap: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: 140,
+  },
+  shimmerFill: {
+    flex: 1,
+    width: '100%',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/SubMandalaTexture.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/SubMandalaTexture.tsx
@@ -1,0 +1,121 @@
+/**
+ * SubMandalaTexture — faint sacred-geometry backdrop for the chat scroll area.
+ *
+ * A 6-pointed star (two overlaid triangles — Shatkona) wrapped in three
+ * concentric rings, drawn with @shopify/react-native-skia. The whole
+ * piece renders at 4 % opacity: barely visible, yet it provides the
+ * subtle sub-mandala depth the web chat has behind messages.
+ *
+ * Static — no animation, no re-draw per frame.
+ */
+
+import React, { useMemo } from 'react';
+import { StyleSheet, View, useWindowDimensions } from 'react-native';
+import { Canvas, Circle, Path, Skia, Group } from '@shopify/react-native-skia';
+
+/** Golden stroke color used for the mandala geometry. */
+const GOLD = '#D4A017';
+/** Overall opacity of the entire texture (per prompt: 0.04). */
+const TEXTURE_OPACITY = 0.04;
+
+export interface SubMandalaTextureProps {
+  /** Override the diameter of the mandala (defaults to ~70 % of screen width). */
+  readonly size?: number;
+}
+
+function SubMandalaTextureInner({ size }: SubMandalaTextureProps): React.JSX.Element {
+  const { width, height } = useWindowDimensions();
+  const diameter = size ?? Math.min(width, height) * 0.75;
+  const cx = width / 2;
+  const cy = height / 2;
+  const outerR = diameter / 2;
+  const midR = outerR * 0.78;
+  const innerR = outerR * 0.52;
+
+  /** Build the Shatkona (6-pointed star) path once — two overlaid triangles. */
+  const starPath = useMemo(() => {
+    const path = Skia.Path.Make();
+    const R = outerR * 0.85;
+
+    // Upward triangle: vertices at -90°, 30°, 150°.
+    const upAngles = [-Math.PI / 2, Math.PI / 6, (5 * Math.PI) / 6];
+    upAngles.forEach((a, i) => {
+      const x = cx + R * Math.cos(a);
+      const y = cy + R * Math.sin(a);
+      if (i === 0) path.moveTo(x, y);
+      else path.lineTo(x, y);
+    });
+    path.close();
+
+    // Downward triangle: vertices at 90°, -30°, -150° (210°).
+    const downAngles = [Math.PI / 2, -Math.PI / 6, (7 * Math.PI) / 6];
+    downAngles.forEach((a, i) => {
+      const x = cx + R * Math.cos(a);
+      const y = cy + R * Math.sin(a);
+      if (i === 0) path.moveTo(x, y);
+      else path.lineTo(x, y);
+    });
+    path.close();
+
+    return path;
+  }, [cx, cy, outerR]);
+
+  return (
+    <View
+      style={styles.container}
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      <Canvas style={StyleSheet.absoluteFill}>
+        <Group opacity={TEXTURE_OPACITY}>
+          {/* Concentric rings */}
+          <Circle
+            cx={cx}
+            cy={cy}
+            r={outerR}
+            color={GOLD}
+            style="stroke"
+            strokeWidth={1}
+          />
+          <Circle
+            cx={cx}
+            cy={cy}
+            r={midR}
+            color={GOLD}
+            style="stroke"
+            strokeWidth={1}
+          />
+          <Circle
+            cx={cx}
+            cy={cy}
+            r={innerR}
+            color={GOLD}
+            style="stroke"
+            strokeWidth={1}
+          />
+
+          {/* 6-pointed Shatkona star */}
+          <Path
+            path={starPath}
+            color={GOLD}
+            style="stroke"
+            strokeWidth={1}
+          />
+
+          {/* Center seed */}
+          <Circle cx={cx} cy={cy} r={3} color={GOLD} />
+        </Group>
+      </Canvas>
+    </View>
+  );
+}
+
+/** Faint sacred-geometry backdrop for the chat scroll area. */
+export const SubMandalaTexture = React.memo(SubMandalaTextureInner);
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/TypingIndicator.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/TypingIndicator.tsx
@@ -1,0 +1,183 @@
+/**
+ * TypingIndicator — compact "Sakha is reflecting" card.
+ *
+ * Port of the web typing indicator:
+ * - Three gold dots (8×8 px, radius 4) that pulse sequentially. Each dot
+ *   animates scale 1.0 → 1.5 → 1.0 over 400 ms with a 150 ms stagger so
+ *   the pulse travels left-to-right rather than firing simultaneously.
+ * - Small ॐ (OM) glyph — NotoSansDevanagari 14 px gold — that slowly
+ *   rotates (8 s full turn).
+ * - Caption: "Reflecting on dharma…" — Outfit Italic 11 px muted.
+ * - Wrapped in a compact SacredCard-style container with a subtle gold
+ *   left-border accent to match SakhaMessage.
+ * - Entrance: opacity 0 → 1 (200 ms); the parent controls exit by
+ *   unmounting, so we only animate opacity in.
+ */
+
+import React, { useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+const GOLD = '#D4A017';
+const TEXT_MUTED = 'rgba(200,191,168,0.7)';
+const BUBBLE_BG = 'rgba(19,26,61,0.92)';
+
+/** One pulsing dot — plays 1.0 → 1.5 → 1.0 with a stagger delay. */
+function PulseDot({ delay }: { delay: number }): React.JSX.Element {
+  const scale = useSharedValue(1);
+  const opacity = useSharedValue(0.55);
+
+  useEffect(() => {
+    scale.value = withDelay(
+      delay,
+      withRepeat(
+        withSequence(
+          withTiming(1.5, { duration: 200, easing: Easing.out(Easing.quad) }),
+          withTiming(1.0, { duration: 200, easing: Easing.in(Easing.quad) }),
+          // Pause before the next cycle so all three dots share a 850 ms period
+          // (3 dots × 150 ms stagger + 400 ms swing ≈ 850 ms).
+          withTiming(1.0, { duration: 450 }),
+        ),
+        -1,
+        false,
+      ),
+    );
+    opacity.value = withDelay(
+      delay,
+      withRepeat(
+        withSequence(
+          withTiming(1.0, { duration: 200, easing: Easing.out(Easing.quad) }),
+          withTiming(0.55, { duration: 200, easing: Easing.in(Easing.quad) }),
+          withTiming(0.55, { duration: 450 }),
+        ),
+        -1,
+        false,
+      ),
+    );
+  }, [delay, scale, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  return <Animated.View style={[styles.dot, animatedStyle]} />;
+}
+
+/** Slowly rotating ॐ glyph. */
+function SpinningOm(): React.JSX.Element {
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, { duration: 8000, easing: Easing.linear }),
+      -1,
+      false,
+    );
+  }, [rotation]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <Animated.Text style={[styles.om, animatedStyle]}>ॐ</Animated.Text>
+  );
+}
+
+function TypingIndicatorInner(): React.JSX.Element {
+  const entrance = useSharedValue(0);
+
+  useEffect(() => {
+    entrance.value = withTiming(1, { duration: 200, easing: Easing.out(Easing.quad) });
+  }, [entrance]);
+
+  const entranceStyle = useAnimatedStyle(() => ({
+    opacity: entrance.value,
+  }));
+
+  return (
+    <Animated.View
+      style={[styles.outer, entranceStyle]}
+      accessibilityRole="text"
+      accessibilityLabel="Sakha is reflecting"
+    >
+      <View style={styles.card}>
+        <View style={styles.leftAccent} />
+        <View style={styles.inner}>
+          <View style={styles.row}>
+            <PulseDot delay={0} />
+            <PulseDot delay={150} />
+            <PulseDot delay={300} />
+            <SpinningOm />
+          </View>
+          <Text style={styles.caption}>Reflecting on dharma…</Text>
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+/** Sacred 3-dot typing indicator with spinning OM and dharma caption. */
+export const TypingIndicator = React.memo(TypingIndicatorInner);
+
+const styles = StyleSheet.create({
+  outer: {
+    paddingVertical: 4,
+    alignItems: 'flex-start',
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    backgroundColor: BUBBLE_BG,
+    borderTopLeftRadius: 4,
+    borderTopRightRadius: 20,
+    borderBottomRightRadius: 20,
+    borderBottomLeftRadius: 20,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.15)',
+    overflow: 'hidden',
+  },
+  leftAccent: {
+    width: 2,
+    backgroundColor: GOLD,
+    opacity: 0.7,
+  },
+  inner: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    gap: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: GOLD,
+  },
+  om: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontSize: 14,
+    color: GOLD,
+    marginLeft: 4,
+  },
+  caption: {
+    fontFamily: 'Outfit-Regular',
+    fontStyle: 'italic',
+    fontSize: 11,
+    color: TEXT_MUTED,
+    marginTop: 2,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/UserMessage.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/UserMessage.tsx
@@ -1,0 +1,110 @@
+/**
+ * UserMessage — right-aligned user chat bubble.
+ *
+ * Port of the web user message bubble:
+ * - Alignment: flex-end (right side).
+ * - Background: Krishna-aura LinearGradient at 135°.
+ * - BorderRadius: [20, 4, 20, 20] — the top-right corner is sharp and acts
+ *   as the bubble tail pointing at the sender.
+ * - Padding: 12 × 16.
+ * - Text: Outfit-Regular 15 px #F5F0E8 (SACRED_WHITE).
+ * - Max width: 72 % of screen.
+ * - Entrance: translateX(16 → 0) + opacity(0 → 1), ~180 ms ease-out.
+ */
+
+import React, { useEffect } from 'react';
+import { StyleSheet, View, useWindowDimensions } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+const SACRED_WHITE = '#F5F0E8';
+const MAX_WIDTH_PERCENT = 0.72;
+
+/** Krishna-aura gradient stops — matches web KRISHNA_AURA gradient. */
+const KRISHNA_AURA: readonly [string, string, string] = [
+  'rgba(27,79,187,0.95)',
+  'rgba(66,41,155,0.9)',
+  'rgba(212,160,23,0.6)',
+];
+
+export interface UserMessageProps {
+  /** Rendered message text. */
+  readonly text: string;
+  /** Stable message id (used as accessibility hint). */
+  readonly id?: string;
+}
+
+function UserMessageInner({ text, id }: UserMessageProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  const maxWidth = Math.round(width * MAX_WIDTH_PERCENT);
+
+  const translateX = useSharedValue(16);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    translateX.value = withTiming(0, {
+      duration: 200,
+      easing: Easing.out(Easing.cubic),
+    });
+    opacity.value = withTiming(1, {
+      duration: 200,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [translateX, opacity]);
+
+  const entranceStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[styles.outer, entranceStyle]}
+      accessibilityRole="text"
+      accessibilityLabel={`You said: ${text}`}
+      testID={id ? `user-msg-${id}` : undefined}
+    >
+      <View style={[styles.bubble, { maxWidth }]}>
+        <LinearGradient
+          colors={KRISHNA_AURA as unknown as string[]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFill}
+        />
+        <Animated.Text style={styles.text}>{text}</Animated.Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+/** Right-aligned user message bubble with Krishna-aura gradient. */
+export const UserMessage = React.memo(UserMessageInner);
+
+const styles = StyleSheet.create({
+  outer: {
+    width: '100%',
+    alignItems: 'flex-end',
+    paddingVertical: 4,
+  },
+  bubble: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    // [topLeft, topRight, bottomRight, bottomLeft] — matches web [20,4,20,20].
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 4,
+    borderBottomRightRadius: 20,
+    borderBottomLeftRadius: 20,
+    overflow: 'hidden',
+  },
+  text: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 15,
+    lineHeight: 22,
+    color: SACRED_WHITE,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/chat/index.ts
+++ b/kiaanverse-mobile/apps/mobile/components/chat/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Barrel exports for the Sakha chat UI.
+ */
+
+export { ChatHeader, type ChatHeaderHandle, type ChatHeaderProps } from './ChatHeader';
+export { SubMandalaTexture, type SubMandalaTextureProps } from './SubMandalaTexture';
+export { UserMessage, type UserMessageProps } from './UserMessage';
+export {
+  SakhaMessage,
+  type SakhaMessageProps,
+  type SakhaMessageShloka,
+} from './SakhaMessage';
+export { TypingIndicator } from './TypingIndicator';
+export { ChatInput, type ChatInputProps } from './ChatInput';
+export {
+  ConversationStarters,
+  type ConversationStartersProps,
+} from './ConversationStarters';
+export {
+  useSakhaStream,
+  type SakhaStreamMessage,
+  type UseSakhaStreamOptions,
+  type UseSakhaStreamResult,
+} from './useSakhaStream';

--- a/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
+++ b/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
@@ -1,0 +1,305 @@
+/**
+ * useSakhaStream — React hook that drives the Sakha SSE streaming lifecycle.
+ *
+ * Why XMLHttpRequest and not fetch?
+ *   React Native's fetch implementation does not expose a reliable
+ *   ReadableStream on Android. XHR's `onreadystatechange` / `onprogress`
+ *   events surface `responseText` incrementally, which is exactly what we
+ *   need for server-sent events over HTTP POST.
+ *
+ * The FastAPI endpoint emits one of two line formats per SSE frame:
+ *
+ *   data: {"word": " Krishna", "done": false}
+ *   data: {"done": true, "verseRefs": [...]}
+ *
+ * Legacy plain-text frames (no JSON) are still supported for backward
+ * compatibility with the web client.
+ *
+ * Usage:
+ *   const { messages, streaming, send, abort, error, reset } = useSakhaStream();
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { API_CONFIG } from '@kiaanverse/api';
+
+/** Message record kept in component state. */
+export interface SakhaStreamMessage {
+  readonly id: string;
+  readonly role: 'user' | 'assistant';
+  text: string;
+  readonly timestamp: number;
+  /** True while the assistant response is actively streaming. */
+  isStreaming?: boolean;
+}
+
+export interface UseSakhaStreamOptions {
+  /** Token getter — called once per request to attach the JWT. */
+  readonly getAccessToken?: () => Promise<string | null> | string | null;
+  /** Optional base URL override (defaults to API_CONFIG.baseURL). */
+  readonly baseUrl?: string;
+}
+
+export interface UseSakhaStreamResult {
+  readonly messages: SakhaStreamMessage[];
+  readonly streaming: boolean;
+  readonly error: string | null;
+  readonly sessionId: string | null;
+  readonly send: (prompt: string) => Promise<void>;
+  readonly abort: () => void;
+  readonly reset: () => void;
+  /** Signal that the caller has acknowledged an end-of-stream transition. */
+  readonly onStreamCompleted: (handler: (() => void) | null) => void;
+}
+
+/** Parse accumulated SSE text into data frames + remaining buffer. */
+function parseSSEFrames(raw: string, cursor: number): { frames: string[]; nextCursor: number } {
+  const frames: string[] = [];
+  let nextCursor = cursor;
+  const slice = raw.slice(cursor);
+  const parts = slice.split('\n');
+
+  // Keep the final (possibly partial) line in the buffer for the next pass.
+  const complete = parts.slice(0, -1);
+  const trailing = parts[parts.length - 1] ?? '';
+  nextCursor += slice.length - trailing.length;
+
+  for (const line of complete) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('data: ')) {
+      frames.push(trimmed.slice(6));
+    }
+  }
+
+  return { frames, nextCursor };
+}
+
+function createMessageId(prefix: 'user' | 'assistant'): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Compassionate error message used when the SSE pipe breaks. */
+const CONNECTION_ERROR_TEXT =
+  'My connection to the cosmic network wavered. Please ask again.';
+
+export function useSakhaStream(
+  options: UseSakhaStreamOptions = {},
+): UseSakhaStreamResult {
+  const { getAccessToken, baseUrl } = options;
+
+  const [messages, setMessages] = useState<SakhaStreamMessage[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+
+  const xhrRef = useRef<XMLHttpRequest | null>(null);
+  const assistantIdRef = useRef<string | null>(null);
+  const streamCompleteCallbackRef = useRef<(() => void) | null>(null);
+
+  // Cleanup any in-flight request on unmount.
+  useEffect(() => {
+    return () => {
+      xhrRef.current?.abort();
+      xhrRef.current = null;
+    };
+  }, []);
+
+  const abort = useCallback(() => {
+    xhrRef.current?.abort();
+    xhrRef.current = null;
+    setStreaming(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    abort();
+    setMessages([]);
+    setSessionId(null);
+    setError(null);
+  }, [abort]);
+
+  const appendAssistantText = useCallback((delta: string) => {
+    const id = assistantIdRef.current;
+    if (!id) return;
+    setMessages((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, text: m.text + delta } : m)),
+    );
+  }, []);
+
+  const send = useCallback(
+    async (prompt: string): Promise<void> => {
+      const trimmed = prompt.trim();
+      if (!trimmed || streaming) return;
+
+      setError(null);
+
+      // 1. Optimistic user message.
+      const userMsg: SakhaStreamMessage = {
+        id: createMessageId('user'),
+        role: 'user',
+        text: trimmed,
+        timestamp: Date.now(),
+      };
+
+      // 2. Empty assistant shell that tokens stream into.
+      const assistantId = createMessageId('assistant');
+      assistantIdRef.current = assistantId;
+      const assistantMsg: SakhaStreamMessage = {
+        id: assistantId,
+        role: 'assistant',
+        text: '',
+        timestamp: Date.now(),
+        isStreaming: true,
+      };
+      setMessages((prev) => [...prev, userMsg, assistantMsg]);
+      setStreaming(true);
+
+      // 3. Resolve bearer token, if any.
+      let token: string | null = null;
+      if (getAccessToken) {
+        try {
+          const resolved = await getAccessToken();
+          token = resolved ?? null;
+        } catch {
+          token = null;
+        }
+      }
+
+      // 4. Open the streaming XHR.
+      const url = `${baseUrl ?? API_CONFIG.baseURL}/api/chat/message/stream`;
+      const xhr = new XMLHttpRequest();
+      xhrRef.current = xhr;
+
+      let cursor = 0;
+      let fullText = '';
+
+      xhr.open('POST', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/json');
+      xhr.setRequestHeader('Accept', 'text/event-stream');
+      xhr.setRequestHeader('X-Client', 'kiaanverse-mobile');
+      if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+
+      const finishStreamingSuccess = (): void => {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId ? { ...m, isStreaming: false } : m,
+          ),
+        );
+        setStreaming(false);
+        xhrRef.current = null;
+        streamCompleteCallbackRef.current?.();
+      };
+
+      const finishStreamingFailure = (): void => {
+        const id = assistantIdRef.current;
+        if (id) {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === id
+                ? {
+                    ...m,
+                    text: m.text.length > 0 ? m.text : CONNECTION_ERROR_TEXT,
+                    isStreaming: false,
+                  }
+                : m,
+            ),
+          );
+        }
+        setError(CONNECTION_ERROR_TEXT);
+        setStreaming(false);
+        xhrRef.current = null;
+      };
+
+      xhr.onreadystatechange = () => {
+        // 3 = LOADING (incremental responseText is available).
+        if (xhr.readyState !== 3 && xhr.readyState !== 4) return;
+        if (xhr.readyState === 4 && xhr.status >= 400) {
+          finishStreamingFailure();
+          return;
+        }
+
+        const raw = xhr.responseText;
+        const { frames, nextCursor } = parseSSEFrames(raw, cursor);
+        cursor = nextCursor;
+
+        let sawDone = false;
+
+        for (const frame of frames) {
+          try {
+            const event = JSON.parse(frame) as {
+              word?: string;
+              done?: boolean;
+              session_id?: string;
+              sessionId?: string;
+              verseRefs?: unknown;
+            };
+            if (event.session_id && !sessionId) setSessionId(event.session_id);
+            if (event.sessionId && !sessionId) setSessionId(event.sessionId);
+            if (event.done) {
+              sawDone = true;
+              break;
+            }
+            if (event.word) {
+              fullText += event.word;
+              appendAssistantText(event.word);
+            }
+          } catch {
+            // Legacy plain-text format.
+            if (frame === '[DONE]') {
+              sawDone = true;
+              break;
+            }
+            const space =
+              fullText.length > 0 && !frame.startsWith(' ') ? ' ' : '';
+            fullText += space + frame;
+            appendAssistantText(space + frame);
+          }
+        }
+
+        if (sawDone || xhr.readyState === 4) {
+          finishStreamingSuccess();
+        }
+      };
+
+      xhr.onerror = () => finishStreamingFailure();
+      xhr.ontimeout = () => finishStreamingFailure();
+      xhr.onabort = () => {
+        // Aborts set isStreaming false silently — no error toast.
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId ? { ...m, isStreaming: false } : m,
+          ),
+        );
+        setStreaming(false);
+      };
+
+      try {
+        xhr.send(
+          JSON.stringify({
+            message: trimmed,
+            session_id: sessionId ?? undefined,
+          }),
+        );
+      } catch {
+        finishStreamingFailure();
+      }
+    },
+    [appendAssistantText, baseUrl, getAccessToken, sessionId, streaming],
+  );
+
+  const onStreamCompleted = useCallback(
+    (handler: (() => void) | null) => {
+      streamCompleteCallbackRef.current = handler;
+    },
+    [],
+  );
+
+  return {
+    messages,
+    streaming,
+    error,
+    sessionId,
+    send,
+    abort,
+    reset,
+    onStreamCompleted,
+  };
+}


### PR DESCRIPTION
## Summary

Ports the web Sakha chat experience (`components/chat/` + `/m/chat`) to React Native under `kiaanverse-mobile/apps/mobile/`. New screen at `app/(tabs)/kiaan.tsx` composes all nine chat components plus a reusable SSE streaming hook, preserving the divine dialogue visual language (living cosmic backdrop, sub-mandala texture, word-by-word reveal, golden pulse on response complete).

## New chat components (`apps/mobile/components/chat/`)

- **ChatHeader.tsx** — 64 + safe-area header, `rgba(5,7,20,0.95)` background, gold bottom divider. Left: `MandalaSpin(40px)` wrapped in a `DivinePresenceIndicator` that breathes continuously. On streaming, halo opacity doubles and mandala speed shifts to `fast`. Imperative `.pulse()` ref fires a one-shot golden pulse ring. Title "Sakha" in `CormorantGaramond-LightItalic` 20 px #D4A017, subtitle "The Paramatma is listening" in Outfit italic 11 px muted. Right: voice toggle + language selector sacred icons.
- **SubMandalaTexture.tsx** — Static Skia canvas drawing a Shatkona (6-pointed star) inside 3 concentric rings at 4 % opacity. `absoluteFill`, `pointerEvents="none"`, no animation.
- **UserMessage.tsx** — Right-aligned bubble, Krishna-aura LinearGradient at 135°, radius `[20, 4, 20, 20]`, padding 12×16, Outfit-Regular 15 px #F5F0E8, max width 72 %, translateX + opacity entrance.
- **SakhaMessage.tsx** — Row layout: `MandalaSpin(28px)` avatar + SacredCard-style bubble with a vertical Krishna-aura ribbon as left accent. `CrimsonText-Regular` 16 px / line-height 28, inline Devanagari auto-detected and restyled to `NotoSansDevanagari-Regular` 17 px gold. Per-word fade-in (60 ms stagger, guarded via `hasRevealedRef` so re-renders don't restart completed animations). Blinking gold `|` cursor while streaming; one-shot golden shimmer sweep on stream complete. Optional inline shloka renderer.
- **TypingIndicator.tsx** — Compact SacredCard with 3 gold dots that pulse sequentially (400 ms swing with 150 ms stagger — left to right, not simultaneous), slow-spinning ॐ glyph, "Reflecting on dharma…" Outfit italic 11 px muted caption. Fade-in entrance.
- **ChatInput.tsx** — 60 + safe-area composer, top gold divider. 44 px mic voice button (1 px gold border), flex-1 sacred field with italic placeholder "Ask Sakha anything…", 44 px send circle with Krishna-aura gradient fill + custom lotus-arrow SVG. Disabled opacity 0.3, press scale 0.9 → 1.0 with `ImpactFeedbackStyle.Light`, one-shot golden pulse ring fires on send.
- **ConversationStarters.tsx** — Empty-state column of 4 SacredChips with the exact web copy:
  - "What is my dharma in this moment?"
  - "I am afraid. What does Krishna say?"
  - "Explain the nature of the Atman"
  - "How do I find peace amidst chaos?"

  200 ms staggered lotus-bloom entrance. Tap fires a Light haptic and submits the prompt immediately.
- **useSakhaStream.ts** — XHR-based SSE streaming hook. React Native's `fetch` streaming is unreliable on Android, so this uses `XMLHttpRequest.onreadystatechange` to parse `data: {…}` frames incrementally. Propagates `session_id`, flips `isStreaming`, and on error returns the compassionate fallback "My connection to the cosmic network wavered. Please ask again." as a SAKHA bubble (not a toast).
- **index.ts** — Barrel exports.

## New screen (`app/(tabs)/kiaan.tsx`)

- `DivineBackground` cosmic wrapper so the particle/aura backdrop shows through.
- `SubMandalaTexture` layered behind an inverted `FlatList` of messages.
- `ConversationStarters` on empty state; `TypingIndicator` in list header (visually at the bottom in inverted mode) while streaming.
- `ChatInput` fixed at the bottom inside a `KeyboardAvoidingView` (`behavior="padding"` on both iOS and Android so the field is never hidden).
- Header pulse fires 1500 ms after stream end via `onStreamCompleted`.
- JWT pulled from SecureStore key `kiaanverse_access_token` (matches `packages/store/src/authStore.ts`).
- Registered in `(tabs)/_layout.tsx` with `href: null` so it's reachable as a deep-link-only route without disturbing the current `sakha.tsx` tab target.

## Design adherence

- All colors, radii, and typography match the spec tokens (#D4A017 gold, Krishna aura gradient, SACRED_WHITE text, sacred-spring motion).
- All animations run on the UI thread via Reanimated worklets.
- Word-by-word reveal uses opacity-only (nested `Animated.Text` transforms don't apply inline on Android).
- Haptics fire on send, chip tap, and voice press.

## Test plan

- [ ] Open the chat screen via deep link `kiaanverse://kiaan` (or a navigation helper) and confirm:
  - [ ] Cosmic background + sub-mandala texture visible behind messages
  - [ ] Empty state shows 4 conversation starters with staggered entrance
  - [ ] Tapping a starter fills the input and sends immediately
  - [ ] User bubbles right-align with Krishna-aura gradient and sharp top-right corner
  - [ ] SAKHA bubbles left-align with gold ribbon, reveal words progressively (~1.5 s for 10 words)
  - [ ] Typing indicator shows 3 dots pulsing sequentially (not simultaneously)
  - [ ] Header mandala intensifies while streaming; golden pulse fires ~1.5 s after stream ends
  - [ ] Keyboard pushes the input field up on Android (not hidden)
  - [ ] Send button golden pulse fires on message send
  - [ ] Voice button renders (STT wiring not yet done)
- [ ] Force a network error (airplane mode during send) and confirm the SAKHA bubble shows the compassionate fallback message
- [ ] Confirm `yarn typecheck` and `yarn lint` pass in `apps/mobile/`

https://claude.ai/code/session_01NCJtx1Kq9ztPk3B8ZZhLMQ