### PR TITLE
feat(mobile): celebrate subscription success with confetti + Sanskrit tier name

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/success.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/success.tsx
@@ -3,14 +3,22 @@
  *
  * Reached via `router.replace('/(app)/subscription/success?tier=X')` from
  * plans.tsx once the receipt has been verified server-side. Displays a
- * short darshan moment before returning the user to the tabs.
+ * short darshan moment — Om, golden confetti, the Sanskrit name of the
+ * tier just entered, then back to the tabs.
+ *
+ * The Sanskrit label mirrors the plans screen (भक्त / साधक / सिद्ध) so
+ * the user recognizes what they chose rather than reading an English
+ * descriptor they just tapped past. Free tier is included for
+ * completeness but is never reached in practice — a successful purchase
+ * always resolves to a paid SubscriptionTier.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import {
+  ConfettiCannon,
   DivineButton,
   DivineScreenWrapper,
 } from '@kiaanverse/ui';
@@ -24,6 +32,18 @@ const VALID_TIERS: ReadonlySet<SubscriptionTier> = new Set([
   'siddha',
 ]);
 
+/**
+ * Sanskrit (Devanagari) label for each paid tier, matching the plans
+ * screen. Free is included only so the Record is exhaustive — the
+ * success flow never renders it.
+ */
+const TIER_SANSKRIT: Record<SubscriptionTier, string> = {
+  free: '',
+  bhakta: 'भक्त',
+  sadhak: 'साधक',
+  siddha: 'सिद्ध',
+};
+
 export default function SubscriptionSuccessScreen(): React.JSX.Element {
   const params = useLocalSearchParams<{ tier?: string }>();
   const tier: SubscriptionTier =
@@ -31,17 +51,26 @@ export default function SubscriptionSuccessScreen(): React.JSX.Element {
       ? (params.tier as SubscriptionTier)
       : 'sadhak';
 
+  // Gate the confetti with state so ConfettiCannon's `isActive` transitions
+  // false → true after the first render. Passing `true` as the initial
+  // value skips the trigger effect the component uses to reset particles.
+  const [celebrating, setCelebrating] = useState(false);
+
   useEffect(() => {
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setCelebrating(true);
   }, []);
 
   const tierName = TIER_CONFIGS[tier].name;
+  const sanskrit = TIER_SANSKRIT[tier];
 
   return (
     <DivineScreenWrapper>
+      <ConfettiCannon isActive={celebrating} particleCount={60} duration={3500} />
       <View style={styles.center}>
         <Text style={styles.om}>ॐ</Text>
         <Text style={styles.title}>Your Sankalpa Is Made</Text>
+        {sanskrit ? <Text style={styles.sanskrit}>{sanskrit}</Text> : null}
         <Text style={styles.subtitle}>
           The sacred path opens before you.{'\n'}
           Welcome, {tierName}.
@@ -49,7 +78,7 @@ export default function SubscriptionSuccessScreen(): React.JSX.Element {
 
         <View style={styles.button}>
           <DivineButton
-            title="Begin Your Journey"
+            title="Begin Your Sacred Journey"
             onPress={() => router.replace('/(tabs)')}
             variant="primary"
           />
@@ -75,6 +104,13 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontFamily: 'CormorantGaramond-BoldItalic',
     color: '#F0EBE1',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  sanskrit: {
+    fontSize: 40,
+    fontFamily: 'NotoSansDevanagari-Regular',
+    color: '#D4A017',
     textAlign: 'center',
     marginBottom: 12,
   },


### PR DESCRIPTION
## Summary

Narrow UX polish on `app/(app)/subscription/success.tsx` only. The rest of the subscription stack (plans, index, legacy paywall, `purchaseSubscription`, receipt verification, restore, product-ID constants, `TIER_CONFIGS`) is already fully implemented and backend-wired — no changes needed there.

The success screen was the single place where the sankalpa language fell back into plain English. `plans.tsx` already shows each tier's Devanagari name (भक्त / साधक / सिद्ध) on the card the user taps; dropping that recognition the moment the purchase completes made the post-purchase moment feel smaller than the commitment the user just made.

## Changes

- **ConfettiCannon on mount** — 60 particles, 3.5 s. Gated by a state transition so the component's first-render particle system triggers cleanly instead of firing on the initial `isActive={true}` render.
- **Sanskrit tier label** — Added above "Welcome, Bhakta." Tinted gold, rendered in `NotoSansDevanagari-Regular` at 40 pt to match the plans screen's card headers.
- **CTA copy** — "Begin Your Journey" → "Begin Your Sacred Journey" to mirror the plans screen title the user tapped in from.

## Audit notes for the rest of Prompt 9

Everything else the framework spec requested was already live on `main`:

| Framework bullet | Where it lives |
|---|---|
| 4 tier product IDs | `packages/api/src/subscription/constants.ts` — `com.kiaanverse.{bhakta,sadhak,siddha}.{monthly,yearly}` with USD/EUR/INR localized price displays |
| Plans screen with monthly/yearly toggle | `app/(app)/subscription/plans.tsx` — toggle, Sanskrit per card, `getProducts()` for localized prices, sticky CTA that auto-resolves subscribe/upgrade/downgrade/current |
| Play Billing sheet on tap | `purchaseSubscription(tier, billing, { onComplete, onError })` — drives the native sheet and verifies server-side |
| Tier updates in store on success | `setTier(result.tier, result.expiresAt)` is called from `onComplete` in both plans and legacy paywall |
| Restore purchases | `restorePurchases()` button on plans and `index.tsx` |
| Current plan / manage / cancel | `app/(app)/subscription/index.tsx` — `/api/subscriptions/current`, `openManageSubscription` deep-link to Play/App Store |

Rewriting `plans.tsx` to the framework's simpler 3-card template would have lost the current upgrade/downgrade CTA resolver and localized store prices, so it was left intact.

## Test plan

- [x] `pnpm -r typecheck` on `kiaanverse-mobile/` — 5/5 projects pass, zero errors
- [ ] On device after any purchase: confirm confetti fires, Sanskrit renders (requires `NotoSansDevanagari-Regular` loaded — it is, since plans.tsx already uses it), CTA returns to `/(tabs)`
- [ ] Screen reader check: Sanskrit glyph is announced as the tier name (may need an `accessibilityLabel`; flag if regression)

## Out of scope (on purpose)

- No store-backed changes
- No `plans.tsx` rewrite
- No receipt-verification changes
- No new product IDs

https://claude.ai/code/session_01BUEbw95r1YKC56m917DDyV