### PR TITLE
Play Billing upgrade / downgrade flow (full stack)

### DIFF
--- a/backend/models/subscription.py
+++ b/backend/models/subscription.py
@@ -131,6 +131,17 @@ class UserSubscription(SoftDeleteMixin, Base):
     razorpay_customer_id: Mapped[str | None] = mapped_column(
         String(128), nullable=True, index=True
     )
+    # Play Billing / StoreKit identifiers. `store_purchase_token` holds the
+    # Play purchaseToken (base64, up to ~4KB) on Android or the StoreKit
+    # originalTransactionId on iOS. `store_product_id` holds the SKU so
+    # upgrade / downgrade flows can reuse it without another round-trip.
+    # Both populated on receipt verification (see mobile_subscription.py).
+    store_product_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, index=True
+    )
+    store_purchase_token: Mapped[str | None] = mapped_column(
+        String(4096), nullable=True, index=True
+    )
     payment_provider: Mapped[str] = mapped_column(
         String(32), default="stripe", index=True
     )

--- a/backend/routes/mobile_subscription.py
+++ b/backend/routes/mobile_subscription.py
@@ -336,6 +336,12 @@ async def verify_mobile_receipt(
             subscription.current_period_end = expires_at
             subscription.cancel_at_period_end = False
             subscription.canceled_at = None
+            # Store receipt identifiers for upgrade/downgrade + webhook lookup.
+            # On Android this is the Play purchaseToken; on iOS it's the
+            # StoreKit originalTransactionId (we keep the base64 receipt as
+            # a fallback for server-to-server verification calls).
+            subscription.store_product_id = payload.product_id
+            subscription.store_purchase_token = payload.receipt
         else:
             subscription = UserSubscription(
                 user_id=user_id,
@@ -345,6 +351,8 @@ async def verify_mobile_receipt(
                 current_period_start=now,
                 current_period_end=expires_at,
                 cancel_at_period_end=False,
+                store_product_id=payload.product_id,
+                store_purchase_token=payload.receipt,
             )
             db.add(subscription)
 

--- a/backend/schemas/subscription.py
+++ b/backend/schemas/subscription.py
@@ -58,6 +58,13 @@ class UserSubscriptionOut(BaseModel):
     created_at: datetime
     is_developer: bool = False
     effective_tier: SubscriptionTier | None = None
+    # Store receipt identifiers. `store_product_id` is required by the
+    # mobile client to deep-link to the current subscription in the Play
+    # Store and to build a Play Billing upgrade request. The raw
+    # `store_purchase_token` is NOT returned — the mobile client fetches
+    # it locally via `getAvailablePurchases()` so it is never exposed
+    # over the wire and never cached in an HTTP response.
+    store_product_id: str | None = None
 
 
 class UsageStatsOut(BaseModel):

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
@@ -36,10 +36,12 @@ import {
   OmLoader,
 } from '@kiaanverse/ui';
 import {
+  apiClient,
   getProducts,
   purchaseSubscription,
   restorePurchases,
   TIER_CONFIGS,
+  TIER_RANK,
   type BillingPeriod,
   type IAPProduct,
 } from '@kiaanverse/api';
@@ -74,10 +76,19 @@ const TIER_COPY: Record<
   },
 };
 
+interface CurrentSubscriptionMini {
+  tier: SubscriptionTier;
+  billing: BillingPeriod | null;
+}
+
 export default function SubscriptionPlansScreen(): React.JSX.Element {
   const [billing, setBilling] = useState<BillingPeriod>('monthly');
   const [selected, setSelected] = useState<Exclude<SubscriptionTier, 'free'>>('sadhak');
   const [products, setProducts] = useState<IAPProduct[]>([]);
+  const [current, setCurrent] = useState<CurrentSubscriptionMini>({
+    tier: 'free',
+    billing: null,
+  });
   const [loadingProducts, setLoadingProducts] = useState(true);
   const [purchasing, setPurchasing] = useState(false);
   const [restoring, setRestoring] = useState(false);
@@ -86,8 +97,26 @@ export default function SubscriptionPlansScreen(): React.JSX.Element {
     let mounted = true;
     (async () => {
       try {
-        const fetched = await getProducts();
-        if (mounted) setProducts(fetched);
+        const [fetched, currentRes] = await Promise.all([
+          getProducts(),
+          apiClient
+            .get<{
+              effective_tier: SubscriptionTier | null;
+              plan: { tier: SubscriptionTier; billing_period?: BillingPeriod } | null;
+              store_product_id: string | null;
+            }>('/api/subscriptions/current')
+            .catch(() => null),
+        ]);
+
+        if (!mounted) return;
+        setProducts(fetched);
+
+        const data = currentRes?.data;
+        const tier = data?.effective_tier ?? data?.plan?.tier ?? 'free';
+        const billingFromSku = deriveBillingFromSku(data?.store_product_id ?? null);
+        const resolvedBilling: BillingPeriod | null =
+          billingFromSku ?? data?.plan?.billing_period ?? null;
+        setCurrent({ tier, billing: resolvedBilling });
       } catch (err) {
         console.warn('Failed to load IAP products:', err);
       } finally {
@@ -149,11 +178,22 @@ export default function SubscriptionPlansScreen(): React.JSX.Element {
     }
   }, []);
 
+  const ctaAction = resolveCtaAction(current, selected, billing);
   const cta = (() => {
     const price = priceFor(selected, billing);
     const period = billing === 'monthly' ? '/month' : '/year';
-    return `Begin with ${TIER_CONFIGS[selected].name} · ${price}${period}`;
+    const name = TIER_CONFIGS[selected].name;
+    if (ctaAction === 'current') return `You are on ${name} · ${price}${period}`;
+    if (ctaAction === 'upgrade') return `Upgrade to ${name} · ${price}${period}`;
+    if (ctaAction === 'downgrade') return `Switch to ${name} · ${price}${period}`;
+    return `Begin with ${name} · ${price}${period}`;
   })();
+  const ctaSub =
+    ctaAction === 'upgrade'
+      ? 'Prorated instantly · Billed via your store account'
+      : ctaAction === 'downgrade'
+      ? 'Takes effect at the end of your current period'
+      : 'Cancel anytime in your store settings';
 
   if (loadingProducts) {
     return (
@@ -299,23 +339,64 @@ export default function SubscriptionPlansScreen(): React.JSX.Element {
             <Text style={styles.loadingText}>Opening sacred payment…</Text>
           </View>
         ) : (
-          <TouchableOpacity onPress={handleSubscribe} activeOpacity={0.85}>
+          <TouchableOpacity
+            onPress={handleSubscribe}
+            activeOpacity={0.85}
+            disabled={ctaAction === 'current'}
+          >
             <LinearGradient
               colors={TIER_COPY[selected].gradient}
               start={{ x: 0, y: 0 }}
               end={{ x: 1, y: 0 }}
-              style={styles.subscribeBtn}
+              style={[
+                styles.subscribeBtn,
+                ctaAction === 'current' && styles.subscribeBtnDisabled,
+              ]}
             >
               <Text style={styles.subscribeBtnText}>{cta}</Text>
-              <Text style={styles.subscribeBtnSub}>
-                Cancel anytime in your store settings
-              </Text>
+              <Text style={styles.subscribeBtnSub}>{ctaSub}</Text>
             </LinearGradient>
           </TouchableOpacity>
         )}
       </View>
     </DivineScreenWrapper>
   );
+}
+
+type CtaAction = 'subscribe' | 'upgrade' | 'downgrade' | 'current';
+
+/**
+ * Decide how to label the CTA based on the user's current plan. Same
+ * sku + same billing period → disabled ("current"). Strictly higher
+ * tier or monthly→yearly on the same tier → upgrade. Anything else
+ * while on a paid tier → downgrade.
+ */
+function resolveCtaAction(
+  current: CurrentSubscriptionMini,
+  selected: Exclude<SubscriptionTier, 'free'>,
+  billing: BillingPeriod,
+): CtaAction {
+  if (current.tier === 'free') return 'subscribe';
+  if (current.tier === selected && current.billing === billing) return 'current';
+
+  const currentRank = TIER_RANK[current.tier];
+  const selectedRank = TIER_RANK[selected];
+  if (selectedRank > currentRank) return 'upgrade';
+  if (
+    selectedRank === currentRank &&
+    current.billing === 'monthly' &&
+    billing === 'yearly'
+  ) {
+    return 'upgrade';
+  }
+  return 'downgrade';
+}
+
+function deriveBillingFromSku(sku: string | null): BillingPeriod | null {
+  if (!sku) return null;
+  if (sku.endsWith('.yearly')) return 'yearly';
+  if (sku.endsWith('.monthly')) return 'monthly';
+  return null;
 }
 
 function featureListFor(tier: SubscriptionTier): string[] {
@@ -498,6 +579,9 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     paddingVertical: 14,
     alignItems: 'center',
+  },
+  subscribeBtnDisabled: {
+    opacity: 0.55,
   },
   subscribeBtnText: {
     fontSize: 16,

--- a/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
+++ b/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
@@ -49,10 +49,13 @@ import {
   type PurchaseError,
 } from 'react-native-iap';
 
+import { ReplacementModesAndroid } from 'react-native-iap';
+
 import { apiClient } from '../client';
 import {
   IAP_PRODUCT_IDS,
   TIER_CONFIGS,
+  TIER_RANK,
   type SubscriptionTier,
   type BillingPeriod,
 } from './constants';
@@ -220,7 +223,9 @@ async function verifyWithRetry(
       lastError = err instanceof Error ? err.message : String(err);
     }
     if (attempt < VERIFY_MAX_ATTEMPTS) {
-      await new Promise((r) => setTimeout(r, VERIFY_RETRY_DELAY_MS * attempt));
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, VERIFY_RETRY_DELAY_MS * attempt),
+      );
     }
   }
   return {
@@ -483,10 +488,22 @@ export async function purchaseSubscription(
 }
 
 /**
- * Android-aware dispatch: picks the correct offerToken (prefer the base
- * plan, fall back to the first available offer) and passes the account
- * tag for server-side receipt binding. On iOS we pass the tag as
- * `appAccountToken` so Apple attaches it to the transaction.
+ * Android-aware dispatch. Responsibilities:
+ * 1. Pick the correct `offerToken` (prefer a base-plan offer over any
+ *    offer tagged as a free trial so upgrades don't silently reset the
+ *    user into a new trial period).
+ * 2. Detect an existing active subscription via
+ *    `getAvailablePurchases()` and, if the user is switching SKUs, add
+ *    `purchaseTokenAndroid` + a policy-correct `replacementModeAndroid`.
+ *    Without this, Play rejects the request with "you already own this
+ *    item". We read from the store locally (not from our backend) so
+ *    the token is always fresh and the flow works offline after init.
+ * 3. Pass the signed-in user id so Play / App Store attach it to the
+ *    transaction, enabling server-side binding of receipts to users.
+ *
+ * iOS doesn't need explicit upgrade args — StoreKit handles it
+ * automatically when all paid SKUs are in the same Subscription Group
+ * in App Store Connect. A one-time store config step, not code.
  */
 async function dispatchSubscriptionRequest(
   sku: string,
@@ -501,9 +518,6 @@ async function dispatchSubscriptionRequest(
     );
     const offers = androidSub?.subscriptionOfferDetails ?? [];
 
-    // Prefer a base-plan offer with no introductory pricing; otherwise
-    // take whatever Play returned first. Play always returns at least
-    // one offer for an active base plan.
     const chosen =
       offers.find(
         (o) =>
@@ -518,19 +532,85 @@ async function dispatchSubscriptionRequest(
       );
     }
 
+    const replacement = await resolveReplacementArgsAndroid(sku);
+
     await requestSubscription({
       sku,
       subscriptionOffers: [{ sku, offerToken: chosen.offerToken }],
+      ...replacement,
       ...(accountTag ? { obfuscatedAccountIdAndroid: accountTag } : {}),
     });
     return;
   }
 
-  // iOS
+  // iOS — relies on the App Store Connect Subscription Group for
+  // upgrade / downgrade behaviour; the client only forwards the account
+  // tag so the user-to-receipt binding is preserved.
   await requestSubscription({
     sku,
     ...(accountTag ? { appAccountToken: accountTag } : {}),
   });
+}
+
+/**
+ * Compute the Play Billing replacement payload for an upgrade or
+ * downgrade. Returns an empty object when the user has no existing
+ * subscription (i.e. a first-time purchase) so `requestSubscription`
+ * can spread it safely in both cases.
+ *
+ * Policy:
+ * - Upgrade (higher tier, or same tier switching monthly→yearly):
+ *   `CHARGE_PRORATED_PRICE` — the new plan starts immediately, the
+ *   user is credited for unused time on the old plan, and billed for
+ *   the prorated remainder of the first period.
+ * - Downgrade (lower tier, or yearly→monthly on the same tier):
+ *   `DEFERRED` — the current plan keeps running until its period end,
+ *   then the new plan takes over. Avoids unexpected refunds and
+ *   matches standard SaaS semantics.
+ */
+async function resolveReplacementArgsAndroid(
+  newSku: string,
+): Promise<
+  | { purchaseTokenAndroid: string; replacementModeAndroid: ReplacementModesAndroid }
+  | Record<string, never>
+> {
+  try {
+    const existingPurchases = await getAvailablePurchases();
+    const existing = existingPurchases.find(
+      (p) => p.productId !== newSku && Boolean(p.purchaseToken),
+    );
+    if (!existing?.purchaseToken) {
+      return {};
+    }
+
+    const newTier = productIdToTier(newSku);
+    const newBilling = productIdToBilling(newSku);
+    const existingTier = productIdToTier(existing.productId);
+    const existingBilling = productIdToBilling(existing.productId);
+
+    const newRank = TIER_RANK[newTier];
+    const existingRank = TIER_RANK[existingTier];
+
+    const isUpgrade =
+      newRank > existingRank ||
+      (newRank === existingRank &&
+        existingBilling === 'monthly' &&
+        newBilling === 'yearly');
+
+    return {
+      purchaseTokenAndroid: existing.purchaseToken,
+      replacementModeAndroid: isUpgrade
+        ? ReplacementModesAndroid.CHARGE_PRORATED_PRICE
+        : ReplacementModesAndroid.DEFERRED,
+    };
+  } catch (err) {
+    // Unable to read active purchases — proceed as a fresh purchase.
+    // Play will surface its own "you already own this item" error if
+    // there really is an active subscription; that's safe and
+    // actionable (user can restore / contact support).
+    console.warn('IAP: resolveReplacementArgsAndroid failed:', err);
+    return {};
+  }
 }
 
 export async function restorePurchases(): Promise<PurchaseResult> {

--- a/migrations/20260420_add_iap_purchase_token.sql
+++ b/migrations/20260420_add_iap_purchase_token.sql
@@ -1,0 +1,35 @@
+-- Add Play Billing / StoreKit purchase-identification columns to
+-- user_subscriptions.
+--
+-- Why we need these columns:
+-- 1. Upgrade / downgrade: Play Billing requires the *previous*
+--    purchase_token to be passed to `requestSubscription` along with a
+--    `replacementModeAndroid`. Without it, Play errors with
+--    "You already own this item" when a user tries to switch tiers.
+--    The mobile client can read this locally from
+--    `getAvailablePurchases()`, but the backend still needs to persist
+--    it for webhook lookup (see #3).
+-- 2. Admin ops: cancelling, refunding, or auditing a subscription via
+--    the Google Play Developer API or App Store Server API requires
+--    the purchase token / original transaction id respectively.
+-- 3. Real-time Developer Notifications (Google) and App Store Server
+--    Notifications v2 (Apple) deliver events keyed by purchase_token /
+--    originalTransactionId. Without persisting them, the backend
+--    cannot map a webhook payload back to a UserSubscription row, so
+--    renewals, grace periods, and cancellations silently never update.
+--
+-- Both columns are nullable so existing free-tier and Stripe-only
+-- subscriptions remain valid. Indexed because webhook handlers and the
+-- current-subscription query both look rows up by token.
+
+ALTER TABLE user_subscriptions
+    ADD COLUMN IF NOT EXISTS store_product_id   VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS store_purchase_token VARCHAR(4096);
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_store_purchase_token
+    ON user_subscriptions (store_purchase_token)
+    WHERE store_purchase_token IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_store_product_id
+    ON user_subscriptions (store_product_id)
+    WHERE store_product_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Closes the last deferred IAP gap from #1575. A Bhakta user tapping Sadhak no longer gets *"you already own this item"* from Play — the mobile client now detects the active purchase locally, passes `purchaseTokenAndroid` with a policy-correct `replacementModeAndroid`, and the backend persists the store purchase token so Real-time Developer Notifications (Google) and App Store Server Notifications v2 (Apple) can map webhook payloads back to the right user.

## Changes

### Backend
- **`migrations/20260420_add_iap_purchase_token.sql`** — adds `store_product_id VARCHAR(128)` and `store_purchase_token VARCHAR(4096)` to `user_subscriptions`, each with a partial index (`WHERE NOT NULL`). Additive, nullable, safe to run under load.
- **`models/subscription.py`** — `UserSubscription` gains both columns as `Mapped[str | None]`.
- **`routes/mobile_subscription.py`** — `/api/subscription/verify` now persists the receipt product id + token on both upsert and create branches.
- **`schemas/subscription.py`** — `UserSubscriptionOut` exposes `store_product_id`. The raw purchase token is intentionally **not** returned — the mobile client reads it locally via `getAvailablePurchases()` so the token never lands in an HTTP response / CDN cache / proxy log.

### Mobile — `packages/api/src/subscription/iapService.ts`
- New `resolveReplacementArgsAndroid(sku)` calls `getAvailablePurchases()` immediately before each Android purchase, finds any existing active subscription on a different SKU, and builds the Play Billing upgrade payload.
- `dispatchSubscriptionRequest` spreads the replacement args into `requestSubscription`.
- iOS untouched — StoreKit handles upgrade/downgrade via the App Store Connect Subscription Group (store-config step, not code).

### Mobile — `apps/mobile/app/(app)/subscription/plans.tsx`
- Fetches `/api/subscriptions/current` alongside `getProducts()` so the CTA reflects real state.
- `resolveCtaAction()` flips between **Begin with**, **Upgrade to**, **Switch to** (downgrade), and **You are on** (disabled on the exact current plan).
- Subtitle copy adjusts: *"Prorated instantly · Billed via your store account"* on upgrade, *"Takes effect at the end of your current period"* on downgrade.

## Upgrade policy

| From → To | Replacement mode | Behavior |
|---|---|---|
| Higher tier, or monthly → yearly same tier | `CHARGE_PRORATED_PRICE` | Immediate, prorated credit for unused time |
| Lower tier, or yearly → monthly same tier | `DEFERRED` | Kicks in at next renewal |
| Exact current SKU + billing | CTA disabled | — |

## Why client-side purchase-token lookup

1. **Always fresh** — after a renewal, Play rotates the purchase token; the client sees the new one instantly, the backend sees it on the next webhook.
2. **No checkout-hot-path latency** — avoids a round-trip before opening the billing sheet.
3. **Zero leak surface** — the token is a bearer credential for the subscription; keeping it out of HTTP response bodies avoids proxy/CDN/logging exposure.

The backend **persists** it anyway because RTDN / ASSN v2 webhooks key by token, not by user id.

## Test plan
- [ ] Apply migration on staging DB: `psql -f migrations/20260420_add_iap_purchase_token.sql`
- [ ] Fresh purchase: Free → Sadhak monthly → confirm `store_product_id` + `store_purchase_token` populated on `user_subscriptions`
- [ ] Upgrade: Sadhak monthly → Siddha monthly → Play sheet opens without "already own" error, prorated charge shown
- [ ] Upgrade: Sadhak monthly → Sadhak yearly → Play sheet opens with prorated charge
- [ ] Downgrade: Siddha yearly → Sadhak yearly → Play sheet opens with deferred-change messaging
- [ ] Already-on plan: CTA shows "You are on …" and is disabled
- [ ] `/api/subscriptions/current` returns `store_product_id` in payload
- [ ] `/api/subscriptions/current` does **not** expose `store_purchase_token`
- [ ] iOS: in-group subscription change works via StoreKit (requires all 6 SKUs in one Subscription Group in ASC)

## Rollout
1. Deploy backend migration + route change (additive, backward compatible)
2. Release mobile build — requires EAS dev-client rebuild if you don't already have one from #1575

https://claude.ai/code/session_01DaGv2bA8tjXpWat9EmALLE