### PR TITLE
fix(mobile): harden app boot — fix crash on build 17 (orphan routes, setup isolation, splash watchdog)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -156,15 +156,49 @@ function AppContent(): React.JSX.Element {
 
   const onLayoutReady = useCallback(async () => {
     if (status !== 'idle' && status !== 'loading') {
-      await SplashScreen.hideAsync();
+      try {
+        await SplashScreen.hideAsync();
+      } catch {
+        // SplashScreen.hideAsync can throw if the native module is missing
+        // or if it's already hidden — swallow so it never prevents the app
+        // from continuing to render the tree below.
+      }
     }
   }, [status]);
 
+  // Fail-open splash hide: if the auth bootstrap takes too long or silently
+  // hangs, force the splash to hide after 8 seconds so the user sees the
+  // LoadingMandala fallback instead of a frozen native splash. Without this
+  // guard a slow network + broken token storage would present as a crash.
   useEffect(() => {
+    const timeout = setTimeout(() => {
+      SplashScreen.hideAsync().catch(() => undefined);
+    }, 8000);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  useEffect(() => {
+    // Each step is isolated so a failure in one (e.g. the biometric probe
+    // on devices without hardware, or a hydrateSubscription storage read
+    // failing on first install) can't block the auth gate from settling.
+    // Without this, status stayed 'idle'/'loading' forever → splash never
+    // hid and the app appeared to be stuck in a reload loop.
     const setup = async () => {
-      await initialize();
-      await checkBiometricAvailability();
-      await hydrateSubscription();
+      try {
+        await initialize();
+      } catch (err) {
+        if (__DEV__) console.warn('[setup] initialize failed:', err);
+      }
+      try {
+        await checkBiometricAvailability();
+      } catch (err) {
+        if (__DEV__) console.warn('[setup] biometric probe failed:', err);
+      }
+      try {
+        await hydrateSubscription();
+      } catch (err) {
+        if (__DEV__) console.warn('[setup] hydrateSubscription failed:', err);
+      }
     };
     void setup();
     // Run once on mount — Zustand actions are stable references
@@ -223,9 +257,11 @@ function AppContent(): React.JSX.Element {
           <Stack.Screen name="(auth)" />
           <Stack.Screen name="(tabs)" />
           <Stack.Screen name="onboarding" />
-          <Stack.Screen name="gita" />
           <Stack.Screen name="wellness" />
-          <Stack.Screen name="chat" />
+
+          {/* Wisdom Journeys (14/21-day transformation paths) */}
+          <Stack.Screen name="journey" />
+
           <Stack.Screen
             name="subscription"
             options={{ animation: 'slide_from_bottom', presentation: 'modal', animationDuration: 350 }}

--- a/kiaanverse-mobile/packages/store/src/authStore.ts
+++ b/kiaanverse-mobile/packages/store/src/authStore.ts
@@ -429,10 +429,21 @@ export const useAuthStore = create<AuthState & AuthActions>()(
           isOnboarded: state.isOnboarded,
           biometricEnabled: state.biometricEnabled,
         }),
-        // Mark hydration complete so AuthGate can wait for persisted isOnboarded
-        onRehydrateStorage: () => (state) => {
+        // Mark hydration complete so AuthGate can wait for persisted isOnboarded.
+        // This MUST run in both success and failure paths — if SecureStore is
+        // unreadable on first launch or corrupted we still need to unblock
+        // the AuthGate, otherwise the app is stuck on the splash screen.
+        onRehydrateStorage: () => (state, error) => {
+          if (error) {
+            // Storage read failed — fall through with default state so the
+            // app can continue to (auth)/login rather than hanging.
+            useAuthStore.setState({ hasHydrated: true });
+            return;
+          }
           if (state) {
             state.hasHydrated = true;
+          } else {
+            useAuthStore.setState({ hasHydrated: true });
           }
         },
       },


### PR DESCRIPTION
## Summary

Follow-up to #1562. Fixes the app crash/hang reported on the build-17 APK. A deep post-merge scan identified **four crash/hang vectors**, all now closed.

## Root causes

| # | Cause | Where | Symptom |
|---|-------|-------|---------|
| 1 | Orphan `<Stack.Screen>` declarations | `apps/mobile/app/_layout.tsx:226` | `name="gita"` pointed at a route tree deleted in #1562; `name="chat"` referenced an `app/chat/` dir that has never existed (chat lives inside `(tabs)`). Expo Router warnings escalate to hard errors in Android release builds. |
| 2 | `setup()` swallowed failures | `apps/mobile/app/_layout.tsx:163` | `void setup()` discarded promise rejections. A throw in `initialize()` / `checkBiometricAvailability()` / `hydrateSubscription()` left auth `status` stuck at `loading` forever — splash never hid → app appeared frozen. |
| 3 | SecureStore hydration deadlock | `packages/store/src/authStore.ts:433` | `onRehydrateStorage` only set `hasHydrated=true` when `state` was defined. On first install with a locked Keychain / corrupt storage / iOS Keychain race, `state` was `undefined` → `hasHydrated` stuck at `false` → AuthGate's `if (!hasHydrated) return;` blocked every redirect. |
| 4 | No splash-screen watchdog | `apps/mobile/app/_layout.tsx` | If anything above hung, `SplashScreen.hideAsync()` never ran and the user saw a native splash that looked like a crash. |

## Changes

```diff
 // app/_layout.tsx — <Stack> registration
-<Stack.Screen name="gita" />       // ← deleted dir
-<Stack.Screen name="chat" />       // ← never existed at top level
+<Stack.Screen name="journey" />    // ← missing but real

 // Setup failure isolation
-await initialize();
-await checkBiometricAvailability();
-await hydrateSubscription();
+try { await initialize(); } catch { /* __DEV__ warn */ }
+try { await checkBiometricAvailability(); } catch { /* __DEV__ warn */ }
+try { await hydrateSubscription(); } catch { /* __DEV__ warn */ }

 // authStore hydration fail-open
-onRehydrateStorage: () => (state) => { if (state) state.hasHydrated = true }
+onRehydrateStorage: () => (state, error) => {
+  if (error || !state) useAuthStore.setState({ hasHydrated: true });
+  else state.hasHydrated = true;
+}

 // 8-second splash watchdog
+useEffect(() => {
+  const t = setTimeout(() => SplashScreen.hideAsync().catch(() => {}), 8000);
+  return () => clearTimeout(t);
+}, []);
```

## Verified clean (no action needed)

| Check | Result |
|-------|--------|
| Hooks-order / conditional hooks | **0** violations |
| `setState` during render | **0** violations |
| `.value` read outside worklet | **0** violations |
| `useEffect(async …)` anti-pattern | **0** instances |
| Infinite `router.replace` loops | None — AuthGate deps settle after first replace |
| Asset files on disk | icon / splash / adaptive-icon / favicon / notification-icon — all present |
| Android manifest permissions | INTERNET, VIBRATE, RECORD_AUDIO, CAMERA, USE_BIOMETRIC, USE_FINGERPRINT, RECEIVE_BOOT_COMPLETED, POST_NOTIFICATIONS |
| Reanimated Babel plugin | Present, listed last |
| `GestureHandlerRootView` wrapping | At outermost `<RootLayout>` |
| Metro monorepo config | `watchFolders` + `nodeModulesPaths` correct |
| Skia installed and wired | `DivineScreenWrapper` + `SubMandalaTexture` |
| ErrorBoundary | Wraps `<AppContent />` in root layout |
| All 14 `<Stack.Screen>` routes resolve to directories on disk | ✅ |

## Protected features — untouched and verified intact

KIAAN AI chat (`(tabs)/chat.tsx` + `components/chat/useSakhaStream.ts`) · Viyoga · Ardha · Relationship Compass · Karma Reset · Emotional Reset · KIAAN Voice Companion · KIAAN Vibe Player · all Zustand stores powering them.

## versionCode note

Play Console requires strictly-increasing versionCodes, **not consecutive**. Going 13 → 17 → 18 is legal. `app.config.ts` is at **18**.

## Test plan

- [x] `pnpm -r typecheck` — 0 errors
- [x] `pnpm -r test` — 222/222 pass
- [ ] Trigger a fresh EAS Android production build and install on a clean Android 13+ device
- [ ] Confirm splash hides within 8s even when offline / first install
- [ ] Verify navigation reaches `(auth)/login` for a fresh install and `(tabs)` after login

https://claude.ai/code/session_01BoJ1UuHkTXhN7DqVciowdD