### PR TITLE
Implement Play Billing / StoreKit IAP with react-native-iap

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -71,6 +71,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       'android.permission.USE_FINGERPRINT',
       'android.permission.RECEIVE_BOOT_COMPLETED',
       'android.permission.POST_NOTIFICATIONS',
+      'com.android.vending.BILLING',
     ],
     intentFilters: [
       {
@@ -134,6 +135,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       {
         faceIDPermission:
           'Kiaanverse uses Face ID for secure, quick login.',
+      },
+    ],
+    [
+      'react-native-iap',
+      {
+        paymentProvider: 'Play Store',
       },
     ],
   ],

--- a/kiaanverse-mobile/apps/mobile/app/(app)/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/_layout.tsx
@@ -1,0 +1,24 @@
+/**
+ * (app) Group Layout — Profile sub-screens.
+ *
+ * Houses settings screens linked from the Profile tab:
+ * notifications, language-settings, edit-profile, change-password,
+ * subscription, billing-history, karmalytix, help, contact, privacy,
+ * terms, data-privacy. Uses the default fade animation inherited from
+ * the root stack.
+ */
+
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function AppGroupLayout(): React.JSX.Element {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: 'fade',
+        animationDuration: 280,
+      }}
+    />
+  );
+}

--- a/kiaanverse-mobile/apps/mobile/app/(app)/language-settings.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/language-settings.tsx
@@ -1,0 +1,99 @@
+/**
+ * Language Settings — single-select list of supported locales.
+ *
+ * Optimistic local select + PATCH /api/user/language. The native script
+ * preview uses NotoSansDevanagari for Indic scripts (falls back to the
+ * system font for non-Indic entries, which is fine).
+ */
+
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { DivineScreenWrapper, SacredCard } from '@kiaanverse/ui';
+import { apiClient } from '@kiaanverse/api';
+
+const LANGUAGES = [
+  { code: 'en', label: 'English',   native: 'English' },
+  { code: 'hi', label: 'Hindi',     native: 'हिन्दी' },
+  { code: 'sa', label: 'Sanskrit',  native: 'संस्कृत' },
+  { code: 'ta', label: 'Tamil',     native: 'தமிழ்' },
+  { code: 'te', label: 'Telugu',    native: 'తెలుగు' },
+  { code: 'mr', label: 'Marathi',   native: 'मराठी' },
+  { code: 'bn', label: 'Bengali',   native: 'বাংলা' },
+  { code: 'gu', label: 'Gujarati',  native: 'ગુજરાતી' },
+  { code: 'kn', label: 'Kannada',   native: 'ಕನ್ನಡ' },
+  { code: 'ml', label: 'Malayalam', native: 'മലയാളം' },
+  { code: 'de', label: 'German',    native: 'Deutsch' },
+  { code: 'fr', label: 'French',    native: 'Français' },
+  { code: 'es', label: 'Spanish',   native: 'Español' },
+] as const;
+
+export default function LanguageSettings(): React.JSX.Element {
+  const [selected, setSelected] = useState('en');
+
+  const handleSelect = async (code: string) => {
+    setSelected(code);
+    try {
+      await apiClient.patch('/api/user/language', { language: code });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <DivineScreenWrapper>
+      <ScrollView
+        style={{ flex: 1, padding: 16 }}
+        contentContainerStyle={{ paddingBottom: 80 }}
+      >
+        <Text style={styles.title}>Language</Text>
+        <SacredCard style={{ padding: 0 }}>
+          {LANGUAGES.map((lang) => (
+            <TouchableOpacity
+              key={lang.code}
+              style={styles.row}
+              onPress={() => handleSelect(lang.code)}
+              activeOpacity={0.7}
+            >
+              <View style={{ flex: 1 }}>
+                <Text style={styles.label}>{lang.label}</Text>
+                <Text style={styles.native}>{lang.native}</Text>
+              </View>
+              {selected === lang.code && (
+                <Text style={{ color: '#D4A017', fontSize: 18 }}>✓</Text>
+              )}
+            </TouchableOpacity>
+          ))}
+        </SacredCard>
+      </ScrollView>
+    </DivineScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 22,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+    marginTop: 60,
+    marginBottom: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(212,160,23,0.08)',
+  },
+  label: {
+    fontSize: 15,
+    fontFamily: 'Outfit-Regular',
+    color: '#F0EBE1',
+  },
+  native: {
+    fontSize: 13,
+    fontFamily: 'NotoSansDevanagari-Regular',
+    color: 'rgba(212,160,23,0.6)',
+    marginTop: 1,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(app)/notifications.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/notifications.tsx
@@ -1,0 +1,101 @@
+/**
+ * Notifications Settings — toggle push categories.
+ *
+ * Optimistic local toggle + PATCH /api/user/notification-preferences.
+ * Failed writes log to console; the UI keeps the optimistic value so the
+ * user doesn't see a flicker (the next hydrate will reconcile if needed).
+ */
+
+import React, { useState } from 'react';
+import { View, Text, Switch, ScrollView, StyleSheet } from 'react-native';
+import { DivineScreenWrapper, SacredCard, GoldenDivider } from '@kiaanverse/ui';
+import { apiClient } from '@kiaanverse/api';
+
+const SETTINGS = [
+  { key: 'daily_verse',      label: 'Daily Verse',     sub: 'Morning shloka reminder' },
+  { key: 'sadhana_reminder', label: 'Nitya Sadhana',   sub: 'Practice reminders' },
+  { key: 'journey_nudge',    label: 'Journey Nudges',  sub: 'Step completion reminders' },
+  { key: 'kiaan_insights',   label: 'KIAAN Insights',  sub: 'Weekly wisdom digest' },
+  { key: 'streak_alert',     label: 'Streak Alerts',   sub: "Don't break your streak" },
+] as const;
+
+export default function NotificationsScreen(): React.JSX.Element {
+  const [prefs, setPrefs] = useState<Record<string, boolean>>({
+    daily_verse: true,
+    sadhana_reminder: true,
+    journey_nudge: false,
+    kiaan_insights: true,
+    streak_alert: true,
+  });
+
+  const toggle = async (key: string, value: boolean) => {
+    setPrefs((p) => ({ ...p, [key]: value }));
+    try {
+      await apiClient.patch('/api/user/notification-preferences', { [key]: value });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <DivineScreenWrapper>
+      <ScrollView
+        style={{ flex: 1, padding: 16 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.title}>Notifications</Text>
+        <SacredCard style={{ padding: 0 }}>
+          {SETTINGS.map((s, idx) => (
+            <React.Fragment key={s.key}>
+              <View style={styles.row}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.label}>{s.label}</Text>
+                  <Text style={styles.sub}>{s.sub}</Text>
+                </View>
+                <Switch
+                  value={prefs[s.key]}
+                  onValueChange={(v) => toggle(s.key, v)}
+                  trackColor={{
+                    false: 'rgba(255,255,255,0.1)',
+                    true: 'rgba(212,160,23,0.4)',
+                  }}
+                  thumbColor={prefs[s.key] ? '#D4A017' : 'rgba(240,235,225,0.5)'}
+                />
+              </View>
+              {idx < SETTINGS.length - 1 && (
+                <GoldenDivider style={{ marginHorizontal: 16 }} />
+              )}
+            </React.Fragment>
+          ))}
+        </SacredCard>
+      </ScrollView>
+    </DivineScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 22,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+    marginTop: 60,
+    marginBottom: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  label: {
+    fontSize: 15,
+    fontFamily: 'Outfit-Regular',
+    color: '#F0EBE1',
+    marginBottom: 2,
+  },
+  sub: {
+    fontSize: 12,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.4)',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/_layout.tsx
@@ -1,0 +1,22 @@
+/**
+ * Subscription subroute layout.
+ *
+ * Groups index (current subscription), plans, and success under a single
+ * stack so back navigation inside the flow feels like one coherent
+ * journey rather than jumping between top-level routes.
+ */
+
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function SubscriptionStackLayout(): React.JSX.Element {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: 'fade',
+        animationDuration: 280,
+      }}
+    />
+  );
+}

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/index.tsx
@@ -1,0 +1,296 @@
+/**
+ * My Subscription — current plan status + management.
+ *
+ * Shows the signed-in user's active subscription from the backend
+ * (`GET /api/subscriptions/current`) and provides entry points to
+ * upgrade, change plan, restore, or manage on the store.
+ *
+ * Policy notes:
+ * - Cancellation MUST happen in the Play Store / App Store account
+ *   screen — in-app cancel flows are not permitted for auto-renewing
+ *   subscriptions purchased via IAP. We deep-link out via `Linking`.
+ * - Restore is provided for users re-installing or switching devices.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Linking, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router } from 'expo-router';
+import * as Haptics from 'expo-haptics';
+import {
+  DivineButton,
+  DivineScreenWrapper,
+  GoldenDivider,
+  OmLoader,
+  SacredCard,
+} from '@kiaanverse/ui';
+import {
+  apiClient,
+  restorePurchases,
+  TIER_CONFIGS,
+} from '@kiaanverse/api';
+import type { SubscriptionTier } from '@kiaanverse/store';
+
+// Matches the backend `UserSubscriptionOut` shape — only the fields we use.
+interface UserSubscriptionResponse {
+  status: string;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+  plan: {
+    tier: SubscriptionTier;
+    name: string;
+    billing_period?: 'monthly' | 'yearly';
+    price_monthly?: number;
+    price_yearly?: number;
+    currency?: string;
+  } | null;
+  effective_tier: SubscriptionTier | null;
+}
+
+const ANDROID_PACKAGE = 'com.kiaanverse.app';
+
+function manageSubscriptionUrl(productId?: string): string {
+  if (Platform.OS === 'ios') {
+    return 'https://apps.apple.com/account/subscriptions';
+  }
+  if (productId) {
+    return `https://play.google.com/store/account/subscriptions?sku=${productId}&package=${ANDROID_PACKAGE}`;
+  }
+  return 'https://play.google.com/store/account/subscriptions';
+}
+
+export default function MySubscriptionScreen(): React.JSX.Element {
+  const [subscription, setSubscription] = useState<UserSubscriptionResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [restoring, setRestoring] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await apiClient.get<UserSubscriptionResponse | null>(
+          '/api/subscriptions/current',
+        );
+        if (mounted) setSubscription(res.data);
+      } catch (err) {
+        console.warn('Failed to load subscription:', err);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const tier: SubscriptionTier =
+    subscription?.effective_tier ?? subscription?.plan?.tier ?? 'free';
+  const isFree = tier === 'free';
+  const renewsAt = subscription?.current_period_end
+    ? new Date(subscription.current_period_end)
+    : null;
+  const willCancel = subscription?.cancel_at_period_end ?? false;
+
+  const handleManage = useCallback(() => {
+    void Haptics.selectionAsync();
+    const url = manageSubscriptionUrl();
+    Linking.openURL(url).catch(() => {
+      Alert.alert(
+        'Unable to open store',
+        Platform.OS === 'ios'
+          ? 'Please open Settings → Apple ID → Subscriptions.'
+          : 'Please open the Google Play Store → Menu → Subscriptions.',
+      );
+    });
+  }, []);
+
+  const handleRestore = useCallback(async () => {
+    setRestoring(true);
+    try {
+      const result = await restorePurchases();
+      if (result.success) {
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        Alert.alert(
+          'Purchases restored',
+          `Your ${TIER_CONFIGS[result.tier].name} subscription is active.`,
+        );
+      } else {
+        Alert.alert(
+          'Nothing to restore',
+          result.error ?? 'No active subscription was found for this account.',
+        );
+      }
+    } finally {
+      setRestoring(false);
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <DivineScreenWrapper>
+        <View style={styles.center}>
+          <OmLoader size={48} label="Loading your subscription…" />
+        </View>
+      </DivineScreenWrapper>
+    );
+  }
+
+  return (
+    <DivineScreenWrapper>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={{ paddingBottom: 80, paddingHorizontal: 16 }}
+      >
+        <Text style={styles.title}>My Subscription</Text>
+
+        <SacredCard style={styles.statusCard}>
+          <Text style={styles.tierLabel}>
+            {isFree ? 'Free Seeker' : `✦ ${TIER_CONFIGS[tier].name}`}
+          </Text>
+          <Text style={styles.tierSubtitle}>{TIER_CONFIGS[tier].description}</Text>
+
+          {!isFree && (
+            <>
+              <GoldenDivider style={{ marginVertical: 14 }} />
+
+              <DetailRow
+                label={willCancel ? 'Access until' : 'Next renewal'}
+                value={renewsAt ? formatDate(renewsAt) : '—'}
+              />
+              <DetailRow
+                label="Status"
+                value={willCancel ? 'Cancels at period end' : 'Active'}
+                valueColor={willCancel ? '#EF4444' : '#10B981'}
+              />
+              {subscription?.plan?.billing_period && (
+                <DetailRow
+                  label="Billing"
+                  value={
+                    subscription.plan.billing_period === 'yearly' ? 'Annual' : 'Monthly'
+                  }
+                />
+              )}
+            </>
+          )}
+        </SacredCard>
+
+        <View style={styles.actions}>
+          {isFree ? (
+            <DivineButton
+              title="Upgrade to Bhakta / Sadhak / Siddha"
+              onPress={() => router.push('/(app)/subscription/plans')}
+              variant="primary"
+            />
+          ) : (
+            <>
+              <DivineButton
+                title="Change Plan"
+                onPress={() => router.push('/(app)/subscription/plans')}
+                variant="secondary"
+              />
+              <DivineButton
+                title={
+                  Platform.OS === 'ios'
+                    ? 'Manage on App Store'
+                    : 'Manage on Google Play'
+                }
+                onPress={handleManage}
+                variant="ghost"
+              />
+            </>
+          )}
+
+          <DivineButton
+            title={restoring ? 'Restoring…' : 'Restore Purchases'}
+            onPress={handleRestore}
+            variant="ghost"
+            loading={restoring}
+            disabled={restoring}
+          />
+        </View>
+
+        <Text style={styles.footnote}>
+          Subscriptions are billed and managed by{' '}
+          {Platform.OS === 'ios' ? 'the App Store' : 'Google Play'}. Cancel anytime
+          in your store account — access continues until the end of the current
+          billing period.
+        </Text>
+      </ScrollView>
+    </DivineScreenWrapper>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+}): React.JSX.Element {
+  return (
+    <View style={styles.detailRow}>
+      <Text style={styles.detailKey}>{label}</Text>
+      <Text style={[styles.detailVal, valueColor ? { color: valueColor } : null]}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: {
+    fontSize: 22,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+    marginTop: 60,
+    marginBottom: 20,
+  },
+  statusCard: { padding: 20, marginBottom: 20 },
+  tierLabel: {
+    fontSize: 22,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#D4A017',
+    textAlign: 'center',
+  },
+  tierSubtitle: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.55)',
+    textAlign: 'center',
+    marginTop: 6,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  detailKey: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.5)',
+  },
+  detailVal: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Medium',
+    color: '#F0EBE1',
+  },
+  actions: { gap: 12, marginBottom: 24 },
+  footnote: {
+    fontSize: 11,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.3)',
+    textAlign: 'center',
+    lineHeight: 16,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/index.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Alert, Linking, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { router } from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import {
@@ -25,6 +25,7 @@ import {
 } from '@kiaanverse/ui';
 import {
   apiClient,
+  openManageSubscription,
   restorePurchases,
   TIER_CONFIGS,
 } from '@kiaanverse/api';
@@ -42,20 +43,9 @@ interface UserSubscriptionResponse {
     price_monthly?: number;
     price_yearly?: number;
     currency?: string;
+    product_id?: string;
   } | null;
   effective_tier: SubscriptionTier | null;
-}
-
-const ANDROID_PACKAGE = 'com.kiaanverse.app';
-
-function manageSubscriptionUrl(productId?: string): string {
-  if (Platform.OS === 'ios') {
-    return 'https://apps.apple.com/account/subscriptions';
-  }
-  if (productId) {
-    return `https://play.google.com/store/account/subscriptions?sku=${productId}&package=${ANDROID_PACKAGE}`;
-  }
-  return 'https://play.google.com/store/account/subscriptions';
 }
 
 export default function MySubscriptionScreen(): React.JSX.Element {
@@ -92,8 +82,8 @@ export default function MySubscriptionScreen(): React.JSX.Element {
 
   const handleManage = useCallback(() => {
     void Haptics.selectionAsync();
-    const url = manageSubscriptionUrl();
-    Linking.openURL(url).catch(() => {
+    const sku = subscription?.plan?.product_id;
+    openManageSubscription(sku).catch(() => {
       Alert.alert(
         'Unable to open store',
         Platform.OS === 'ios'
@@ -101,7 +91,7 @@ export default function MySubscriptionScreen(): React.JSX.Element {
           : 'Please open the Google Play Store → Menu → Subscriptions.',
       );
     });
-  }, []);
+  }, [subscription?.plan?.product_id]);
 
   const handleRestore = useCallback(async () => {
     setRestoring(true);

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
@@ -19,6 +19,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Linking,
   ScrollView,
   StyleSheet,
   Text,
@@ -266,6 +267,23 @@ export default function SubscriptionPlansScreen(): React.JSX.Element {
             cancelled at least 24 hours before the end of the current period.
             Manage or cancel anytime in your store account.
           </Text>
+          <View style={styles.legalLinkRow}>
+            <TouchableOpacity
+              onPress={() => {
+                void Linking.openURL('https://kiaanverse.com/terms');
+              }}
+            >
+              <Text style={styles.legalLink}>Terms of Service</Text>
+            </TouchableOpacity>
+            <Text style={styles.legalDot}>·</Text>
+            <TouchableOpacity
+              onPress={() => {
+                void Linking.openURL('https://kiaanverse.com/privacy');
+              }}
+            >
+              <Text style={styles.legalLink}>Privacy Policy</Text>
+            </TouchableOpacity>
+          </View>
           <TouchableOpacity onPress={handleRestore} disabled={restoring}>
             <Text style={styles.restoreText}>
               {restoring ? 'Restoring…' : 'Restore purchases'}
@@ -449,6 +467,22 @@ const styles = StyleSheet.create({
     fontFamily: 'Outfit-Medium',
     color: GOLD,
     marginTop: 4,
+  },
+  legalLinkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 2,
+  },
+  legalLink: {
+    fontSize: 12,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.55)',
+    textDecorationLine: 'underline',
+  },
+  legalDot: {
+    fontSize: 12,
+    color: 'rgba(240,235,225,0.35)',
   },
   stickyBottom: {
     position: 'absolute',

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
@@ -1,0 +1,491 @@
+/**
+ * Subscription Plans — Google Play Billing / App Store IAP.
+ *
+ * Shows the three paid tiers (Bhakta, Sadhak, Siddha) with a monthly /
+ * annual toggle. Prices are pulled from the store so they honour the
+ * user's locale and currency (USD, EUR, INR — whatever Play/StoreKit
+ * returns). Purchase is mediated by `purchaseSubscription()`, which
+ * drives the native Billing sheet, verifies the receipt server-side,
+ * then acknowledges on success.
+ *
+ * Policy notes:
+ * - Play / App Store require in-app subscriptions go through their
+ *   billing SDK — no alternative payment methods shown on this screen.
+ * - Prices shown are the store's `localizedPrice` (not hardcoded),
+ *   which is required by Play content policy.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
+import * as Haptics from 'expo-haptics';
+import { LinearGradient } from 'expo-linear-gradient';
+import {
+  DivineScreenWrapper,
+  SacredCard,
+  GoldenDivider,
+  OmLoader,
+} from '@kiaanverse/ui';
+import {
+  getProducts,
+  purchaseSubscription,
+  restorePurchases,
+  TIER_CONFIGS,
+  type BillingPeriod,
+  type IAPProduct,
+} from '@kiaanverse/api';
+import type { SubscriptionTier } from '@kiaanverse/store';
+
+const PAID_TIERS: readonly SubscriptionTier[] = ['bhakta', 'sadhak', 'siddha'];
+
+const TIER_COPY: Record<
+  Exclude<SubscriptionTier, 'free'>,
+  {
+    sanskrit: string;
+    subtitle: string;
+    gradient: readonly [string, string];
+    recommended?: boolean;
+  }
+> = {
+  bhakta: {
+    sanskrit: 'भक्त',
+    subtitle: 'The Devotee',
+    gradient: ['#1B4FBB', '#0E7490'],
+  },
+  sadhak: {
+    sanskrit: 'साधक',
+    subtitle: 'The Sacred Path',
+    gradient: ['#6B3FC4', '#1B4FBB'],
+    recommended: true,
+  },
+  siddha: {
+    sanskrit: 'सिद्ध',
+    subtitle: 'The Realized One',
+    gradient: ['#D4A017', '#F0C040'],
+  },
+};
+
+export default function SubscriptionPlansScreen(): React.JSX.Element {
+  const [billing, setBilling] = useState<BillingPeriod>('monthly');
+  const [selected, setSelected] = useState<Exclude<SubscriptionTier, 'free'>>('sadhak');
+  const [products, setProducts] = useState<IAPProduct[]>([]);
+  const [loadingProducts, setLoadingProducts] = useState(true);
+  const [purchasing, setPurchasing] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const fetched = await getProducts();
+        if (mounted) setProducts(fetched);
+      } catch (err) {
+        console.warn('Failed to load IAP products:', err);
+      } finally {
+        if (mounted) setLoadingProducts(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const priceFor = useCallback(
+    (tier: Exclude<SubscriptionTier, 'free'>, period: BillingPeriod): string => {
+      const match = products.find((p) => p.tier === tier && p.billingPeriod === period);
+      if (match) return match.price;
+      return TIER_CONFIGS[tier].priceDisplay[period].usd;
+    },
+    [products],
+  );
+
+  const handleSubscribe = useCallback(async () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setPurchasing(true);
+    try {
+      await purchaseSubscription(selected, billing, {
+        onComplete: (result) => {
+          void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+          router.replace({
+            pathname: '/(app)/subscription/success',
+            params: { tier: result.tier },
+          });
+        },
+        onError: (message) => {
+          if (message === 'Purchase cancelled.') return;
+          Alert.alert('Purchase unsuccessful', message);
+        },
+      });
+    } finally {
+      setPurchasing(false);
+    }
+  }, [selected, billing]);
+
+  const handleRestore = useCallback(async () => {
+    setRestoring(true);
+    try {
+      const result = await restorePurchases();
+      if (result.success) {
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        Alert.alert(
+          'Purchases restored',
+          `Your ${TIER_CONFIGS[result.tier].name} subscription is active.`,
+          [{ text: 'Continue', onPress: () => router.back() }],
+        );
+      } else {
+        Alert.alert('Nothing to restore', result.error ?? 'No active subscription found.');
+      }
+    } finally {
+      setRestoring(false);
+    }
+  }, []);
+
+  const cta = (() => {
+    const price = priceFor(selected, billing);
+    const period = billing === 'monthly' ? '/month' : '/year';
+    return `Begin with ${TIER_CONFIGS[selected].name} · ${price}${period}`;
+  })();
+
+  if (loadingProducts) {
+    return (
+      <DivineScreenWrapper>
+        <View style={styles.center}>
+          <OmLoader size={48} label="Opening the sacred store…" />
+        </View>
+      </DivineScreenWrapper>
+    );
+  }
+
+  return (
+    <DivineScreenWrapper>
+      <ScrollView
+        style={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 140 }}
+      >
+        <View style={styles.header}>
+          <Text style={styles.title}>Begin Your Sacred Journey</Text>
+          <Text style={styles.subtitle}>
+            Choose the path that calls to your dharma
+          </Text>
+        </View>
+
+        <View style={styles.toggleRow}>
+          {(['monthly', 'yearly'] as const).map((period) => (
+            <TouchableOpacity
+              key={period}
+              style={[styles.toggleBtn, billing === period && styles.toggleBtnActive]}
+              onPress={() => {
+                setBilling(period);
+                void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              }}
+              activeOpacity={0.85}
+            >
+              <Text
+                style={[styles.toggleText, billing === period && styles.toggleTextActive]}
+              >
+                {period === 'monthly' ? 'Monthly' : 'Annual  ·  Save ~40%'}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        {PAID_TIERS.map((tier) => {
+          const copy = TIER_COPY[tier as Exclude<SubscriptionTier, 'free'>];
+          const config = TIER_CONFIGS[tier];
+          const isSelected = selected === tier;
+          const price = priceFor(tier as Exclude<SubscriptionTier, 'free'>, billing);
+          const features = featureListFor(tier);
+
+          return (
+            <TouchableOpacity
+              key={tier}
+              onPress={() => {
+                setSelected(tier as Exclude<SubscriptionTier, 'free'>);
+                void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              }}
+              activeOpacity={0.85}
+              style={styles.planWrapper}
+            >
+              <SacredCard
+                style={StyleSheet.flatten([
+                  styles.planCard,
+                  isSelected && styles.planCardSelected,
+                ])}
+              >
+                {copy.recommended && (
+                  <View style={styles.recommendedBadge}>
+                    <Text style={styles.recommendedText}>Most Popular</Text>
+                  </View>
+                )}
+
+                <View style={styles.planHeader}>
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.planName}>{config.name}</Text>
+                    <Text style={styles.planSanskrit}>{copy.sanskrit}</Text>
+                    <Text style={styles.planSubtitle}>{copy.subtitle}</Text>
+                  </View>
+                  <View style={styles.priceBlock}>
+                    <Text style={styles.price}>{price}</Text>
+                    <Text style={styles.pricePer}>
+                      {billing === 'monthly' ? '/month' : '/year'}
+                    </Text>
+                  </View>
+                </View>
+
+                <GoldenDivider style={{ marginVertical: 12 }} />
+
+                {features.map((f) => (
+                  <View key={f} style={styles.featureRow}>
+                    <Text style={styles.featureDot}>✦</Text>
+                    <Text style={styles.featureText}>{f}</Text>
+                  </View>
+                ))}
+
+                {isSelected && (
+                  <View style={styles.selectedIndicator}>
+                    <Text style={styles.selectedCheck}>✓ Selected</Text>
+                  </View>
+                )}
+              </SacredCard>
+            </TouchableOpacity>
+          );
+        })}
+
+        <View style={styles.legalBlock}>
+          <Text style={styles.legalText}>
+            Billed via Google Play / App Store. Subscriptions auto-renew unless
+            cancelled at least 24 hours before the end of the current period.
+            Manage or cancel anytime in your store account.
+          </Text>
+          <TouchableOpacity onPress={handleRestore} disabled={restoring}>
+            <Text style={styles.restoreText}>
+              {restoring ? 'Restoring…' : 'Restore purchases'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+
+      <View style={styles.stickyBottom}>
+        {purchasing ? (
+          <View style={styles.loadingBtn}>
+            <ActivityIndicator color="#D4A017" />
+            <Text style={styles.loadingText}>Opening sacred payment…</Text>
+          </View>
+        ) : (
+          <TouchableOpacity onPress={handleSubscribe} activeOpacity={0.85}>
+            <LinearGradient
+              colors={TIER_COPY[selected].gradient}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={styles.subscribeBtn}
+            >
+              <Text style={styles.subscribeBtnText}>{cta}</Text>
+              <Text style={styles.subscribeBtnSub}>
+                Cancel anytime in your store settings
+              </Text>
+            </LinearGradient>
+          </TouchableOpacity>
+        )}
+      </View>
+    </DivineScreenWrapper>
+  );
+}
+
+function featureListFor(tier: SubscriptionTier): string[] {
+  const f = TIER_CONFIGS[tier].features;
+  const lines: string[] = [];
+  if (f.kiaanDivineChat) lines.push('KIAAN Divine Chat');
+  if (f.kiaanVoiceCompanion) lines.push('Divine Voice Companion');
+  if (f.kiaanSoulReading) lines.push('Soul Reading insights');
+  if (f.kiaanQuantumDive) lines.push('Quantum Dive journeys');
+  if (f.encryptedJournal) lines.push('Encrypted Sacred Journal');
+  if (f.advancedAnalytics) lines.push('KarmaLytix insights');
+  if (f.offlineAccess) lines.push('Offline access');
+  if (f.dedicatedSupport) lines.push('Dedicated support');
+  else if (f.prioritySupport) lines.push('Priority support');
+  return lines.slice(0, 6);
+}
+
+const GOLD = '#D4A017';
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  header: { paddingTop: 60, paddingHorizontal: 20, paddingBottom: 20 },
+  title: {
+    fontSize: 26,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.5)',
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    marginHorizontal: 16,
+    marginBottom: 20,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 12,
+    padding: 3,
+  },
+  toggleBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  toggleBtnActive: {
+    backgroundColor: 'rgba(212,160,23,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.3)',
+  },
+  toggleText: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Medium',
+    color: 'rgba(240,235,225,0.5)',
+  },
+  toggleTextActive: { color: GOLD },
+  planWrapper: { marginHorizontal: 16, marginBottom: 12 },
+  planCard: {
+    padding: 20,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.1)',
+  },
+  planCardSelected: {
+    borderColor: 'rgba(212,160,23,0.5)',
+    borderWidth: 1.5,
+  },
+  recommendedBadge: {
+    position: 'absolute',
+    top: -1,
+    right: 16,
+    backgroundColor: GOLD,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  recommendedText: {
+    fontSize: 11,
+    fontFamily: 'Outfit-SemiBold',
+    color: '#050714',
+  },
+  planHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  planName: {
+    fontSize: 20,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+  },
+  planSanskrit: {
+    fontSize: 14,
+    fontFamily: 'NotoSansDevanagari-Regular',
+    color: GOLD,
+    marginTop: 1,
+  },
+  planSubtitle: {
+    fontSize: 12,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.4)',
+    marginTop: 3,
+  },
+  priceBlock: { alignItems: 'flex-end' },
+  price: {
+    fontSize: 24,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: GOLD,
+  },
+  pricePer: {
+    fontSize: 12,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.4)',
+  },
+  featureRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+    gap: 8,
+  },
+  featureDot: { fontSize: 10, color: GOLD },
+  featureText: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.8)',
+  },
+  selectedIndicator: { marginTop: 12, alignItems: 'center' },
+  selectedCheck: {
+    fontSize: 13,
+    fontFamily: 'Outfit-SemiBold',
+    color: GOLD,
+  },
+  legalBlock: {
+    marginHorizontal: 20,
+    marginTop: 16,
+    alignItems: 'center',
+    gap: 10,
+  },
+  legalText: {
+    fontSize: 11,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.35)',
+    textAlign: 'center',
+    lineHeight: 16,
+  },
+  restoreText: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Medium',
+    color: GOLD,
+    marginTop: 4,
+  },
+  stickyBottom: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+    paddingTop: 12,
+    backgroundColor: 'rgba(5,7,20,0.97)',
+  },
+  subscribeBtn: {
+    borderRadius: 16,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  subscribeBtnText: {
+    fontSize: 16,
+    fontFamily: 'Outfit-SemiBold',
+    color: '#fff',
+  },
+  subscribeBtnSub: {
+    fontSize: 11,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(255,255,255,0.6)',
+    marginTop: 3,
+  },
+  loadingBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    paddingVertical: 16,
+  },
+  loadingText: {
+    fontSize: 14,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.6)',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/success.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/success.tsx
@@ -1,0 +1,90 @@
+/**
+ * Subscription Success — post-purchase confirmation.
+ *
+ * Reached via `router.replace('/(app)/subscription/success?tier=X')` from
+ * plans.tsx once the receipt has been verified server-side. Displays a
+ * short darshan moment before returning the user to the tabs.
+ */
+
+import React, { useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import * as Haptics from 'expo-haptics';
+import {
+  DivineButton,
+  DivineScreenWrapper,
+} from '@kiaanverse/ui';
+import { TIER_CONFIGS } from '@kiaanverse/api';
+import type { SubscriptionTier } from '@kiaanverse/store';
+
+const VALID_TIERS: ReadonlySet<SubscriptionTier> = new Set([
+  'free',
+  'bhakta',
+  'sadhak',
+  'siddha',
+]);
+
+export default function SubscriptionSuccessScreen(): React.JSX.Element {
+  const params = useLocalSearchParams<{ tier?: string }>();
+  const tier: SubscriptionTier =
+    params.tier && VALID_TIERS.has(params.tier as SubscriptionTier)
+      ? (params.tier as SubscriptionTier)
+      : 'sadhak';
+
+  useEffect(() => {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  }, []);
+
+  const tierName = TIER_CONFIGS[tier].name;
+
+  return (
+    <DivineScreenWrapper>
+      <View style={styles.center}>
+        <Text style={styles.om}>ॐ</Text>
+        <Text style={styles.title}>Your Sankalpa Is Made</Text>
+        <Text style={styles.subtitle}>
+          The sacred path opens before you.{'\n'}
+          Welcome, {tierName}.
+        </Text>
+
+        <View style={styles.button}>
+          <DivineButton
+            title="Begin Your Journey"
+            onPress={() => router.replace('/(tabs)')}
+            variant="primary"
+          />
+        </View>
+      </View>
+    </DivineScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  om: {
+    fontSize: 72,
+    color: '#D4A017',
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontFamily: 'CrimsonText-Regular',
+    color: 'rgba(240,235,225,0.6)',
+    textAlign: 'center',
+    lineHeight: 26,
+    marginBottom: 40,
+  },
+  button: { alignSelf: 'stretch' },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/profile.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/profile.tsx
@@ -1,183 +1,404 @@
 /**
- * Profile Tab
+ * Profile Tab — 1:1 port of kiaanverse.com/m/profile
  *
- * User info, settings, journal, and analytics links.
- * Features cosmic gradient background and golden aura ring on avatar.
+ * Avatar + name + email, subscription tier badge, stats row
+ * (streak · journeys · verses), menu sections (Account, Subscription,
+ * Sacred Tools, Support, Legal), and sign-out.
  */
 
-import React, { useCallback } from 'react';
-import { View, StyleSheet, Pressable, Alert } from 'react-native';
+import React, { useEffect, useState } from 'react';
 import {
-  BookOpen,
-  BarChart3,
-  Settings,
-  Moon,
-  Sun,
-  ChevronRight,
-} from 'lucide-react-native';
-import { Screen, Text, Avatar, SacredDivider, Button, GlowCard, colors, spacing, radii, useTheme } from '@kiaanverse/ui';
-import { useAuthStore, useThemeStore } from '@kiaanverse/store';
-import { useTranslation } from '@kiaanverse/i18n';
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  Image,
+  Alert,
+} from 'react-native';
+import { router } from 'expo-router';
+import * as SecureStore from 'expo-secure-store';
+import * as Haptics from 'expo-haptics';
+import { LinearGradient } from 'expo-linear-gradient';
+import {
+  DivineScreenWrapper,
+  SacredCard,
+  GoldenDivider,
+  OmLoader,
+} from '@kiaanverse/ui';
+import { apiClient } from '@kiaanverse/api';
 
-interface MenuItemProps {
-  icon: React.ReactNode;
-  label: string;
-  onPress: () => void;
+// ── Types ──────────────────────────────────────────────────
+interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  profile_photo_url?: string;
+  subscription_tier: 'free' | 'sadhak' | 'siddha';
+  streak_days: number;
+  journeys_completed: number;
+  verses_read: number;
+  language: string;
+  created_at: string;
 }
 
-function MenuItem({ icon, label, onPress }: MenuItemProps): React.JSX.Element {
-  const { theme } = useTheme();
-  return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.menuItem,
-        pressed && { opacity: 0.7 },
-      ]}
-      accessibilityRole="button"
-    >
-      {icon}
-      <Text variant="body" style={styles.menuLabel}>{label}</Text>
-      <ChevronRight size={18} color={theme.colors.textTertiary} />
-    </Pressable>
-  );
-}
+// ── Menu structure ─────────────────────────────────────────
+const MENU_SECTIONS: ReadonlyArray<{
+  title: string;
+  items: ReadonlyArray<{
+    label: string;
+    route: string;
+    icon: string;
+    gold?: boolean;
+  }>;
+}> = [
+  {
+    title: 'Account',
+    items: [
+      { label: 'Edit Profile',    route: '/(app)/edit-profile',      icon: '✦' },
+      { label: 'Change Password', route: '/(app)/change-password',   icon: '🔒' },
+      { label: 'Language',        route: '/(app)/language-settings', icon: '🌐' },
+      { label: 'Notifications',   route: '/(app)/notifications',     icon: '🔔' },
+    ],
+  },
+  {
+    title: 'Subscription',
+    items: [
+      { label: 'My Subscription', route: '/(app)/subscription',       icon: '✦', gold: true },
+      { label: 'Upgrade Plan',    route: '/(app)/subscription/plans', icon: '⬆', gold: true },
+      { label: 'Billing History', route: '/(app)/billing-history',    icon: '📋' },
+    ],
+  },
+  {
+    title: 'Sacred Tools',
+    items: [
+      { label: 'My Journeys',     route: '/(tabs)/journal',         icon: '🗺' },
+      { label: 'Karma Footprint', route: '/(app)/karma-footprint',  icon: '☸' },
+      { label: 'KarmaLytix',      route: '/(app)/karmalytix',       icon: '📊' },
+    ],
+  },
+  {
+    title: 'Support',
+    items: [
+      { label: 'Help Center', route: '/(app)/help',    icon: '❓' },
+      { label: 'Contact Us',  route: '/(app)/contact', icon: '✉' },
+      { label: 'Rate the App', route: 'external:rate', icon: '⭐' },
+    ],
+  },
+  {
+    title: 'Legal',
+    items: [
+      { label: 'Privacy Policy',   route: '/(app)/privacy',      icon: '📄' },
+      { label: 'Terms of Service', route: '/(app)/terms',        icon: '📄' },
+      { label: 'Data & Privacy',   route: '/(app)/data-privacy', icon: '🛡' },
+    ],
+  },
+];
+
+const TIER_CONFIG: Record<
+  UserProfile['subscription_tier'],
+  { label: string; color: string; bg: string }
+> = {
+  free:   { label: 'Free Seeker', color: 'rgba(240,235,225,0.5)', bg: 'rgba(255,255,255,0.05)' },
+  sadhak: { label: 'Sadhak',      color: '#D4A017',               bg: 'rgba(212,160,23,0.12)' },
+  siddha: { label: 'Siddha',      color: '#F5E27A',               bg: 'rgba(245,226,122,0.15)' },
+};
 
 export default function ProfileScreen(): React.JSX.Element {
-  const { t } = useTranslation('common');
-  const { theme, isDark } = useTheme();
-  const c = theme.colors;
-  const { user, logout } = useAuthStore();
-  const { mode: _mode, setMode } = useThemeStore();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [signingOut, setSigningOut] = useState(false);
 
-  const handleToggleTheme = useCallback(() => {
-    setMode(isDark ? 'light' : 'dark');
-  }, [isDark, setMode]);
+  useEffect(() => {
+    void fetchProfile();
+  }, []);
 
-  const handleLogout = useCallback(() => {
+  const fetchProfile = async () => {
+    try {
+      const { data } = await apiClient.get<UserProfile>('/api/user/me');
+      setProfile(data);
+    } catch (e) {
+      console.error('Profile fetch error:', e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSignOut = () => {
     Alert.alert(
       'Sign Out',
-      'Are you sure you want to sign out?',
+      'Are you sure you want to sign out of Kiaanverse?',
       [
-        { text: t('cancel'), style: 'cancel' },
+        { text: 'Cancel', style: 'cancel' },
         {
           text: 'Sign Out',
           style: 'destructive',
-          onPress: () => void logout(),
+          onPress: async () => {
+            setSigningOut(true);
+            await SecureStore.deleteItemAsync('auth_token');
+            await SecureStore.deleteItemAsync('refresh_token');
+            router.replace('/(auth)/login');
+          },
         },
       ],
     );
-  }, [logout, t]);
+  };
+
+  const handleMenuPress = (route: string) => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    if (route.startsWith('external:')) {
+      // TODO: handle external links (Rate app → Play Store / App Store)
+      return;
+    }
+    router.push(route as never);
+  };
+
+  if (loading) {
+    return (
+      <DivineScreenWrapper>
+        <View style={styles.center}>
+          <OmLoader size={48} label="Loading your sacred profile…" />
+        </View>
+      </DivineScreenWrapper>
+    );
+  }
+
+  const tier = TIER_CONFIG[profile?.subscription_tier ?? 'free'];
 
   return (
-    <Screen scroll gradient>
-      <View style={styles.profileSection}>
-        {/* Avatar with golden aura ring */}
-        <View style={styles.avatarContainer}>
-          <View style={styles.auraRing}>
-            <Avatar name={user?.name ?? 'Seeker'} size={72} />
+    <DivineScreenWrapper>
+      <ScrollView
+        style={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 100 }}
+      >
+        {/* ── AVATAR SECTION ── */}
+        <View style={styles.avatarSection}>
+          <View style={styles.avatarWrapper}>
+            {profile?.profile_photo_url ? (
+              <Image source={{ uri: profile.profile_photo_url }} style={styles.avatar} />
+            ) : (
+              <LinearGradient colors={['#1B4FBB', '#0E7490']} style={styles.avatarPlaceholder}>
+                <Text style={styles.avatarInitial}>
+                  {profile?.name?.charAt(0)?.toUpperCase() ?? 'S'}
+                </Text>
+              </LinearGradient>
+            )}
+            {/* Gold ring around avatar */}
+            <View style={styles.avatarRing} />
+          </View>
+
+          <Text style={styles.name}>{profile?.name ?? 'Sacred Seeker'}</Text>
+          <Text style={styles.email}>{profile?.email}</Text>
+
+          {/* Subscription tier badge */}
+          <View style={[styles.tierBadge, { backgroundColor: tier.bg }]}>
+            <Text style={[styles.tierText, { color: tier.color }]}>✦ {tier.label}</Text>
           </View>
         </View>
-        <Text variant="h2">{user?.name ?? 'Seeker'}</Text>
-        <Text variant="bodySmall" color={c.textTertiary}>
-          {user?.email ?? ''}
-        </Text>
-        <View style={styles.tierBadge}>
-          <Text variant="caption" color={colors.primary[300]}>
-            {user?.subscriptionTier ?? 'FREE'} Plan
+
+        {/* ── STATS ROW ── */}
+        <SacredCard style={styles.statsCard}>
+          <StatItem value={profile?.streak_days ?? 0}         label="Day Streak"  unit="🔥" />
+          <View style={styles.statDivider} />
+          <StatItem value={profile?.journeys_completed ?? 0}  label="Journeys"    unit="☸" />
+          <View style={styles.statDivider} />
+          <StatItem value={profile?.verses_read ?? 0}         label="Verses Read" unit="📖" />
+        </SacredCard>
+
+        {/* ── MENU SECTIONS ── */}
+        {MENU_SECTIONS.map((section) => (
+          <View key={section.title} style={styles.section}>
+            <Text style={styles.sectionTitle}>{section.title}</Text>
+            <SacredCard style={styles.sectionCard}>
+              {section.items.map((item, idx) => (
+                <React.Fragment key={item.route}>
+                  <TouchableOpacity
+                    style={styles.menuItem}
+                    onPress={() => handleMenuPress(item.route)}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={styles.menuIcon}>{item.icon}</Text>
+                    <Text style={[styles.menuLabel, item.gold && { color: '#D4A017' }]}>
+                      {item.label}
+                    </Text>
+                    <Text style={styles.menuChevron}>›</Text>
+                  </TouchableOpacity>
+                  {idx < section.items.length - 1 && (
+                    <GoldenDivider style={{ marginHorizontal: 16 }} />
+                  )}
+                </React.Fragment>
+              ))}
+            </SacredCard>
+          </View>
+        ))}
+
+        {/* ── SIGN OUT ── */}
+        <TouchableOpacity
+          style={styles.signOutBtn}
+          onPress={handleSignOut}
+          disabled={signingOut}
+        >
+          <Text style={styles.signOutText}>
+            {signingOut ? 'Signing out…' : 'Sign Out'}
           </Text>
-        </View>
-      </View>
+        </TouchableOpacity>
 
-      <SacredDivider />
-
-      <GlowCard style={styles.menuCard}>
-        <MenuItem
-          icon={<BookOpen size={20} color={c.accent} />}
-          label="Sacred Journal"
-          onPress={() => {}}
-        />
-        <View style={[styles.menuDivider, { backgroundColor: c.divider }]} />
-        <MenuItem
-          icon={<BarChart3 size={20} color={c.accent} />}
-          label="Analytics"
-          onPress={() => {}}
-        />
-        <View style={[styles.menuDivider, { backgroundColor: c.divider }]} />
-        <MenuItem
-          icon={<Settings size={20} color={c.accent} />}
-          label="Settings"
-          onPress={() => {}}
-        />
-        <View style={[styles.menuDivider, { backgroundColor: c.divider }]} />
-        <MenuItem
-          icon={isDark
-            ? <Sun size={20} color={c.accent} />
-            : <Moon size={20} color={c.accent} />
-          }
-          label={isDark ? 'Light Mode' : 'Dark Mode'}
-          onPress={handleToggleTheme}
-        />
-      </GlowCard>
-
-      <View style={styles.logoutSection}>
-        <Button
-          title="Sign Out"
-          variant="ghost"
-          onPress={handleLogout}
-        />
-      </View>
-    </Screen>
+        {/* Member since */}
+        {profile?.created_at && (
+          <Text style={styles.memberSince}>
+            Sacred seeker since{' '}
+            {new Date(profile.created_at).toLocaleDateString('en-US', {
+              month: 'long',
+              year: 'numeric',
+            })}
+          </Text>
+        )}
+      </ScrollView>
+    </DivineScreenWrapper>
   );
 }
 
+function StatItem({
+  value,
+  label,
+  unit,
+}: {
+  value: number;
+  label: string;
+  unit: string;
+}): React.JSX.Element {
+  return (
+    <View style={styles.stat}>
+      <Text style={styles.statValue}>{value}</Text>
+      <Text style={styles.statUnit}>{unit}</Text>
+      <Text style={styles.statLabel}>{label}</Text>
+    </View>
+  );
+}
+
+const GOLD = '#D4A017';
 const styles = StyleSheet.create({
-  profileSection: {
+  scroll: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  avatarSection: { alignItems: 'center', paddingTop: 60, paddingBottom: 24 },
+  avatarWrapper: { position: 'relative', marginBottom: 12 },
+  avatar: { width: 80, height: 80, borderRadius: 40 },
+  avatarPlaceholder: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
     alignItems: 'center',
-    gap: spacing.sm,
-    paddingTop: spacing.xl,
-    paddingBottom: spacing.xl,
+    justifyContent: 'center',
   },
-  avatarContainer: {
-    alignItems: 'center',
+  avatarInitial: {
+    fontSize: 32,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#fff',
   },
-  auraRing: {
-    padding: 4,
-    borderRadius: radii.full,
-    borderWidth: 2,
-    borderColor: colors.divine.aura,
-    shadowColor: colors.divine.aura,
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0.4,
-    shadowRadius: 16,
-    elevation: 8,
+  avatarRing: {
+    position: 'absolute',
+    top: -3,
+    left: -3,
+    right: -3,
+    bottom: -3,
+    borderRadius: 43,
+    borderWidth: 1.5,
+    borderColor: 'rgba(212,160,23,0.5)',
+  },
+  name: {
+    fontSize: 22,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: '#F0EBE1',
+    marginBottom: 4,
+  },
+  email: {
+    fontSize: 13,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.45)',
+    marginBottom: 10,
   },
   tierBadge: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs,
-    borderRadius: radii.full,
-    backgroundColor: colors.alpha.goldLight,
+    paddingHorizontal: 14,
+    paddingVertical: 5,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.2)',
   },
-  menuCard: {
-    padding: 0,
-    overflow: 'hidden',
+  tierText: {
+    fontSize: 12,
+    fontFamily: 'Outfit-SemiBold',
+    letterSpacing: 0.08,
   },
+  statsCard: {
+    flexDirection: 'row',
+    marginHorizontal: 16,
+    marginBottom: 24,
+    padding: 16,
+  },
+  stat: { flex: 1, alignItems: 'center' },
+  statValue: {
+    fontSize: 26,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: GOLD,
+  },
+  statUnit: { fontSize: 14, marginTop: -4 },
+  statLabel: {
+    fontSize: 11,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.45)',
+    marginTop: 2,
+  },
+  statDivider: { width: 1, backgroundColor: 'rgba(212,160,23,0.15)' },
+  section: { marginHorizontal: 16, marginBottom: 16 },
+  sectionTitle: {
+    fontSize: 11,
+    fontFamily: 'Outfit-SemiBold',
+    color: 'rgba(240,235,225,0.4)',
+    letterSpacing: 0.12,
+    textTransform: 'uppercase',
+    marginBottom: 8,
+    paddingLeft: 4,
+  },
+  sectionCard: { padding: 0, overflow: 'hidden' },
   menuItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.lg,
-    gap: spacing.md,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
   },
+  menuIcon: { fontSize: 16, width: 28 },
   menuLabel: {
     flex: 1,
+    fontSize: 15,
+    fontFamily: 'Outfit-Regular',
+    color: '#F0EBE1',
   },
-  menuDivider: {
-    height: StyleSheet.hairlineWidth,
-    marginHorizontal: spacing.lg,
+  menuChevron: {
+    fontSize: 20,
+    color: 'rgba(240,235,225,0.3)',
+    fontWeight: '300',
   },
-  logoutSection: {
-    marginTop: spacing.xl,
+  signOutBtn: {
+    marginHorizontal: 16,
+    marginTop: 8,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(239,68,68,0.25)',
     alignItems: 'center',
+    backgroundColor: 'rgba(239,68,68,0.05)',
+  },
+  signOutText: {
+    fontSize: 15,
+    fontFamily: 'Outfit-Medium',
+    color: '#EF4444',
+  },
+  memberSince: {
+    fontSize: 11,
+    fontFamily: 'Outfit-Regular',
+    color: 'rgba(240,235,225,0.25)',
+    textAlign: 'center',
+    marginTop: 16,
   },
 });

--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -294,6 +294,9 @@ function AppContent(): React.JSX.Element {
 
           {/* Settings */}
           <Stack.Screen name="settings" />
+
+          {/* Profile sub-screens (notifications, language, billing, legal, etc.) */}
+          <Stack.Screen name="(app)" />
         </Stack>
       </AuthGate>
     </View>

--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -32,7 +32,13 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ThemeProvider, useTheme, colors, LoadingMandala } from '@kiaanverse/ui';
 import { I18nProvider } from '@kiaanverse/i18n';
-import { api, type SyncQueueItem } from '@kiaanverse/api';
+import {
+  api,
+  type SyncQueueItem,
+  initializeIAP,
+  disconnectIAP,
+  setIapAccountTag,
+} from '@kiaanverse/api';
 import { useAuthStore, useThemeStore, useUserPreferencesStore, useSyncQueueStore, startSyncOnForeground, useSubscriptionStore } from '@kiaanverse/store';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import { useNotifications } from '../hooks/useNotifications';
@@ -147,7 +153,7 @@ function AuthGate({ children }: { children: React.ReactNode }): React.JSX.Elemen
 
 function AppContent(): React.JSX.Element {
   const { theme } = useTheme();
-  const { status, initialize, checkBiometricAvailability } = useAuthStore();
+  const { status, user, initialize, checkBiometricAvailability } = useAuthStore();
   const hydrateSubscription = useSubscriptionStore((s) => s.hydrate);
   const { isOnline } = useNetworkStatus();
   const pendingCount = useSyncQueueStore((s) => s.queue.length);
@@ -210,6 +216,26 @@ function AppContent(): React.JSX.Element {
     const cleanup = startSyncOnForeground(executeSyncItem);
     return cleanup;
   }, []);
+
+  // Play Billing / StoreKit lifecycle — connect when the user is signed
+  // in so `flushFailedPurchasesCachedAsPendingAndroid` can replay any
+  // purchase cached by Play from a prior crash, and disconnect on logout
+  // to release the native connection. The `setIapAccountTag` call binds
+  // each purchase to the signed-in user so replayed receipts can't be
+  // applied to someone else's account.
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      setIapAccountTag(null);
+      return;
+    }
+    setIapAccountTag(user?.id ?? null);
+    void initializeIAP().catch((err) => {
+      if (__DEV__) console.warn('[iap] initializeIAP failed:', err);
+    });
+    return () => {
+      void disconnectIAP().catch(() => undefined);
+    };
+  }, [status, user?.id]);
 
   // Initialize notification system (channels, handlers, scheduling)
   useNotifications();

--- a/kiaanverse-mobile/apps/mobile/package.json
+++ b/kiaanverse-mobile/apps/mobile/package.json
@@ -69,6 +69,7 @@
     "react-hook-form": "^7.71.2",
     "react-native": "0.74.5",
     "react-native-gesture-handler": "~2.16.0",
+    "react-native-iap": "^12.15.0",
     "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "~3.10.0",
     "react-native-safe-area-context": "4.10.5",

--- a/kiaanverse-mobile/packages/api/src/index.ts
+++ b/kiaanverse-mobile/packages/api/src/index.ts
@@ -50,6 +50,8 @@ export {
   purchaseSubscription,
   restorePurchases,
   verifyReceipt,
+  setIapAccountTag,
+  openManageSubscription,
   IAPError,
   type IAPProduct,
   type PurchaseResult,

--- a/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
+++ b/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
@@ -1,18 +1,47 @@
 /**
  * In-App Purchase Service for Kiaanverse — 4-Tier Model (March 2026)
  *
- * Stub implementation — expo-in-app-purchases was removed because it is
- * deprecated and incompatible with Gradle 8.8+. Replace with
- * react-native-iap or expo-purchase when ready for production IAP.
+ * Play Billing / StoreKit implementation on top of react-native-iap 12.x.
  *
- * All public functions maintain the same signature so callers
- * (subscription.tsx, store) compile without changes.
+ * Design:
+ * - Module-scoped connection + listeners attached once at first init. The
+ *   Play / StoreKit stores fire purchase events asynchronously (even after
+ *   app restart), so listeners MUST outlive any single screen.
+ * - Purchases are never finished (acknowledged) until the backend has
+ *   verified the receipt. This is required by Play: an unacknowledged
+ *   purchase auto-refunds after 72h, which is a feature (server failure
+ *   → user not charged), not a bug.
+ * - Pending promise resolvers are keyed by productId so `purchaseSubscription`
+ *   can await the event-loop outcome instead of the SDK's immediate return.
+ * - Android subscriptions require an `offerToken` from the fetched
+ *   SubscriptionAndroid — we cache the store payload so `requestSubscription`
+ *   can look it up.
+ *
+ * Public API is unchanged from the prior stub so existing callers
+ * (subscription.tsx, store) compile without edits.
  */
 
-import { Platform } from 'react-native';
+import { Platform, type EmitterSubscription } from 'react-native';
+import {
+  initConnection,
+  endConnection,
+  getSubscriptions,
+  getAvailablePurchases,
+  requestSubscription,
+  finishTransaction,
+  purchaseUpdatedListener,
+  purchaseErrorListener,
+  flushFailedPurchasesCachedAsPendingAndroid,
+  type Subscription,
+  type SubscriptionAndroid,
+  type SubscriptionIOS,
+  type SubscriptionPurchase,
+  type ProductPurchase,
+  type PurchaseError,
+} from 'react-native-iap';
+
 import { apiClient } from '../client';
 import {
-  ALL_PRODUCT_IDS,
   IAP_PRODUCT_IDS,
   TIER_CONFIGS,
   type SubscriptionTier,
@@ -20,7 +49,7 @@ import {
 } from './constants';
 
 // ---------------------------------------------------------------------------
-// Types
+// Types (unchanged — callers depend on these)
 // ---------------------------------------------------------------------------
 
 export interface IAPProduct {
@@ -54,23 +83,207 @@ export interface ReceiptVerificationResponse {
   error?: string;
 }
 
+export class IAPError extends Error {
+  code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'IAPError';
+    this.code = code;
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Stub implementations (expo-in-app-purchases removed)
+// Module state
 // ---------------------------------------------------------------------------
 
-let isInitialized = false;
+let connectionPromise: Promise<boolean> | null = null;
+let purchaseSub: EmitterSubscription | null = null;
+let errorSub: EmitterSubscription | null = null;
+
+/** Cached store payload — needed on Android to resolve the offerToken. */
+let cachedSubscriptions: Subscription[] = [];
+
+/** Pending resolvers keyed by productId so purchaseSubscription can await. */
+type Resolver = (result: PurchaseResult) => void;
+const pendingResolvers: Map<string, Resolver> = new Map();
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function productIdToTier(productId: string): SubscriptionTier {
+  if (productId.includes('bhakta')) return 'bhakta';
+  if (productId.includes('sadhak')) return 'sadhak';
+  if (productId.includes('siddha')) return 'siddha';
+  return 'free';
+}
+
+function productIdToBilling(productId: string): BillingPeriod {
+  return productId.includes('yearly') ? 'yearly' : 'monthly';
+}
+
+function resolvePending(productId: string, result: PurchaseResult): void {
+  const resolver = pendingResolvers.get(productId);
+  if (resolver) {
+    pendingResolvers.delete(productId);
+    resolver(result);
+  }
+}
+
+/**
+ * Extract the platform-appropriate receipt token.
+ * - Android: `purchaseToken` (required for server-side verification via
+ *   Google Play Developer API).
+ * - iOS: `transactionReceipt` (StoreKit base64-encoded receipt).
+ */
+function extractReceipt(purchase: ProductPurchase | SubscriptionPurchase): string {
+  if (Platform.OS === 'android') {
+    return purchase.purchaseToken ?? purchase.transactionReceipt ?? '';
+  }
+  return purchase.transactionReceipt ?? '';
+}
+
+/**
+ * Handle a purchase event: verify with backend → finish transaction →
+ * resolve the pending promise. We intentionally do NOT finish the
+ * transaction before verification — if verification fails (or the device
+ * dies), Play auto-refunds after 72h, which is the correct outcome.
+ */
+async function handlePurchaseEvent(
+  purchase: ProductPurchase | SubscriptionPurchase,
+): Promise<void> {
+  const productId = purchase.productId;
+  const receipt = extractReceipt(purchase);
+
+  if (!receipt) {
+    resolvePending(productId, {
+      success: false,
+      tier: 'free',
+      error: 'Purchase receipt is missing — please contact support.',
+    });
+    return;
+  }
+
+  try {
+    const verification = await verifyReceipt(receipt, productId);
+
+    if (!verification.valid) {
+      resolvePending(productId, {
+        success: false,
+        tier: 'free',
+        error: verification.error ?? 'Receipt verification failed.',
+      });
+      return;
+    }
+
+    // Subscriptions on Android must be acknowledged within 3 days or Play
+    // auto-refunds. `finishTransaction` with isConsumable=false sends the
+    // acknowledge call. On iOS this finishes the StoreKit transaction.
+    try {
+      await finishTransaction({ purchase, isConsumable: false });
+    } catch (finishErr) {
+      // Verification already succeeded — server-side truth is the subscription
+      // is active. Log and move on; Play will retry acknowledge on next
+      // foreground via flushFailedPurchasesCachedAsPendingAndroid().
+      console.warn('IAP: finishTransaction failed post-verify:', finishErr);
+    }
+
+    const success: PurchaseResult = {
+      success: true,
+      tier: verification.tier as SubscriptionTier,
+    };
+    if (verification.expires_at) success.expiresAt = verification.expires_at;
+    resolvePending(productId, success);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Receipt verification error';
+    resolvePending(productId, { success: false, tier: 'free', error: message });
+  }
+}
+
+function handlePurchaseError(error: PurchaseError): void {
+  // User cancellation is not a failure — Play reports code E_USER_CANCELLED,
+  // iOS reports paymentCancelled. Surface distinct copy so the UI can suppress
+  // an error toast in that case.
+  const isCancelled =
+    error.code === 'E_USER_CANCELLED' || error.code === 'E_USER_ERROR';
+
+  // We don't know which productId this error belongs to (react-native-iap
+  // doesn't expose it on the error object reliably), so reject all pending.
+  const message = isCancelled
+    ? 'Purchase cancelled.'
+    : error.message ?? 'Purchase failed. Please try again.';
+
+  for (const [productId, resolver] of pendingResolvers) {
+    pendingResolvers.delete(productId);
+    resolver({ success: false, tier: 'free', error: message });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 export async function initializeIAP(): Promise<void> {
-  isInitialized = true;
-  console.warn('IAP: using stub — expo-in-app-purchases removed. Integrate react-native-iap for production.');
+  if (!connectionPromise) {
+    connectionPromise = initConnection();
+  }
+
+  const connected = await connectionPromise;
+  if (!connected) {
+    connectionPromise = null;
+    throw new IAPError('Store connection failed', 'E_CONNECTION_FAILED');
+  }
+
+  // Android: replay any pending purchases cached by Play (e.g. user paid
+  // but app crashed before acknowledge). Required per Play Billing docs.
+  if (Platform.OS === 'android') {
+    try {
+      await flushFailedPurchasesCachedAsPendingAndroid();
+    } catch {
+      // non-fatal — the purchase listener will still pick up new events
+    }
+  }
+
+  // Attach listeners exactly once. Screens mount and unmount but purchases
+  // can arrive at any time (e.g. asynchronous Play grace period).
+  if (!purchaseSub) {
+    purchaseSub = purchaseUpdatedListener((event) => {
+      void handlePurchaseEvent(event);
+    });
+  }
+  if (!errorSub) {
+    errorSub = purchaseErrorListener(handlePurchaseError);
+  }
 }
 
 export async function disconnectIAP(): Promise<void> {
-  isInitialized = false;
+  purchaseSub?.remove();
+  errorSub?.remove();
+  purchaseSub = null;
+  errorSub = null;
+  connectionPromise = null;
+  cachedSubscriptions = [];
+  pendingResolvers.clear();
+  try {
+    await endConnection();
+  } catch {
+    // safe to swallow — endConnection is idempotent
+  }
 }
 
 export async function getProducts(): Promise<IAPProduct[]> {
-  return getDefaultProducts();
+  await initializeIAP();
+
+  try {
+    const platform: 'ios' | 'android' = Platform.OS === 'ios' ? 'ios' : 'android';
+    const skus = Object.values(IAP_PRODUCT_IDS).map((entry) => entry[platform]);
+    cachedSubscriptions = await getSubscriptions({ skus });
+
+    return cachedSubscriptions.map(mapSubscriptionToIAPProduct);
+  } catch (err) {
+    console.warn('IAP: getSubscriptions failed, returning fallback config:', err);
+    return getFallbackProducts();
+  }
 }
 
 export async function purchaseSubscription(
@@ -81,22 +294,137 @@ export async function purchaseSubscription(
     onError?: (error: string) => void;
   },
 ): Promise<void> {
-  callbacks?.onError?.('In-app purchases are not yet available. Please subscribe via the web at kiaanverse.com/pricing');
+  if (tier === 'free') {
+    callbacks?.onError?.('Cannot purchase the free tier.');
+    return;
+  }
+
+  try {
+    await initializeIAP();
+
+    // Make sure we have the store payload so we can find the offerToken on
+    // Android. Harmless on iOS.
+    if (cachedSubscriptions.length === 0) {
+      await getProducts();
+    }
+
+    const platform = Platform.OS === 'ios' ? 'ios' : 'android';
+    const tierKey = `${tier.toUpperCase()}_${billingPeriod.toUpperCase()}` as
+      | 'BHAKTA_MONTHLY'
+      | 'BHAKTA_YEARLY'
+      | 'SADHAK_MONTHLY'
+      | 'SADHAK_YEARLY'
+      | 'SIDDHA_MONTHLY'
+      | 'SIDDHA_YEARLY';
+    const sku = IAP_PRODUCT_IDS[tierKey][platform];
+
+    // Register a resolver so we can convert the async listener event back
+    // into the callback-based API our callers expect.
+    const result = await new Promise<PurchaseResult>((resolve) => {
+      pendingResolvers.set(sku, resolve);
+
+      if (Platform.OS === 'android') {
+        const androidSub = cachedSubscriptions.find(
+          (s): s is SubscriptionAndroid =>
+            'subscriptionOfferDetails' in s && s.productId === sku,
+        );
+        const offerToken = androidSub?.subscriptionOfferDetails?.[0]?.offerToken;
+
+        if (!offerToken) {
+          pendingResolvers.delete(sku);
+          resolve({
+            success: false,
+            tier: 'free',
+            error:
+              'This plan is not yet available on the Play Store. Please try again later.',
+          });
+          return;
+        }
+
+        void requestSubscription({
+          sku,
+          subscriptionOffers: [{ sku, offerToken }],
+        }).catch((err: unknown) => {
+          pendingResolvers.delete(sku);
+          const message = err instanceof Error ? err.message : 'Purchase failed.';
+          resolve({ success: false, tier: 'free', error: message });
+        });
+      } else {
+        void requestSubscription({ sku }).catch((err: unknown) => {
+          pendingResolvers.delete(sku);
+          const message = err instanceof Error ? err.message : 'Purchase failed.';
+          resolve({ success: false, tier: 'free', error: message });
+        });
+      }
+    });
+
+    if (result.success) {
+      callbacks?.onComplete?.(result);
+    } else {
+      callbacks?.onError?.(result.error ?? 'Purchase did not complete.');
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unexpected purchase error';
+    callbacks?.onError?.(message);
+  }
 }
 
 export async function restorePurchases(): Promise<PurchaseResult> {
-  return {
-    success: false,
-    tier: 'free',
-    error: 'In-app purchase restore is not yet available. Please contact support.',
-  };
+  try {
+    await initializeIAP();
+
+    const purchases = await getAvailablePurchases();
+    if (purchases.length === 0) {
+      return {
+        success: false,
+        tier: 'free',
+        error: 'No active subscriptions found on this account.',
+      };
+    }
+
+    // Verify the most recent purchase with our backend. The server is the
+    // source of truth for tier/expiry.
+    const latest = purchases.reduce((a, b) =>
+      (a.transactionDate ?? 0) > (b.transactionDate ?? 0) ? a : b,
+    );
+    const receipt = extractReceipt(latest);
+    if (!receipt) {
+      return { success: false, tier: 'free', error: 'Restore receipt missing.' };
+    }
+
+    const verification = await verifyReceipt(receipt, latest.productId);
+    if (!verification.valid) {
+      return {
+        success: false,
+        tier: 'free',
+        error: verification.error ?? 'Subscription is no longer active.',
+      };
+    }
+
+    // Acknowledge restored purchases if they weren't previously acknowledged.
+    try {
+      await finishTransaction({ purchase: latest, isConsumable: false });
+    } catch {
+      // non-fatal
+    }
+
+    const restored: PurchaseResult = {
+      success: true,
+      tier: verification.tier as SubscriptionTier,
+    };
+    if (verification.expires_at) restored.expiresAt = verification.expires_at;
+    return restored;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Restore failed';
+    return { success: false, tier: 'free', error: message };
+  }
 }
 
 export async function verifyReceipt(
   receipt: string,
   productId: string,
 ): Promise<ReceiptVerificationResponse> {
-  const platform = Platform.OS === 'ios' ? 'ios' : 'android';
+  const platform: 'ios' | 'android' = Platform.OS === 'ios' ? 'ios' : 'android';
   try {
     const response = await apiClient.post<ReceiptVerificationResponse>(
       '/api/subscription/verify',
@@ -104,85 +432,81 @@ export async function verifyReceipt(
     );
     return response.data;
   } catch {
-    return { valid: false, tier: 'free', expires_at: null, error: 'Receipt validation failed.' };
+    return {
+      valid: false,
+      tier: 'free',
+      expires_at: null,
+      error: 'Receipt validation failed.',
+    };
   }
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Mappers / fallbacks
 // ---------------------------------------------------------------------------
 
-export class IAPError extends Error {
-  code: string;
-  constructor(message: string, code: string) {
-    super(message);
-    this.name = 'IAPError';
-    this.code = code;
+function mapSubscriptionToIAPProduct(sub: Subscription): IAPProduct {
+  const productId = sub.productId;
+  const tier = productIdToTier(productId);
+  const billingPeriod = productIdToBilling(productId);
+
+  // Android v5 subscription payload
+  if ('subscriptionOfferDetails' in sub) {
+    const android = sub as SubscriptionAndroid;
+    const phase =
+      android.subscriptionOfferDetails?.[0]?.pricingPhases?.pricingPhaseList?.[0];
+    return {
+      productId,
+      title: android.title || TIER_CONFIGS[tier].name,
+      description: android.description || TIER_CONFIGS[tier].description,
+      price: phase?.formattedPrice ?? TIER_CONFIGS[tier].priceDisplay[billingPeriod].usd,
+      priceAmountMicros: Number(phase?.priceAmountMicros ?? 0),
+      priceCurrencyCode: phase?.priceCurrencyCode ?? 'USD',
+      tier,
+      billingPeriod,
+    };
   }
+
+  // iOS StoreKit payload
+  const ios = sub as SubscriptionIOS;
+  return {
+    productId,
+    title: ios.title || TIER_CONFIGS[tier].name,
+    description: ios.description || TIER_CONFIGS[tier].description,
+    price: ios.localizedPrice ?? TIER_CONFIGS[tier].priceDisplay[billingPeriod].usd,
+    priceAmountMicros: Math.round(Number(ios.price ?? 0) * 1_000_000),
+    priceCurrencyCode: ios.currency ?? 'USD',
+    tier,
+    billingPeriod,
+  };
 }
 
-function getDefaultProducts(): IAPProduct[] {
+/** Used when the store is unavailable (dev environment, airplane mode). */
+function getFallbackProducts(): IAPProduct[] {
   const platform = Platform.OS === 'ios' ? 'ios' : 'android';
-  return [
-    {
-      productId: IAP_PRODUCT_IDS.BHAKTA_MONTHLY[platform],
-      title: TIER_CONFIGS.bhakta.name,
-      description: TIER_CONFIGS.bhakta.description,
-      price: '$6.99',
-      priceAmountMicros: 6990000,
-      priceCurrencyCode: 'USD',
-      tier: 'bhakta',
-      billingPeriod: 'monthly',
-    },
-    {
-      productId: IAP_PRODUCT_IDS.BHAKTA_YEARLY[platform],
-      title: TIER_CONFIGS.bhakta.name,
-      description: TIER_CONFIGS.bhakta.description,
-      price: '$59.99',
-      priceAmountMicros: 59990000,
-      priceCurrencyCode: 'USD',
-      tier: 'bhakta',
-      billingPeriod: 'yearly',
-    },
-    {
-      productId: IAP_PRODUCT_IDS.SADHAK_MONTHLY[platform],
-      title: TIER_CONFIGS.sadhak.name,
-      description: TIER_CONFIGS.sadhak.description,
-      price: '$12.99',
-      priceAmountMicros: 12990000,
-      priceCurrencyCode: 'USD',
-      tier: 'sadhak',
-      billingPeriod: 'monthly',
-    },
-    {
-      productId: IAP_PRODUCT_IDS.SADHAK_YEARLY[platform],
-      title: TIER_CONFIGS.sadhak.name,
-      description: TIER_CONFIGS.sadhak.description,
-      price: '$109.99',
-      priceAmountMicros: 109990000,
-      priceCurrencyCode: 'USD',
-      tier: 'sadhak',
-      billingPeriod: 'yearly',
-    },
-    {
-      productId: IAP_PRODUCT_IDS.SIDDHA_MONTHLY[platform],
-      title: TIER_CONFIGS.siddha.name,
-      description: TIER_CONFIGS.siddha.description,
-      price: '$22.99',
-      priceAmountMicros: 22990000,
-      priceCurrencyCode: 'USD',
-      tier: 'siddha',
-      billingPeriod: 'monthly',
-    },
-    {
-      productId: IAP_PRODUCT_IDS.SIDDHA_YEARLY[platform],
-      title: TIER_CONFIGS.siddha.name,
-      description: TIER_CONFIGS.siddha.description,
-      price: '$199.99',
-      priceAmountMicros: 199990000,
-      priceCurrencyCode: 'USD',
-      tier: 'siddha',
-      billingPeriod: 'yearly',
-    },
-  ];
+  const tiers: SubscriptionTier[] = ['bhakta', 'sadhak', 'siddha'];
+  const periods: BillingPeriod[] = ['monthly', 'yearly'];
+
+  return tiers.flatMap((tier) =>
+    periods.map((period) => {
+      const tierKey = `${tier.toUpperCase()}_${period.toUpperCase()}` as
+        | 'BHAKTA_MONTHLY'
+        | 'BHAKTA_YEARLY'
+        | 'SADHAK_MONTHLY'
+        | 'SADHAK_YEARLY'
+        | 'SIDDHA_MONTHLY'
+        | 'SIDDHA_YEARLY';
+      const config = TIER_CONFIGS[tier];
+      return {
+        productId: IAP_PRODUCT_IDS[tierKey][platform],
+        title: config.name,
+        description: config.description,
+        price: config.priceDisplay[period].usd,
+        priceAmountMicros: Math.round(config.prices[period].usd * 1_000_000),
+        priceCurrencyCode: 'USD',
+        tier,
+        billingPeriod: period,
+      };
+    }),
+  );
 }

--- a/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
+++ b/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
@@ -4,18 +4,25 @@
  * Play Billing / StoreKit implementation on top of react-native-iap 12.x.
  *
  * Design:
- * - Module-scoped connection + listeners attached once at first init. The
- *   Play / StoreKit stores fire purchase events asynchronously (even after
- *   app restart), so listeners MUST outlive any single screen.
+ * - Module-scoped connection + listeners attached once, stored on
+ *   `globalThis` so they survive Metro hot reloads without duplicating
+ *   native subscriptions (a common source of double-finishTransaction
+ *   bugs in dev).
  * - Purchases are never finished (acknowledged) until the backend has
- *   verified the receipt. This is required by Play: an unacknowledged
- *   purchase auto-refunds after 72h, which is a feature (server failure
- *   → user not charged), not a bug.
- * - Pending promise resolvers are keyed by productId so `purchaseSubscription`
- *   can await the event-loop outcome instead of the SDK's immediate return.
- * - Android subscriptions require an `offerToken` from the fetched
- *   SubscriptionAndroid — we cache the store payload so `requestSubscription`
- *   can look it up.
+ *   verified the receipt. Play auto-refunds unacknowledged purchases
+ *   after 72h — that is the safety net: if verification fails or the
+ *   device dies, the user is not charged.
+ * - Android PENDING purchases (cash, direct carrier billing) are NOT
+ *   verified or acknowledged. They are held by Play until settlement,
+ *   at which point Play re-emits the event as PURCHASED.
+ * - Every purchase is tagged with the signed-in user id
+ *   (`obfuscatedAccountIdAndroid` / `appAccountToken`) so the backend
+ *   can reject receipts replayed from other accounts.
+ * - Pending promise resolvers are keyed by productId so
+ *   `purchaseSubscription` can await the event-loop outcome, with a
+ *   2-minute ceiling so promises can never hang.
+ * - Receipt verification is retried once with short backoff; a purchase
+ *   that fails to verify is intentionally left unacknowledged.
  *
  * Public API is unchanged from the prior stub so existing callers
  * (subscription.tsx, store) compile without edits.
@@ -32,6 +39,8 @@ import {
   purchaseUpdatedListener,
   purchaseErrorListener,
   flushFailedPurchasesCachedAsPendingAndroid,
+  deepLinkToSubscriptions,
+  PurchaseStateAndroid,
   type Subscription,
   type SubscriptionAndroid,
   type SubscriptionIOS,
@@ -49,7 +58,7 @@ import {
 } from './constants';
 
 // ---------------------------------------------------------------------------
-// Types (unchanged — callers depend on these)
+// Public types (callers depend on these — do not break)
 // ---------------------------------------------------------------------------
 
 export interface IAPProduct {
@@ -68,6 +77,8 @@ export interface PurchaseResult {
   tier: SubscriptionTier;
   expiresAt?: string;
   error?: string;
+  /** True when the user dismissed the billing sheet (no toast needed). */
+  cancelled?: boolean;
 }
 
 export interface ReceiptVerificationPayload {
@@ -93,19 +104,63 @@ export class IAPError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Module state
+// Constants
 // ---------------------------------------------------------------------------
 
-let connectionPromise: Promise<boolean> | null = null;
-let purchaseSub: EmitterSubscription | null = null;
-let errorSub: EmitterSubscription | null = null;
+const PURCHASE_TIMEOUT_MS = 120_000;
+const VERIFY_MAX_ATTEMPTS = 2;
+const VERIFY_RETRY_DELAY_MS = 1_500;
 
-/** Cached store payload — needed on Android to resolve the offerToken. */
-let cachedSubscriptions: Subscription[] = [];
+// ---------------------------------------------------------------------------
+// Module state — bridged via globalThis so Metro reloads don't leak
+// native listeners. Without this, each `r` key in the Metro CLI attaches
+// a fresh JS listener while the old native one remains — which means
+// every purchase event fires twice (and the second call to
+// finishTransaction throws).
+// ---------------------------------------------------------------------------
 
-/** Pending resolvers keyed by productId so purchaseSubscription can await. */
-type Resolver = (result: PurchaseResult) => void;
-const pendingResolvers: Map<string, Resolver> = new Map();
+interface GlobalIapState {
+  connectionPromise: Promise<boolean> | null;
+  purchaseSub: EmitterSubscription | null;
+  errorSub: EmitterSubscription | null;
+  cachedSubscriptions: Subscription[];
+  pendingResolvers: Map<string, (r: PurchaseResult) => void>;
+  inflightProductIds: Set<string>;
+  /** Optional app-account tag for linking receipts to the signed-in user. */
+  accountTag: string | null;
+}
+
+const GLOBAL_KEY = '__kiaanverseIapState';
+
+function getState(): GlobalIapState {
+  const g = globalThis as unknown as Record<string, GlobalIapState | undefined>;
+  if (!g[GLOBAL_KEY]) {
+    g[GLOBAL_KEY] = {
+      connectionPromise: null,
+      purchaseSub: null,
+      errorSub: null,
+      cachedSubscriptions: [],
+      pendingResolvers: new Map(),
+      inflightProductIds: new Set(),
+      accountTag: null,
+    };
+  }
+  return g[GLOBAL_KEY]!;
+}
+
+// ---------------------------------------------------------------------------
+// Account tagging
+// ---------------------------------------------------------------------------
+
+/**
+ * Set the signed-in user tag. Called from the auth flow at login so
+ * purchases can be bound to this user on both stores. Clearing is safe
+ * on logout. Android hash must be ≤ 64 chars alphanumeric; iOS requires
+ * a UUID. We pass the raw string and trust the caller to normalise.
+ */
+export function setIapAccountTag(tag: string | null): void {
+  getState().accountTag = tag;
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -123,9 +178,11 @@ function productIdToBilling(productId: string): BillingPeriod {
 }
 
 function resolvePending(productId: string, result: PurchaseResult): void {
-  const resolver = pendingResolvers.get(productId);
+  const state = getState();
+  const resolver = state.pendingResolvers.get(productId);
   if (resolver) {
-    pendingResolvers.delete(productId);
+    state.pendingResolvers.delete(productId);
+    state.inflightProductIds.delete(productId);
     resolver(result);
   }
 }
@@ -133,7 +190,7 @@ function resolvePending(productId: string, result: PurchaseResult): void {
 /**
  * Extract the platform-appropriate receipt token.
  * - Android: `purchaseToken` (required for server-side verification via
- *   Google Play Developer API).
+ *   the Google Play Developer API).
  * - iOS: `transactionReceipt` (StoreKit base64-encoded receipt).
  */
 function extractReceipt(purchase: ProductPurchase | SubscriptionPurchase): string {
@@ -143,18 +200,65 @@ function extractReceipt(purchase: ProductPurchase | SubscriptionPurchase): strin
   return purchase.transactionReceipt ?? '';
 }
 
+async function verifyWithRetry(
+  receipt: string,
+  productId: string,
+): Promise<ReceiptVerificationResponse> {
+  let lastError: string | undefined;
+  for (let attempt = 1; attempt <= VERIFY_MAX_ATTEMPTS; attempt++) {
+    try {
+      const result = await verifyReceipt(receipt, productId);
+      // Transient backend failure — our verifyReceipt() swallows network
+      // errors into `{ valid: false, error: 'Receipt validation failed.' }`.
+      // Only retry if it looks like a transport issue, not a valid
+      // "invalid receipt" response.
+      if (result.valid || result.error !== 'Receipt validation failed.') {
+        return result;
+      }
+      lastError = result.error;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    if (attempt < VERIFY_MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, VERIFY_RETRY_DELAY_MS * attempt));
+    }
+  }
+  return {
+    valid: false,
+    tier: 'free',
+    expires_at: null,
+    error: lastError ?? 'Receipt validation failed.',
+  };
+}
+
 /**
- * Handle a purchase event: verify with backend → finish transaction →
- * resolve the pending promise. We intentionally do NOT finish the
- * transaction before verification — if verification fails (or the device
- * dies), Play auto-refunds after 72h, which is the correct outcome.
+ * Handle a purchase event: skip if pending, verify with backend, then
+ * finish transaction. We intentionally do NOT finish the transaction
+ * before verification — if verification fails (or the device dies),
+ * Play auto-refunds after 72h, which is the correct outcome.
  */
 async function handlePurchaseEvent(
   purchase: ProductPurchase | SubscriptionPurchase,
 ): Promise<void> {
   const productId = purchase.productId;
-  const receipt = extractReceipt(purchase);
 
+  // Android PENDING state: user paid via cash / DCB and Play is waiting
+  // for settlement. Do NOT verify, do NOT acknowledge. Play re-emits the
+  // event as PURCHASED once funds clear (typically minutes, up to 3 days).
+  if (
+    Platform.OS === 'android' &&
+    purchase.purchaseStateAndroid === PurchaseStateAndroid.PENDING
+  ) {
+    resolvePending(productId, {
+      success: false,
+      tier: 'free',
+      error:
+        'Your payment is being processed. You will receive access as soon as it completes.',
+    });
+    return;
+  }
+
+  const receipt = extractReceipt(purchase);
   if (!receipt) {
     resolvePending(productId, {
       success: false,
@@ -165,7 +269,7 @@ async function handlePurchaseEvent(
   }
 
   try {
-    const verification = await verifyReceipt(receipt, productId);
+    const verification = await verifyWithRetry(receipt, productId);
 
     if (!verification.valid) {
       resolvePending(productId, {
@@ -182,9 +286,10 @@ async function handlePurchaseEvent(
     try {
       await finishTransaction({ purchase, isConsumable: false });
     } catch (finishErr) {
-      // Verification already succeeded — server-side truth is the subscription
-      // is active. Log and move on; Play will retry acknowledge on next
-      // foreground via flushFailedPurchasesCachedAsPendingAndroid().
+      // Verification already succeeded — server-side truth is the
+      // subscription is active. Play will retry acknowledge on next
+      // flushFailedPurchasesCachedAsPendingAndroid() call (wired in
+      // initializeIAP). Safe to continue.
       console.warn('IAP: finishTransaction failed post-verify:', finishErr);
     }
 
@@ -201,21 +306,26 @@ async function handlePurchaseEvent(
 }
 
 function handlePurchaseError(error: PurchaseError): void {
-  // User cancellation is not a failure — Play reports code E_USER_CANCELLED,
-  // iOS reports paymentCancelled. Surface distinct copy so the UI can suppress
-  // an error toast in that case.
+  // User cancellation is not a failure — Play reports E_USER_CANCELLED,
+  // iOS reports paymentCancelled. Surface cancel flag so the UI can
+  // suppress an error toast.
   const isCancelled =
     error.code === 'E_USER_CANCELLED' || error.code === 'E_USER_ERROR';
 
-  // We don't know which productId this error belongs to (react-native-iap
-  // doesn't expose it on the error object reliably), so reject all pending.
+  const state = getState();
   const message = isCancelled
     ? 'Purchase cancelled.'
     : error.message ?? 'Purchase failed. Please try again.';
 
-  for (const [productId, resolver] of pendingResolvers) {
-    pendingResolvers.delete(productId);
-    resolver({ success: false, tier: 'free', error: message });
+  // react-native-iap doesn't reliably expose which productId the error
+  // belongs to, so we reject every in-flight purchase. In practice there
+  // is always ≤ 1 in flight because of the inflightProductIds guard.
+  for (const [productId, resolver] of state.pendingResolvers) {
+    state.pendingResolvers.delete(productId);
+    state.inflightProductIds.delete(productId);
+    const result: PurchaseResult = { success: false, tier: 'free', error: message };
+    if (isCancelled) result.cancelled = true;
+    resolver(result);
   }
 }
 
@@ -224,13 +334,14 @@ function handlePurchaseError(error: PurchaseError): void {
 // ---------------------------------------------------------------------------
 
 export async function initializeIAP(): Promise<void> {
-  if (!connectionPromise) {
-    connectionPromise = initConnection();
+  const state = getState();
+  if (!state.connectionPromise) {
+    state.connectionPromise = initConnection();
   }
 
-  const connected = await connectionPromise;
+  const connected = await state.connectionPromise;
   if (!connected) {
-    connectionPromise = null;
+    state.connectionPromise = null;
     throw new IAPError('Store connection failed', 'E_CONNECTION_FAILED');
   }
 
@@ -244,42 +355,46 @@ export async function initializeIAP(): Promise<void> {
     }
   }
 
-  // Attach listeners exactly once. Screens mount and unmount but purchases
-  // can arrive at any time (e.g. asynchronous Play grace period).
-  if (!purchaseSub) {
-    purchaseSub = purchaseUpdatedListener((event) => {
+  // Attach listeners exactly once across the app lifetime AND across
+  // Metro hot reloads (see globalThis comment above).
+  if (!state.purchaseSub) {
+    state.purchaseSub = purchaseUpdatedListener((event) => {
       void handlePurchaseEvent(event);
     });
   }
-  if (!errorSub) {
-    errorSub = purchaseErrorListener(handlePurchaseError);
+  if (!state.errorSub) {
+    state.errorSub = purchaseErrorListener(handlePurchaseError);
   }
 }
 
 export async function disconnectIAP(): Promise<void> {
-  purchaseSub?.remove();
-  errorSub?.remove();
-  purchaseSub = null;
-  errorSub = null;
-  connectionPromise = null;
-  cachedSubscriptions = [];
-  pendingResolvers.clear();
+  const state = getState();
+  state.purchaseSub?.remove();
+  state.errorSub?.remove();
+  state.purchaseSub = null;
+  state.errorSub = null;
+  state.connectionPromise = null;
+  state.cachedSubscriptions = [];
+  state.pendingResolvers.clear();
+  state.inflightProductIds.clear();
+  state.accountTag = null;
   try {
     await endConnection();
   } catch {
-    // safe to swallow — endConnection is idempotent
+    // endConnection is idempotent — safe to swallow
   }
 }
 
 export async function getProducts(): Promise<IAPProduct[]> {
   await initializeIAP();
+  const state = getState();
 
   try {
     const platform: 'ios' | 'android' = Platform.OS === 'ios' ? 'ios' : 'android';
     const skus = Object.values(IAP_PRODUCT_IDS).map((entry) => entry[platform]);
-    cachedSubscriptions = await getSubscriptions({ skus });
+    state.cachedSubscriptions = await getSubscriptions({ skus });
 
-    return cachedSubscriptions.map(mapSubscriptionToIAPProduct);
+    return state.cachedSubscriptions.map(mapSubscriptionToIAPProduct);
   } catch (err) {
     console.warn('IAP: getSubscriptions failed, returning fallback config:', err);
     return getFallbackProducts();
@@ -301,14 +416,15 @@ export async function purchaseSubscription(
 
   try {
     await initializeIAP();
+    const state = getState();
 
-    // Make sure we have the store payload so we can find the offerToken on
-    // Android. Harmless on iOS.
-    if (cachedSubscriptions.length === 0) {
+    // Make sure we have the store payload so we can find the offerToken
+    // on Android. Harmless on iOS.
+    if (state.cachedSubscriptions.length === 0) {
       await getProducts();
     }
 
-    const platform = Platform.OS === 'ios' ? 'ios' : 'android';
+    const platform: 'ios' | 'android' = Platform.OS === 'ios' ? 'ios' : 'android';
     const tierKey = `${tier.toUpperCase()}_${billingPeriod.toUpperCase()}` as
       | 'BHAKTA_MONTHLY'
       | 'BHAKTA_YEARLY'
@@ -318,55 +434,103 @@ export async function purchaseSubscription(
       | 'SIDDHA_YEARLY';
     const sku = IAP_PRODUCT_IDS[tierKey][platform];
 
-    // Register a resolver so we can convert the async listener event back
-    // into the callback-based API our callers expect.
+    // Re-entrance guard: ignore a second tap while the first purchase is
+    // still awaiting the native sheet. Prevents resolver collisions.
+    if (state.inflightProductIds.has(sku)) {
+      callbacks?.onError?.('A purchase is already in progress.');
+      return;
+    }
+    state.inflightProductIds.add(sku);
+
+    // Timeout + resolver promise. If the native sheet never emits (e.g.
+    // a system dialog eats the response), we still resolve cleanly.
     const result = await new Promise<PurchaseResult>((resolve) => {
-      pendingResolvers.set(sku, resolve);
-
-      if (Platform.OS === 'android') {
-        const androidSub = cachedSubscriptions.find(
-          (s): s is SubscriptionAndroid =>
-            'subscriptionOfferDetails' in s && s.productId === sku,
-        );
-        const offerToken = androidSub?.subscriptionOfferDetails?.[0]?.offerToken;
-
-        if (!offerToken) {
-          pendingResolvers.delete(sku);
-          resolve({
-            success: false,
-            tier: 'free',
-            error:
-              'This plan is not yet available on the Play Store. Please try again later.',
-          });
-          return;
-        }
-
-        void requestSubscription({
-          sku,
-          subscriptionOffers: [{ sku, offerToken }],
-        }).catch((err: unknown) => {
-          pendingResolvers.delete(sku);
-          const message = err instanceof Error ? err.message : 'Purchase failed.';
-          resolve({ success: false, tier: 'free', error: message });
+      const timeout = setTimeout(() => {
+        // Clean up the resolver so a late event doesn't double-call.
+        state.pendingResolvers.delete(sku);
+        state.inflightProductIds.delete(sku);
+        resolve({
+          success: false,
+          tier: 'free',
+          error: 'The Play Store took too long to respond. Please try again.',
         });
-      } else {
-        void requestSubscription({ sku }).catch((err: unknown) => {
-          pendingResolvers.delete(sku);
-          const message = err instanceof Error ? err.message : 'Purchase failed.';
-          resolve({ success: false, tier: 'free', error: message });
-        });
-      }
+      }, PURCHASE_TIMEOUT_MS);
+
+      state.pendingResolvers.set(sku, (r) => {
+        clearTimeout(timeout);
+        resolve(r);
+      });
+
+      void dispatchSubscriptionRequest(sku, state.accountTag).catch((err: unknown) => {
+        clearTimeout(timeout);
+        state.pendingResolvers.delete(sku);
+        state.inflightProductIds.delete(sku);
+        const message = err instanceof Error ? err.message : 'Purchase failed.';
+        resolve({ success: false, tier: 'free', error: message });
+      });
     });
 
     if (result.success) {
       callbacks?.onComplete?.(result);
-    } else {
+    } else if (!result.cancelled) {
       callbacks?.onError?.(result.error ?? 'Purchase did not complete.');
     }
+    // Silently ignore cancelled purchases — user dismissed the sheet.
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unexpected purchase error';
     callbacks?.onError?.(message);
   }
+}
+
+/**
+ * Android-aware dispatch: picks the correct offerToken (prefer the base
+ * plan, fall back to the first available offer) and passes the account
+ * tag for server-side receipt binding. On iOS we pass the tag as
+ * `appAccountToken` so Apple attaches it to the transaction.
+ */
+async function dispatchSubscriptionRequest(
+  sku: string,
+  accountTag: string | null,
+): Promise<void> {
+  const state = getState();
+
+  if (Platform.OS === 'android') {
+    const androidSub = state.cachedSubscriptions.find(
+      (s): s is SubscriptionAndroid =>
+        'subscriptionOfferDetails' in s && s.productId === sku,
+    );
+    const offers = androidSub?.subscriptionOfferDetails ?? [];
+
+    // Prefer a base-plan offer with no introductory pricing; otherwise
+    // take whatever Play returned first. Play always returns at least
+    // one offer for an active base plan.
+    const chosen =
+      offers.find(
+        (o) =>
+          (o.offerTags ?? []).length === 0 ||
+          (o.offerTags ?? []).every((t) => t.toLowerCase() !== 'free-trial'),
+      ) ?? offers[0];
+
+    if (!chosen?.offerToken) {
+      throw new IAPError(
+        'This plan is not available on the Play Store yet. Please try again later.',
+        'E_OFFER_UNAVAILABLE',
+      );
+    }
+
+    await requestSubscription({
+      sku,
+      subscriptionOffers: [{ sku, offerToken: chosen.offerToken }],
+      ...(accountTag ? { obfuscatedAccountIdAndroid: accountTag } : {}),
+    });
+    return;
+  }
+
+  // iOS
+  await requestSubscription({
+    sku,
+    ...(accountTag ? { appAccountToken: accountTag } : {}),
+  });
 }
 
 export async function restorePurchases(): Promise<PurchaseResult> {
@@ -382,8 +546,8 @@ export async function restorePurchases(): Promise<PurchaseResult> {
       };
     }
 
-    // Verify the most recent purchase with our backend. The server is the
-    // source of truth for tier/expiry.
+    // Verify the most recent purchase with our backend. The server is
+    // the source of truth for tier / expiry.
     const latest = purchases.reduce((a, b) =>
       (a.transactionDate ?? 0) > (b.transactionDate ?? 0) ? a : b,
     );
@@ -392,7 +556,7 @@ export async function restorePurchases(): Promise<PurchaseResult> {
       return { success: false, tier: 'free', error: 'Restore receipt missing.' };
     }
 
-    const verification = await verifyReceipt(receipt, latest.productId);
+    const verification = await verifyWithRetry(receipt, latest.productId);
     if (!verification.valid) {
       return {
         success: false,
@@ -401,7 +565,8 @@ export async function restorePurchases(): Promise<PurchaseResult> {
       };
     }
 
-    // Acknowledge restored purchases if they weren't previously acknowledged.
+    // Acknowledge restored purchases if they weren't previously
+    // acknowledged (e.g. re-install on a new device).
     try {
       await finishTransaction({ purchase: latest, isConsumable: false });
     } catch {
@@ -438,6 +603,21 @@ export async function verifyReceipt(
       expires_at: null,
       error: 'Receipt validation failed.',
     };
+  }
+}
+
+/**
+ * Open the store's subscription-management screen. On iOS this opens
+ * Settings → Apple ID → Subscriptions; on Android it deep-links to the
+ * Play subscription screen for the current app (and the specific sku
+ * when provided). Falls back to a plain URL if the SDK call fails.
+ */
+export async function openManageSubscription(sku?: string): Promise<void> {
+  try {
+    await deepLinkToSubscriptions(sku ? { sku } : {});
+  } catch (err) {
+    console.warn('IAP: deepLinkToSubscriptions failed:', err);
+    throw err;
   }
 }
 
@@ -483,7 +663,7 @@ function mapSubscriptionToIAPProduct(sub: Subscription): IAPProduct {
 
 /** Used when the store is unavailable (dev environment, airplane mode). */
 function getFallbackProducts(): IAPProduct[] {
-  const platform = Platform.OS === 'ios' ? 'ios' : 'android';
+  const platform: 'ios' | 'android' = Platform.OS === 'ios' ? 'ios' : 'android';
   const tiers: SubscriptionTier[] = ['bhakta', 'sadhak', 'siddha'];
   const periods: BillingPeriod[] = ['monthly', 'yearly'];
 

--- a/kiaanverse-mobile/packages/api/src/subscription/index.ts
+++ b/kiaanverse-mobile/packages/api/src/subscription/index.ts
@@ -22,6 +22,8 @@ export {
   purchaseSubscription,
   restorePurchases,
   verifyReceipt,
+  setIapAccountTag,
+  openManageSubscription,
   IAPError,
   type IAPProduct,
   type PurchaseResult,

--- a/kiaanverse-mobile/pnpm-lock.yaml
+++ b/kiaanverse-mobile/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.16.0
         version: 2.16.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react-native-iap:
+        specifier: ^12.15.0
+        version: 12.16.4(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       react-native-markdown-display:
         specifier: ^7.0.2
         version: 7.0.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -5121,6 +5124,16 @@ packages:
     resolution: {integrity: sha512-m3CkXWss6B1dd6mCMleLpzDCJJGGaHOLQsUzZv8kAASJmMfmVT4d2fx375iXKTRWT25ThBfae3dECuX5cq/8hg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
+
+  react-native-iap@12.16.4:
+    resolution: {integrity: sha512-3l3/k5ho2hzVCyfwlPRTrdn4gY1ku3dZFN9qJ7giZUBGr3wffciL5WRKxVUs7jQAXOgAtea9JexrMrgvEXSO/w==}
+    peerDependencies:
+      expo: '>=47.0.0'
+      react: '>=16.13.1'
+      react-native: '>=0.65.1'
+    peerDependenciesMeta:
+      expo:
+        optional: true
 
   react-native-markdown-display@7.0.2:
     resolution: {integrity: sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==}
@@ -12463,6 +12476,13 @@ snapshots:
       react: 18.2.0
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
+
+  react-native-iap@12.16.4(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0)
+    optionalDependencies:
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
 
   react-native-markdown-display@7.0.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
     dependencies:


### PR DESCRIPTION
## Summary

Replace the deprecated expo-in-app-purchases stub with a production-ready implementation using react-native-iap 12.x, supporting Google Play Billing and Apple StoreKit. Includes new subscription management UI screens (plans, current subscription, success confirmation) and profile/settings screens.

## Changes

### Core IAP Service (`iapService.ts`)
- **Replaced stub with full react-native-iap integration** using Play Billing / StoreKit APIs
- **Module-scoped connection & listeners** stored on `globalThis` to survive Metro hot reloads without duplicating native subscriptions or causing double-finish bugs
- **Receipt verification flow**: purchases are never finished until backend verifies the receipt; Play auto-refunds unacknowledged purchases after 72h as a safety net
- **Android PENDING state handling**: cash/DCB payments held by Play until settlement are not verified or acknowledged
- **Account tagging** via `setIapAccountTag()` to bind receipts to signed-in users (prevents replay attacks)
- **Pending promise resolvers** keyed by productId with 2-minute timeout ceiling
- **Retry logic** for receipt verification (max 2 attempts with backoff)
- **New `IAPError` class** for structured error handling
- Public API unchanged from stub so existing callers compile without edits

### New Subscription UI Screens
- **`subscription/plans.tsx`**: Monthly/annual toggle, three paid tiers (Bhakta/Sadhak/Siddha) with store prices, purchase flow with haptics and error handling
- **`subscription/index.tsx`**: Current subscription status, renewal date, billing period, deep-link to store management, restore purchases
- **`subscription/success.tsx`**: Post-purchase confirmation screen with tier display

### Profile & Settings Screens
- **`profile.tsx`**: Complete rewrite as 1:1 port of web profile; avatar + name + email, subscription tier badge, stats row (streak/journeys/verses), menu sections (Account, Subscription, Sacred Tools, Support, Legal)
- **`notifications.tsx`**: Toggle push notification categories with optimistic local updates
- **`language-settings.tsx`**: Single-select language picker with native script previews
- **`(app)/_layout.tsx`**: New route group for profile sub-screens
- **`(app)/subscription/_layout.tsx`**: Subscription flow stack layout

### Integration Points
- **`_layout.tsx` (root)**: Wire up `initializeIAP()` on app start, `disconnectIAP()` on unmount, `setIapAccountTag()` on auth state changes
- **`app.config.ts`**: Add `BILLING` permission for Android
- **`package.json`**: Add `react-native-iap@^12.15.0` dependency
- **API exports**: Expose `setIapAccountTag` and `openManageSubscription` from subscription module

## Design Rationale

**Why globalThis for state?** Metro hot reloads (`r` key) create new JS listeners while old native ones remain, causing duplicate purchase events and double-finish errors. Storing connection/listeners on `globalThis` ensures they survive reloads.

**Why not finish before verification?** If verification fails or the device dies, Play auto-refunds unacknowledged purchases after 72h—the correct outcome. Finishing early would lock the user out.

**Why retry verification?** Network transients are common; one retry with backoff handles most cases without user friction.

**Why account tagging?** Prevents receipt replay attacks where a user could claim another user's purchase.

## Testing

- Existing callers (`subscription.tsx`, store) compile without changes
- Manual testing on Android (Play Billing) and iOS (StoreKit) required for:
  - Purchase flow (monthly/annual toggle, tier selection)
  - Receipt verification and acknowledgment
  - Restore purchases
  - PENDING state handling (Android cash/DCB)
  - Metro hot reload stability (no duplicate listeners)
- CI passes (no new unit tests added; IAP is integration-heavy)

## Checklist
- [x] No private keys committed
- [x] Public API unchanged from stub (backward compatible

https://claude.ai/code/session_01DaGv2bA8tjXpWat9EmALLE