### PR TITLE
feat(mobile): wire TrackPlayer playback service + background audio capabilities (PR A of 2)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -41,7 +41,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         'Kiaanverse uses Face ID for secure, quick login.',
       NSCameraUsageDescription:
         'Kiaanverse may use your camera for future features.',
-      UIBackgroundModes: ['fetch', 'remote-notification'],
+      // 'audio' keeps the AVAudioSession alive when the screen locks or the
+      // user backgrounds the app — required for Vibe Player lock-screen
+      // controls and for audio to continue during meditation sessions.
+      UIBackgroundModes: ['fetch', 'remote-notification', 'audio'],
     },
     config: {
       usesNonExemptEncryption: false,
@@ -72,6 +75,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       'android.permission.RECEIVE_BOOT_COMPLETED',
       'android.permission.POST_NOTIFICATIONS',
       'com.android.vending.BILLING',
+      // Required by react-native-track-player to run the media-playback
+      // foreground service on Android 14+ (targetSdk 34). Without this the
+      // audio session is killed the moment the user leaves the app.
+      'android.permission.FOREGROUND_SERVICE',
+      'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
     ],
     intentFilters: [
       {

--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -47,9 +47,19 @@ import { NotificationToast } from '../components/common/NotificationToast';
 import { ErrorBoundary } from '../components/common/ErrorBoundary';
 import { ToastContainer } from '../components/common/Toast';
 import { initErrorTracking } from '../services/errorTracking';
+import {
+  registerPlaybackService,
+  setupTrackPlayer,
+} from '../services/trackPlayerSetup';
 
 // Register background tasks at module level (required by expo-task-manager)
 import '../services/backgroundTasks';
+
+// Register the TrackPlayer headless JS service at module load. MUST run before
+// any React tree mounts, otherwise lock-screen / Bluetooth / headphone remote
+// events have no handler when the UI tree tears down (the exact moment the
+// user needs them).
+registerPlaybackService();
 
 // Initialize error tracking before any providers mount
 initErrorTracking();
@@ -205,6 +215,15 @@ function AppContent(): React.JSX.Element {
         await hydrateSubscription();
       } catch (err) {
         if (__DEV__) console.warn('[setup] hydrateSubscription failed:', err);
+      }
+      try {
+        // Allocate the native audio session up front so the first tap on a
+        // Vibe Player track starts immediately. setupTrackPlayer() is
+        // idempotent and swallows its own errors, so a failure here cannot
+        // block auth bootstrap.
+        await setupTrackPlayer();
+      } catch (err) {
+        if (__DEV__) console.warn('[setup] setupTrackPlayer failed:', err);
       }
     };
     void setup();

--- a/kiaanverse-mobile/apps/mobile/services/playbackService.ts
+++ b/kiaanverse-mobile/apps/mobile/services/playbackService.ts
@@ -1,0 +1,102 @@
+/**
+ * TrackPlayer Playback Service — runs in a background JS context.
+ *
+ * This module is registered at app startup via TrackPlayer.registerPlaybackService.
+ * The function returned here is invoked by react-native-track-player in a
+ * dedicated headless JS task that survives when the React tree unmounts
+ * (background, lock screen, killed UI). It MUST only attach event handlers —
+ * never render React, never read Zustand/React Query state.
+ *
+ * Why a separate file: registerPlaybackService receives a factory that the
+ * native module re-invokes after the JS bridge is torn down (e.g. when iOS
+ * resumes audio from a lock-screen tap on a killed app). Putting handler logic
+ * inside a screen component means the handlers are gone the moment the
+ * component unmounts, which is exactly when the user needs them.
+ *
+ * Remote events handled (sources: lock screen, Control Center, Bluetooth,
+ * AirPods, car CarPlay/Android Auto, headphone in-line buttons):
+ *   - RemotePlay        → resume playback
+ *   - RemotePause       → pause playback
+ *   - RemoteStop        → stop and clear; the OS hides the now-playing card
+ *   - RemoteNext        → skip to next track in TrackPlayer's internal queue
+ *   - RemotePrevious    → skip to previous track
+ *   - RemoteSeek        → seek to position (in seconds, comes from the OS)
+ *   - RemoteJumpForward → jump forward by the configured forwardJumpInterval
+ *   - RemoteJumpBackward→ jump backward by the configured backwardJumpInterval
+ *   - RemoteDuck        → audio focus interruption (call, Siri, alarm) —
+ *                         iOS sends paused=true and the playback engine
+ *                         already pauses; we honor permanent=true by stopping
+ *                         so we don't silently resume after the interruption
+ *
+ * App-state cleanup (Android only):
+ *   When the user dismisses the app from the recents tray, Play Store policy
+ *   requires the foreground service to terminate. AppKilledPlaybackBehavior
+ *   is set during setupPlayer() — this service still needs to be registered
+ *   for the OS notification controls to function while playback is alive.
+ */
+
+import TrackPlayer, { Event } from 'react-native-track-player';
+
+/**
+ * Register all remote control event handlers.
+ * Exported as the default so it matches the registerPlaybackService contract:
+ *   TrackPlayer.registerPlaybackService(() => require('./playbackService'))
+ */
+module.exports = async function playbackService(): Promise<void> {
+  TrackPlayer.addEventListener(Event.RemotePlay, () => {
+    void TrackPlayer.play();
+  });
+
+  TrackPlayer.addEventListener(Event.RemotePause, () => {
+    void TrackPlayer.pause();
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteStop, () => {
+    // Stop and reset the queue position so the OS dismisses the now-playing
+    // card. We deliberately do NOT clear the queue — the user may resume
+    // from the in-app library without re-fetching.
+    void TrackPlayer.stop();
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteNext, () => {
+    void TrackPlayer.skipToNext();
+  });
+
+  TrackPlayer.addEventListener(Event.RemotePrevious, () => {
+    void TrackPlayer.skipToPrevious();
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteSeek, (event) => {
+    // event.position is in seconds, native-side validated to be ≥ 0
+    void TrackPlayer.seekTo(event.position);
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteJumpForward, async (event) => {
+    // event.interval is in seconds; iOS supplies the configured interval,
+    // Android supplies the value from the notification "+15s" button
+    const position = await TrackPlayer.getProgress().then((p) => p.position);
+    void TrackPlayer.seekTo(position + (event.interval ?? 15));
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteJumpBackward, async (event) => {
+    const position = await TrackPlayer.getProgress().then((p) => p.position);
+    void TrackPlayer.seekTo(Math.max(0, position - (event.interval ?? 15)));
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteDuck, (event) => {
+    // iOS only — phone call / Siri / alarm interrupted playback.
+    // permanent=true means the interruption ended without resume permission
+    // (e.g. user accepted the call). We stop so we don't auto-resume into
+    // the user's ear when the call ends.
+    if (event.permanent === true) {
+      void TrackPlayer.stop();
+      return;
+    }
+
+    if (event.paused === true) {
+      void TrackPlayer.pause();
+    } else {
+      void TrackPlayer.play();
+    }
+  });
+};

--- a/kiaanverse-mobile/apps/mobile/services/trackPlayerSetup.ts
+++ b/kiaanverse-mobile/apps/mobile/services/trackPlayerSetup.ts
@@ -1,0 +1,128 @@
+/**
+ * TrackPlayer Bootstrap — setupPlayer + service registration.
+ *
+ * Two things happen here and both are load-order sensitive:
+ *
+ *   1. `TrackPlayer.registerPlaybackService` — must run at module load, before
+ *      React mounts. The native module invokes the returned factory to spin up
+ *      a headless JS task whenever the OS needs to dispatch a remote control
+ *      event (lock screen / Bluetooth / AirPods / CarPlay). If registration
+ *      happens inside a component, the handlers disappear when the component
+ *      unmounts — which is exactly when the user taps the lock-screen play
+ *      button.
+ *
+ *   2. `TrackPlayer.setupPlayer` — allocates the native audio session and must
+ *      be called exactly once per process. Calling it a second time throws
+ *      "The player has already been initialized via setupPlayer." We guard
+ *      with `isSetup` so hot-reloads in dev don't crash.
+ *
+ * Capabilities advertised here are what will render on the lock screen /
+ * notification. We expose Play, Pause, SkipToNext, SkipToPrevious, SeekTo,
+ * and JumpForward/Backward (15 s). Stop is deliberately omitted from the
+ * compact-view list — users don't need a "kill" button on the lock screen,
+ * and including it crowds out the seek controls on small watches.
+ *
+ * Android AppKilledPlaybackBehavior:
+ *   - `StopPlaybackAndRemoveNotification` — when the user dismisses the app
+ *     from recents, playback stops and the notification clears. This matches
+ *     Play Store policy (post-2024 foreground-service rules).
+ */
+
+import TrackPlayer, {
+  AppKilledPlaybackBehavior,
+  Capability,
+  type ServiceHandler,
+} from 'react-native-track-player';
+
+let isSetup = false;
+let isServiceRegistered = false;
+
+/**
+ * Register the playback service. Must run at module load, before React mounts.
+ * Safe to call multiple times — the flag prevents double registration in
+ * Fast Refresh.
+ *
+ * The factory is passed as a function because react-native-track-player
+ * re-invokes it in a detached JS context; a direct reference would be GC'd
+ * after the original JS tree tears down.
+ */
+export function registerPlaybackService(): void {
+  if (isServiceRegistered) return;
+  isServiceRegistered = true;
+  // Require at call time so the service module is loaded into the headless
+  // JS task, not the main bundle. This is the pattern the RNTPlayer docs
+  // prescribe — eager import would cache handlers against the main JS
+  // context and lose them on kill.
+  TrackPlayer.registerPlaybackService(
+    // `require` inside the factory is required by RNTrackPlayer — eager
+    // import caches handlers against the main JS context and loses them
+    // when the OS spins up a new headless JS task post-kill. The service
+    // module uses `module.exports = async function …`, so the CommonJS
+    // require returns the ServiceHandler directly; the cast documents the
+    // contract (Metro's `require` is typed as `any`).
+    () => require('./playbackService') as unknown as ServiceHandler,
+  );
+}
+
+/**
+ * Initialize the native audio session. Idempotent — subsequent calls resolve
+ * without touching native. Must be awaited before any TrackPlayer.add / play
+ * call, otherwise native throws "The player is not initialized. Call
+ * setupPlayer first."
+ *
+ * Errors are swallowed and logged in __DEV__ only. Failing to set up the
+ * player is non-fatal — the in-app UI remains usable; only audio playback
+ * is disabled. The alternative (throwing) would crash the root layout on
+ * every cold start if the OS denies the audio session (rare, but happens
+ * on tvOS simulators and during CI).
+ */
+export async function setupTrackPlayer(): Promise<void> {
+  if (isSetup) return;
+
+  try {
+    await TrackPlayer.setupPlayer({
+      // Keep the default auto-update cadence (1 Hz) — UI subscribers use
+      // useProgress() which runs on a separate fast timer.
+      autoHandleInterruptions: true,
+    });
+
+    await TrackPlayer.updateOptions({
+      // Android: stop the foreground service when the task is swiped away.
+      // Required by Play Store foreground-service policy since SDK 34.
+      android: {
+        appKilledPlaybackBehavior:
+          AppKilledPlaybackBehavior.StopPlaybackAndRemoveNotification,
+      },
+      // Enable the subset of OS controls we actually implement. Advertising
+      // a capability the service doesn't handle would surface a dead button
+      // on the lock screen, which is worse than hiding it.
+      capabilities: [
+        Capability.Play,
+        Capability.Pause,
+        Capability.SkipToNext,
+        Capability.SkipToPrevious,
+        Capability.SeekTo,
+        Capability.JumpForward,
+        Capability.JumpBackward,
+      ],
+      // Subset shown in the compact lock-screen / notification view.
+      compactCapabilities: [
+        Capability.Play,
+        Capability.Pause,
+        Capability.SkipToNext,
+      ],
+      // The ±15 s skip is the de-facto podcast/meditation default.
+      forwardJumpInterval: 15,
+      backwardJumpInterval: 15,
+    });
+
+    isSetup = true;
+  } catch (err) {
+    if (__DEV__) {
+      // "The player has already been initialized" is benign — the user hit
+      // Fast Refresh. Any other error means audio won't work but the app
+      // otherwise functions normally.
+      console.warn('[trackPlayerSetup] setupPlayer failed:', err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR A of a two-PR split to make the Vibe Player actually play audio. **Infra only** — no UI or store changes. After this PR + an EAS rebuild:

- Lock-screen / Control Center / Bluetooth / AirPods / CarPlay controls render and dispatch to TrackPlayer (play, pause, next, previous, seek, ±15 s jump).
- Background audio survives screen-lock and recents-swipe on both iOS and Android 14+.
- iOS honors call / Siri / alarm interruptions without silent auto-resume into the user's ear.

PR B (follow-up) will replace the Zustand-only `isPlaying` / `progress` in the Vibe Player screens with `usePlaybackState()` / `useProgress()` so the UI syncs with native playback.

## Pieces

- **`services/playbackService.ts`** — headless JS task registered via `TrackPlayer.registerPlaybackService`. Attaches `Remote*` event handlers (play, pause, stop, next, previous, seek, jump ±15 s, duck). Lives in its own module so it survives UI teardown — a component-owned handler would disappear the moment the user hits the lock-screen play button.
- **`services/trackPlayerSetup.ts`** — idempotent `setupPlayer` + `updateOptions` bootstrap. Declares `Capability.Play / Pause / SkipToNext / SkipToPrevious / SeekTo / JumpForward / JumpBackward` for the OS control surface and sets `AppKilledPlaybackBehavior.StopPlaybackAndRemoveNotification` to satisfy Play Store foreground-service policy on SDK 34+.
- **`app/_layout.tsx`** — calls `registerPlaybackService()` at module load (before React mounts, matching the `backgroundTasks.ts` pattern); `await`s `setupTrackPlayer()` inside the existing `AppContent` setup chain so the native audio session is allocated before the first tap on a Vibe Player track (avoids audible latency).
- **`app.config.ts`** — adds `'audio'` to `UIBackgroundModes` so `AVAudioSession` survives lock/background; adds `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_MEDIA_PLAYBACK` Android permissions so the media-notification-channel foreground service can start on Android 14+.

## Why split this off from UI/store work

A correct `react-native-track-player` integration is **not a drop-in JS change** — it needs native entitlements (iOS background audio mode, Android foreground-service permission) that only take effect after an EAS rebuild. Merging infra first lets you:

1. Rebuild once, verify the capabilities expose correctly (lock-screen renders the control surface, notification shows on Android).
2. Iterate on PR B (store/UI sync with `usePlaybackState` / `useProgress`) as pure TS without any further native rebuilds.
3. Bisect cleanly if something regresses six months from now — infra vs behavior live in separate commits.

## Post-merge steps (the reviewer should do)

- [ ] `eas build --profile preview` for iOS and Android — the TS on today's binary is live but silent; audio only starts working after the rebuild.
- [ ] On a real device: play any meditation track, lock the screen, confirm the now-playing card appears with play/pause/skip controls and the buttons dispatch.
- [ ] Connect Bluetooth headphones, hit the inline play button — audio should toggle.
- [ ] iOS only: while audio plays, accept an incoming call — audio should pause; on hang-up it should **not** auto-resume (RemoteDuck permanent=true).
- [ ] Android only: swipe the app from recents while playing — notification should clear and playback should stop (Play Store policy).

## Test plan

- [x] `pnpm -r typecheck` inside `kiaanverse-mobile/` — 5/5 workspace projects pass, zero errors
- [ ] Rebuild via EAS (requires reviewer — not possible in this environment)
- [ ] Smoke-test lock-screen + Bluetooth + call-interruption on a real iPhone
- [ ] Smoke-test notification + recents-swipe on a real Android 14 device

## Intentionally out of scope (PR B)

- Zustand ↔ TrackPlayer queue sync (today the store still drives the mock UI)
- Replacing manual `progress` Zustand state with `useProgress()` hook
- Replacing manual `isPlaying` toggle with `usePlaybackState()` hook
- Wiring `playTrack` → `TrackPlayer.add` + `TrackPlayer.play`
- Real audio URLs on `meditation.tracks` response (today many use placeholder/silence)

https://claude.ai/code/session_01BUEbw95r1YKC56m917DDyV