### PR TITLE
fix(mobile): wire ardha / viyoga / relationship-compass to backend

### DIFF
--- a/kiaanverse-mobile/packages/api/src/endpoints.ts
+++ b/kiaanverse-mobile/packages/api/src/endpoints.ts
@@ -271,8 +271,17 @@ export const api = {
 
   /** Relationship Compass — Dharma-guided relationship clarity */
   relationship: {
+    // Backend (routes/relationship_compass.py) reads `conflict` (not
+    // `question`) and accepts an optional `relationship_type` /
+    // `analysis_mode`. Sending the wrong key triggers a 400 because the
+    // backend rejects empty conflict text.
     guide: (question: string, context?: string) =>
-      apiClient.post('/api/relationship-compass/guide', { question, context }),
+      apiClient.post('/api/relationship-compass/guide', {
+        conflict: question,
+        context: context ?? '',
+        relationship_type: 'romantic',
+        analysis_mode: 'standard',
+      }),
   },
 
   /** Karma Footprint — Track karmic ripples and impact */
@@ -294,14 +303,30 @@ export const api = {
 
   /** Viyoga — Detachment and letting-go tool */
   viyoga: {
+    // Backend (routes/viyoga.py) reads `sessionId` in camelCase, plus
+    // `mode` and `secularMode` for the v4.0 enhanced pipeline. The
+    // previous snake_case `session_id` was silently dropped, so every
+    // turn started a brand-new conversation on the server.
     chat: (message: string, sessionId?: string) =>
-      apiClient.post('/api/viyoga/chat', { message, session_id: sessionId }),
+      apiClient.post('/api/viyoga/chat', {
+        message,
+        sessionId: sessionId ?? '',
+        mode: 'full',
+        secularMode: true,
+      }),
   },
 
   /** Ardha — Reframing and perspective tool */
   ardha: {
-    reframe: (situation: string, perspective?: string) =>
-      apiClient.post('/api/ardha/reframe', { situation, perspective }),
+    // Backend (routes/ardha.py) reads `thought` (not `situation`) and
+    // requires it non-empty; sending `situation` produced
+    // 400 "thought is required". `depth` defaults to "quick" but we send
+    // it explicitly so the server picks the right Gita pipeline.
+    reframe: (situation: string, _perspective?: string) =>
+      apiClient.post('/api/ardha/reframe', {
+        thought: situation,
+        depth: 'quick',
+      }),
   },
 
   /** Meditation tracks for Vibe Player */

--- a/kiaanverse-mobile/packages/api/src/hooks.ts
+++ b/kiaanverse-mobile/packages/api/src/hooks.ts
@@ -972,12 +972,73 @@ export function useRelationshipCompass(): UseMutationResult<RelationshipCompassR
   });
 }
 
-/** Relationship guidance returning extended RelationshipGuidance type. */
+/**
+ * Parse a backend "BG c.v" reference string into chapter/verse numbers.
+ * Returns null if the format isn't recognised.
+ */
+function _parseGitaReference(ref: string | undefined): { chapter: number; verse: number } | null {
+  if (!ref) return null;
+  const match = /BG\s*(\d+)\.(\d+)/i.exec(ref);
+  if (!match) return null;
+  return { chapter: Number(match[1]), verse: Number(match[2]) };
+}
+
+/**
+ * Relationship guidance returning extended RelationshipGuidance type.
+ *
+ * Maps the backend's `compass_guidance` response (routes/relationship_compass.py)
+ * into the screen-expected RelationshipGuidance shape:
+ *   - guidance        ← `response`
+ *   - dharma_principles ← `relationship_teachings.core_principles`
+ *   - reflection_prompts ← derived from compass_guidance sections
+ *   - verse           ← parsed from gita_context.sources[0]
+ */
 export function useRelationshipGuide(): UseMutationResult<RelationshipGuidance, Error, { question: string; context?: string }> {
   return useMutation({
     mutationFn: async ({ question, context }) => {
       const { data } = await api.relationship.guide(question, context);
-      return data as RelationshipGuidance;
+      const raw = data as {
+        response?: string;
+        compass_guidance?: Record<string, unknown> | unknown[];
+        relationship_teachings?: { core_principles?: string[]; key_teaching?: string };
+        gita_context?: { sources?: Array<{ reference?: string; reference_if_any?: string }> };
+        emotion_insight?: string;
+      };
+
+      const ref = raw.gita_context?.sources?.[0];
+      const parsed = _parseGitaReference(ref?.reference ?? ref?.reference_if_any);
+
+      // Pull reflection prompts from any "reflection" / "questions" section
+      // the model produced. Falls back to an empty list if compass_guidance
+      // is shaped as a string body instead of structured sections.
+      const reflectionPrompts: string[] = [];
+      if (raw.compass_guidance && !Array.isArray(raw.compass_guidance)) {
+        for (const [key, value] of Object.entries(raw.compass_guidance)) {
+          if (/reflection|question|prompt/i.test(key) && Array.isArray(value)) {
+            for (const item of value) {
+              if (typeof item === 'string') reflectionPrompts.push(item);
+            }
+          }
+        }
+      }
+
+      const result: RelationshipGuidance = {
+        question,
+        guidance: raw.response ?? raw.relationship_teachings?.key_teaching ?? '',
+        dharma_principles: raw.relationship_teachings?.core_principles ?? [],
+        reflection_prompts: reflectionPrompts,
+        ...(parsed
+          ? {
+              verse: {
+                chapter: parsed.chapter,
+                verse: parsed.verse,
+                text: '',
+                translation: raw.emotion_insight ?? '',
+              },
+            }
+          : {}),
+      };
+      return result;
     },
   });
 }
@@ -1072,21 +1133,115 @@ export function useViyogaGuide(): UseMutationResult<ViyogaResult, Error, string>
   });
 }
 
-/** Viyoga chat with session support. */
+/**
+ * Viyoga chat with session support.
+ *
+ * Maps the backend's chat response (routes/viyoga.py) — `assistant`,
+ * `citations`, `karma_yoga_insight` — into the screen-expected
+ * ViyogaResponse shape with `message`, `session_id`, optional `verse`.
+ * The backend doesn't echo the session id, so we round-trip the one
+ * the caller passed in (or empty string for the first turn).
+ */
 export function useViyogaChat(): UseMutationResult<ViyogaResponse, Error, { message: string; sessionId?: string }> {
   return useMutation({
     mutationFn: async ({ message, sessionId }) => {
       const { data } = await api.viyoga.chat(message, sessionId);
-      return data as ViyogaResponse;
+      const raw = data as {
+        assistant?: string;
+        citations?: Array<{ reference_if_any?: string }>;
+        karma_yoga_insight?: { teaching?: string; verse?: string; remedy?: string };
+        error?: string;
+      };
+
+      // Surface server-side validation errors (empty/too-long message)
+      // so the caller's catch block runs the same fallback path it
+      // would for a network failure.
+      if (raw.error) {
+        throw new Error(raw.error);
+      }
+
+      // Prefer the first citation; fall back to the karma-yoga insight
+      // verse string ("BG 2.47"-style) so the optional verse field is
+      // populated even when no citations were attached.
+      const ref =
+        raw.citations?.[0]?.reference_if_any ?? raw.karma_yoga_insight?.verse;
+      const parsed = _parseGitaReference(ref);
+
+      const result: ViyogaResponse = {
+        message: raw.assistant ?? '',
+        session_id: sessionId ?? '',
+        ...(parsed
+          ? {
+              verse: {
+                chapter: parsed.chapter,
+                verse: parsed.verse,
+                text: raw.karma_yoga_insight?.teaching ?? '',
+              },
+            }
+          : {}),
+        ...(raw.karma_yoga_insight?.remedy
+          ? { practice: raw.karma_yoga_insight.remedy }
+          : {}),
+      };
+      return result;
     },
   });
 }
 
+/**
+ * Ardha thought-reframing.
+ *
+ * Maps the backend's `/api/ardha/reframe` response (routes/ardha.py) —
+ * `response`, `sources`, `ardha_analysis` — into the
+ * screen-expected ArdhaReframeResponse:
+ *   - original_situation   ← echo of the caller's situation
+ *   - reframed_perspective ← `response`
+ *   - verse                ← parsed from `sources[0].reference`
+ *   - affirmation          ← derived from the recommended pillar's
+ *                            compliance_test, which is always a short,
+ *                            uplifting Sanskrit-grounded line.
+ */
 export function useArdhaReframe(): UseMutationResult<ArdhaReframeResponse, Error, { situation: string; perspective?: string }> {
   return useMutation({
     mutationFn: async ({ situation, perspective }) => {
       const { data } = await api.ardha.reframe(situation, perspective);
-      return data as ArdhaReframeResponse;
+      const raw = data as {
+        response?: string;
+        sources?: Array<{ reference?: string }>;
+        ardha_analysis?: {
+          pillars?: Array<{
+            sanskrit_name?: string;
+            name?: string;
+            compliance_test?: string;
+          }>;
+          crisis_detected?: boolean;
+        };
+      };
+
+      const parsed = _parseGitaReference(raw.sources?.[0]?.reference);
+      const firstPillar = raw.ardha_analysis?.pillars?.[0];
+      const affirmation =
+        firstPillar?.compliance_test
+        ?? (firstPillar?.sanskrit_name
+          ? `I rest in ${firstPillar.sanskrit_name}.`
+          : 'I am the witness; the storm is not me.');
+
+      const result: ArdhaReframeResponse = {
+        original_situation: situation,
+        reframed_perspective: raw.response ?? '',
+        affirmation,
+        ...(parsed
+          ? {
+              verse: {
+                chapter: parsed.chapter,
+                verse: parsed.verse,
+                text: '',
+                translation: '',
+              },
+            }
+          : {}),
+      };
+      return result;
     },
   });
 }

--- a/kiaanverse-mobile/packages/api/src/types.ts
+++ b/kiaanverse-mobile/packages/api/src/types.ts
@@ -699,7 +699,10 @@ export interface KarmaResetCompletion {
 export interface RelationshipGuidance {
   question: string;
   guidance: string;
-  verse: { chapter: number; verse: number; text: string; translation: string };
+  // verse is optional because the backend's /guide endpoint surfaces
+  // citations as references only — full sanskrit + translation isn't
+  // always reconstructable client-side.
+  verse?: { chapter: number; verse: number; text: string; translation: string };
   dharma_principles: string[];
   reflection_prompts: string[];
 }
@@ -730,7 +733,9 @@ export interface ViyogaResponse {
 export interface ArdhaReframeResponse {
   original_situation: string;
   reframed_perspective: string;
-  verse: { chapter: number; verse: number; text: string; translation: string };
+  // Optional — the backend returns verse references in the `sources`
+  // array but not always full Sanskrit + translation text.
+  verse?: { chapter: number; verse: number; text: string; translation: string };
   affirmation: string;
 }
 


### PR DESCRIPTION
## Summary

The three sacred-tool screens (`app/tools/ardha`, `app/tools/viyoga`, `app/tools/relationship-compass`) were broken at the API contract layer, not the UI. None of the user's hypothesised causes applied — all three screens already exist, the tools hub already uses `router.push()`, URLs already match the backend, and the backend routes have no auth dependency.

The real root cause was **wire-level field-name mismatches** in three endpoints:

| Tool | Backend reads | Mobile sent | Backend returns | Mobile read |
|---|---|---|---|---|
| Ardha | `thought` | `situation` → 400 | `{response, sources, ardha_analysis}` | `original_situation`, `reframed_perspective`, `verse`, `affirmation` (all `undefined`) |
| Viyoga | `sessionId` (camelCase) | `session_id` | `{assistant, citations, karma_yoga_insight}` | `message`, `session_id` (`undefined`) |
| Relationship Compass | `conflict` | `question` → 400 | `{response, compass_guidance, relationship_teachings, gita_context}` | `guidance`, `verse`, `dharma_principles`, `reflection_prompts` (all `undefined`) |

Even when a request didn't return 400, the screen rendered with all-undefined fields.

## Changes

- **`endpoints.ts`** — send the field names the backend actually parses:
  - Ardha: `{ thought: situation, depth: 'quick' }`
  - Viyoga: `{ message, sessionId, mode: 'full', secularMode: true }`
  - Relationship Compass: `{ conflict: question, context, relationship_type: 'romantic', analysis_mode: 'standard' }`
- **`hooks.ts`** — map each backend response into the camelCase shape the screens render. Added a shared `_parseGitaReference()` helper that extracts chapter/verse from `BG c.v` strings the backend returns in `sources` / `citations` arrays. Affirmation derived from `ardha_analysis.pillars[0].compliance_test`; viyoga `session_id` round-tripped from the caller (backend never echoes it); relationship `dharma_principles` ← `relationship_teachings.core_principles`, `reflection_prompts` ← derived from `compass_guidance` sections.
- **`types.ts`** — made `verse` optional on `ArdhaReframeResponse` and `RelationshipGuidance` since the backend surfaces references only. Both screens already guard `<VerseCard>` behind a truthiness check.

## Files

- `kiaanverse-mobile/packages/api/src/endpoints.ts`
- `kiaanverse-mobile/packages/api/src/hooks.ts`
- `kiaanverse-mobile/packages/api/src/types.ts`

## Test plan

- [ ] Open Ardha → enter situation → "Reframe My Perspective" → result card renders with reframed text + affirmation; verse appears when backend returns a citation
- [ ] Open Viyoga → send a message → assistant bubble shows backend response (not blank); subsequent turns reuse the same `sessionId`
- [ ] Open Relationship Compass → enter question → guidance card + dharma principles render; verse appears when backend returns a citation
- [ ] No 400s in network log for `/api/ardha/reframe`, `/api/viyoga/chat`, `/api/relationship-compass/guide`

https://claude.ai/code/session_015KUco44VU53ZWLh6zPNW55