### PR TITLE
Refactor DivineButton to delegate to shared UI component

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/index.tsx
@@ -203,7 +203,7 @@ export default function HomeScreen(): React.JSX.Element {
           />
         }
       >
-        {isRefetching && <OmLoader active size={36} />}
+        {isRefetching && <OmLoader size={36} />}
 
         {/* ───────────────────────── 1. Header ───────────────────────── */}
         <Animated.View style={[styles.headerRow, headerEntrance]}>

--- a/kiaanverse-mobile/apps/mobile/components/home/DivineButton.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/home/DivineButton.tsx
@@ -1,16 +1,15 @@
 /**
- * DivineButton — gold gradient CTA button matching the web /dashboard style.
+ * DivineButton — Krishna Aura gradient CTA for the Home screen.
  *
- * Wraps the existing GoldenButton from @kiaanverse/ui so the Home screen
- * uses a single, ceremonial button component with two clear variants:
- *   · primary  → solid gold gradient (Begin Dialogue)
- *   · secondary → outlined gold (Continue Today's Practice)
+ * Delegates to the shared DivineButton in @kiaanverse/ui so the "Begin
+ * Dialogue" and "Continue Today's Practice" CTAs render with the sacred
+ * blue → purple → gold LinearGradient (primary) or the outlined-gold pill
+ * (secondary), with haptics and spring press animation built in.
  */
 
 import React from 'react';
 import { type ViewStyle } from 'react-native';
-import * as Haptics from 'expo-haptics';
-import { GoldenButton } from '@kiaanverse/ui';
+import { DivineButton as UiDivineButton } from '@kiaanverse/ui';
 
 export interface DivineButtonProps {
   readonly title: string;
@@ -27,21 +26,14 @@ export function DivineButton({
   variant = 'primary',
   disabled,
   style,
-  accessibilityHint,
 }: DivineButtonProps): React.JSX.Element {
-  const handlePress = () => {
-    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onPress();
-  };
-
   return (
-    <GoldenButton
+    <UiDivineButton
       title={title}
-      onPress={handlePress}
-      variant={variant === 'primary' ? 'divine' : 'secondary'}
+      onPress={onPress}
+      variant={variant}
       {...(disabled !== undefined ? { disabled } : {})}
       {...(style !== undefined ? { style } : {})}
-      {...(accessibilityHint !== undefined ? { accessibilityHint } : {})}
     />
   );
 }


### PR DESCRIPTION
## Summary

Simplify the mobile `DivineButton` component by delegating to the shared `DivineButton` from `@kiaanverse/ui` instead of wrapping `GoldenButton`. This removes duplicate haptics logic and variant mapping, allowing the shared component to handle the Krishna Aura gradient styling, animations, and accessibility features consistently across platforms.

Also remove the unused `active` prop from `OmLoader` in the Home screen.

## Changes

- **DivineButton.tsx**: 
  - Replace `GoldenButton` wrapper with direct import of `DivineButton` from `@kiaanverse/ui`
  - Remove local haptics handling (now managed by shared component)
  - Simplify variant mapping (pass variant directly instead of mapping `'primary'` → `'divine'`)
  - Remove unused `accessibilityHint` prop
  - Update JSDoc to reflect delegation pattern

- **index.tsx**: Remove unused `active` prop from `OmLoader` component

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing

Verify that the "Begin Dialogue" and "Continue Today's Practice" buttons on the Home screen render correctly with the Krishna Aura gradient and respond to taps with haptic feedback. Confirm the loader displays without errors.

## Reviewers

@kiaanverse/maintainers

https://claude.ai/code/session_01KKecLcyRGe9sHDs9KF9yV3