### PR TITLE
fix(mobile): align journey enemy filters with the canonical shadripu

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/journey/[id].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/journey/[id].tsx
@@ -51,11 +51,15 @@ import { DaySelector } from '../../components/journey/DaySelector';
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Enemy colors mapped by journey category keyword for theming. */
+/**
+ * Enemy colors mapped by journey category keyword for theming.
+ * Keys match the backend's `EnemyType` enum (six shadripu) — kama, krodha,
+ * lobha, moha, mada, matsarya. Bhaya (fear) is NOT one of the shadripu.
+ */
 const ENEMY_COLORS: Record<string, string> = {
-  krodha: '#ef4444',
-  bhaya: '#3b82f6',
   kama: '#f59e0b',
+  krodha: '#ef4444',
+  lobha: '#10b981',
   moha: '#8b5cf6',
   mada: '#ec4899',
   matsarya: '#06b6d4',
@@ -63,12 +67,12 @@ const ENEMY_COLORS: Record<string, string> = {
 
 /** Sanskrit names for the six inner enemies (shadripu). */
 const ENEMY_SANSKRIT: Record<string, string> = {
-  krodha: '\u0915\u094D\u0930\u094B\u0927',      // Anger
-  bhaya: '\u092D\u092F',                          // Fear
-  kama: '\u0915\u093E\u092E',                     // Desire
-  moha: '\u092E\u094B\u0939',                     // Delusion
-  mada: '\u092E\u0926',                           // Pride
-  matsarya: '\u092E\u093E\u0924\u094D\u0938\u0930\u094D\u092F', // Jealousy
+  kama: '\u0915\u093E\u092E',                                            // Desire
+  krodha: '\u0915\u094D\u0930\u094B\u0927',                            // Anger
+  lobha: '\u0932\u094B\u092D',                                           // Greed
+  moha: '\u092E\u094B\u0939',                                            // Delusion
+  mada: '\u092E\u0926',                                                   // Pride
+  matsarya: '\u092E\u093E\u0924\u094D\u0938\u0930\u094D\u092F',     // Jealousy
 };
 
 /** Status badge styling by journey status. */

--- a/kiaanverse-mobile/apps/mobile/app/journey/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/journey/index.tsx
@@ -68,11 +68,18 @@ import { useTranslation } from '@kiaanverse/i18n';
 
 type TabKey = 'discover' | 'active' | 'completed';
 
-/** Inner enemy metadata — Sanskrit name, English translation, and accent color. */
+/**
+ * Inner enemy metadata — Sanskrit name, English translation, and accent color.
+ *
+ * The keys here MUST match the backend's `EnemyType` enum (six shadripu):
+ *   kama · krodha · lobha · moha · mada · matsarya
+ *
+ * (Bhaya / fear is NOT one of the shadripu and is intentionally absent.)
+ */
 const ENEMY_INFO: Record<string, { name: string; sanskrit: string; color: string }> = {
-  krodha: { name: 'Anger', sanskrit: 'क्रोध', color: '#ef4444' },
-  bhaya: { name: 'Fear', sanskrit: 'भय', color: '#3b82f6' },
   kama: { name: 'Desire', sanskrit: 'काम', color: '#f59e0b' },
+  krodha: { name: 'Anger', sanskrit: 'क्रोध', color: '#ef4444' },
+  lobha: { name: 'Greed', sanskrit: 'लोभ', color: '#10b981' },
   moha: { name: 'Delusion', sanskrit: 'मोह', color: '#8b5cf6' },
   mada: { name: 'Pride', sanskrit: 'मद', color: '#ec4899' },
   matsarya: { name: 'Envy', sanskrit: 'मत्सर्य', color: '#06b6d4' },

--- a/kiaanverse-mobile/apps/mobile/app/journey/step/[day].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/journey/step/[day].tsx
@@ -59,11 +59,15 @@ import { StepContent } from '../../../components/journey/StepContent';
 
 const MAX_REFLECTION_LENGTH = 5000;
 
-/** Enemy colors for journey theming. */
+/**
+ * Enemy colors for journey theming.
+ * Keys match the backend's `EnemyType` enum (six shadripu) — kama, krodha,
+ * lobha, moha, mada, matsarya. Bhaya (fear) is NOT one of the shadripu.
+ */
 const ENEMY_COLORS: Record<string, string> = {
-  krodha: '#ef4444',
-  bhaya: '#3b82f6',
   kama: '#f59e0b',
+  krodha: '#ef4444',
+  lobha: '#10b981',
   moha: '#8b5cf6',
   mada: '#ec4899',
   matsarya: '#06b6d4',
@@ -92,9 +96,9 @@ const DAY_META: Record<number, { theme: string; focus: string }> = {
  * Falls back to 'divine' if no mapping exists.
  */
 const ENEMY_GRADIENT_VARIANT: Record<string, string> = {
-  krodha: 'release',
-  bhaya: 'peace',
   kama: 'renewal',
+  krodha: 'release',
+  lobha: 'healing',
   moha: 'healing',
   mada: 'divine',
   matsarya: 'peace',


### PR DESCRIPTION
## Summary

The mobile journey UI listed `bhaya` (fear) as one of the inner enemies, but **bhaya is not one of the शड्रिपु**. The backend's canonical `EnemyType` enum (`backend/services/journey_engine/template_generator.py`) only ever emits the six shadripu: **kama, krodha, lobha, moha, mada, matsarya**.

### Effects of the bug
- Templates tagged `lobha` (greed) had no color / Sanskrit / icon mapping, so the discover card fell through to the default golden accent.
- The "Bhaya / Fear" filter chip never matched any backend template (dead filter).
- The detail and step screens couldn't theme any greed-related journey.

### Fix
- Drop `bhaya` and add `lobha` (लोभ, emerald `#10b981`).
- Reorder all five maps to follow the canonical shadripu sequence so future
  edits stay aligned with the backend enum.

### Files
- `apps/mobile/app/journey/index.tsx` — `ENEMY_INFO`
- `apps/mobile/app/journey/[id].tsx` — `ENEMY_COLORS`, `ENEMY_SANSKRIT`
- `apps/mobile/app/journey/step/[day].tsx` — `ENEMY_COLORS`, `ENEMY_GRADIENT_VARIANT`

The journey route itself (Discover/Active/Completed tabs, ripu filter chips, JourneyCard, ActiveJourneyCard, day selector, step player with reflection input + ConfettiCannon + CompletionCelebration) is already fully implemented and wired to the real `useJourneyTemplates` / `useJourneys` / `useStartJourney` / `useWisdomJourneyDetail` / `useCompleteWisdomStep` hooks against `/api/journey-engine/*` endpoints — no functional rebuild was needed beyond this categorization fix.

## Test plan

- [x] `pnpm -r typecheck` → all 5 workspace projects pass with zero errors
- [x] `grep -r bhaya apps/mobile/app/journey` returns no matches
- [x] Backend `EnemyType` enum verified: `kama, krodha, lobha, moha, mada, matsarya`
- [ ] Manual smoke: tap "Lobha / Greed" chip → templates with `primary_enemy_tags=["lobha"]` are shown; their cards render with the emerald accent and `लोभ` badge

https://claude.ai/code/session_01C7g9SKcbTaSw6t7iB759C8