### PR TITLE
fix(mobile): route profile sign-out through authStore + add verse bookmark

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/profile.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/profile.tsx
@@ -17,7 +17,6 @@ import {
   Alert,
 } from 'react-native';
 import { router } from 'expo-router';
-import * as SecureStore from 'expo-secure-store';
 import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import {
@@ -27,6 +26,7 @@ import {
   OmLoader,
 } from '@kiaanverse/ui';
 import { apiClient } from '@kiaanverse/api';
+import { useAuthStore } from '@kiaanverse/store';
 
 // ── Types ──────────────────────────────────────────────────
 interface UserProfile {
@@ -108,6 +108,7 @@ export default function ProfileScreen(): React.JSX.Element {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [signingOut, setSigningOut] = useState(false);
+  const logout = useAuthStore((s) => s.logout);
 
   useEffect(() => {
     void fetchProfile();
@@ -135,8 +136,10 @@ export default function ProfileScreen(): React.JSX.Element {
           style: 'destructive',
           onPress: async () => {
             setSigningOut(true);
-            await SecureStore.deleteItemAsync('auth_token');
-            await SecureStore.deleteItemAsync('refresh_token');
+            // authStore.logout() invalidates the backend session, clears both
+            // tokens from SecureStore, and resets the Zustand state to
+            // `unauthenticated` so gated components re-render correctly.
+            await logout();
             router.replace('/(auth)/login');
           },
         },

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/[chapter]/[verse].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/[chapter]/[verse].tsx
@@ -26,7 +26,8 @@ import {
   View,
 } from 'react-native';
 import Animated, { FadeIn, FadeInDown } from 'react-native-reanimated';
-import { ChevronLeft, Share2, Sparkles } from 'lucide-react-native';
+import * as Haptics from 'expo-haptics';
+import { Bookmark, BookmarkCheck, ChevronLeft, Share2, Sparkles } from 'lucide-react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -69,6 +70,10 @@ export default function VerseDetailScreen(): React.JSX.Element {
   const verseId = paramsValid ? `${chapterNum}.${verseNum}` : '';
 
   const addRecentlyViewed = useGitaStore((s) => s.addRecentlyViewed);
+  const toggleBookmark = useGitaStore((s) => s.toggleBookmark);
+  const isBookmarked = useGitaStore((s) =>
+    verseId.length > 0 && s.bookmarkedVerseIds.includes(verseId),
+  );
 
   const { data, isLoading, error, refetch } = useGitaVerseDetail(
     paramsValid ? chapterNum : 0,
@@ -79,6 +84,18 @@ export default function VerseDetailScreen(): React.JSX.Element {
   useEffect(() => {
     if (paramsValid) addRecentlyViewed({ chapter: chapterNum, verse: verseNum });
   }, [addRecentlyViewed, chapterNum, paramsValid, verseNum]);
+
+  const handleToggleBookmark = useCallback(() => {
+    if (!paramsValid || verseId.length === 0) return;
+    void Haptics.impactAsync(
+      isBookmarked
+        ? Haptics.ImpactFeedbackStyle.Light
+        : Haptics.ImpactFeedbackStyle.Medium,
+    ).catch(() => {
+      // Haptics unavailable (simulator / tests) — silent.
+    });
+    toggleBookmark(verseId);
+  }, [isBookmarked, paramsValid, toggleBookmark, verseId]);
 
   const handleShare = useCallback(async () => {
     if (!data?.verse) return;
@@ -185,6 +202,8 @@ export default function VerseDetailScreen(): React.JSX.Element {
         title={reference}
         subtitle={v.theme ? v.theme.replace(/_/g, ' ') : undefined}
         onBack={() => router.back()}
+        isBookmarked={isBookmarked}
+        onToggleBookmark={handleToggleBookmark}
       />
 
       <ScrollView
@@ -309,9 +328,17 @@ interface HeaderProps {
   readonly title: string;
   readonly subtitle?: string | undefined;
   readonly onBack: () => void;
+  readonly isBookmarked?: boolean;
+  readonly onToggleBookmark?: () => void;
 }
 
-function Header({ title, subtitle, onBack }: HeaderProps): React.JSX.Element {
+function Header({
+  title,
+  subtitle,
+  onBack,
+  isBookmarked,
+  onToggleBookmark,
+}: HeaderProps): React.JSX.Element {
   return (
     <View style={styles.header}>
       <Pressable
@@ -333,7 +360,24 @@ function Header({ title, subtitle, onBack }: HeaderProps): React.JSX.Element {
           </Text>
         ) : null}
       </View>
-      <View style={styles.headerSpacer} />
+      {onToggleBookmark ? (
+        <Pressable
+          onPress={onToggleBookmark}
+          accessibilityRole="button"
+          accessibilityLabel={isBookmarked ? 'Remove bookmark' : 'Bookmark this verse'}
+          accessibilityState={{ selected: isBookmarked ?? false }}
+          hitSlop={12}
+          style={styles.backButton}
+        >
+          {isBookmarked ? (
+            <BookmarkCheck size={20} color={GOLD} fill={GOLD} />
+          ) : (
+            <Bookmark size={20} color={GOLD} />
+          )}
+        </Pressable>
+      ) : (
+        <View style={styles.headerSpacer} />
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary

After auditing all five remaining screens (sadhana / journal / shlokas / profile / settings) called out by the prompt, I found only two concrete gaps worth a targeted fix. The rest of the screens are already fully implemented against the real stores and API hooks and don't need changes.

### Fix 1 — Profile sign-out bypassed `authStore.logout()`

`app/(tabs)/profile.tsx` was manually calling
`SecureStore.deleteItemAsync('auth_token' / 'refresh_token')` and then
`router.replace('/(auth)/login')`, which left:

- Zustand state on `status: 'authenticated'` with the old `user` object still attached — any component gated on `useAuthStore(s => s.status)` would still treat the user as logged in.
- Backend session never invalidated (no call to `authService.logout()`).

`app/settings/index.tsx` already does this correctly via
`useAuthStore().logout()`. Profile now matches, which:

- calls `authService.logout()` to invalidate the backend session,
- clears both tokens via `clearTokens()`,
- resets the Zustand state to `unauthenticated`.

### Fix 2 — Verse detail had no bookmark action

`app/(tabs)/shlokas/[chapter]/[verse].tsx` had Ask Sakha + Share but no bookmark, even though `gitaStore.toggleBookmark(verseId)` and `bookmarkedVerseIds` have been in the store for a while and the prompt explicitly called for it.

Added a bookmark / bookmark-filled toggle to the verse header (right side of back button), wired to the store with haptic feedback and proper `accessibilityState` / `accessibilityLabel`.

### What I audited but didn't change

- **Sadhana** (`app/sadhana/index.tsx`) — already a full 5-phase ritual flow using the real `useSadhanaDaily` / `useSadhanaStreak` / `useCompleteSadhana` hooks. The prompt's described store API (`completePhase`, `todayPhases`) doesn't match the actual `sadhanaStore` shape; the real store exposes `phase`, `nextPhase`, `setMoodScore`, `setReflection`, `setIntention` — and the existing screen uses those correctly.
- **Journal** (`new.tsx` + `[id].tsx`) — both screens already implement AES-GCM encryption (`encryptContent` / `decryptContent` with `globalThis.crypto.subtle`), wire `useCreateJournal` / `useJournalEntry` / `useUpdateJournal` / `useDeleteJournal`, and have edit mode on the detail view.
- **Shlokas chapter list + chapter detail** — wired to `useGitaChapters` / `useGitaVerseDetail` with rich UI, `gitaStore` for verse-of-the-day and recently-viewed.
- **Settings** — already routes through `useAuthStore().logout()` on sign-out; wires `useUpdateSettings` for toggle changes.

## Test plan

- [x] `pnpm -r typecheck` → all 5 workspace projects pass with zero errors
- [x] `grep SecureStore.deleteItemAsync` in `profile.tsx` → no matches
- [x] `grep toggleBookmark` in `shlokas/[chapter]/[verse].tsx` → wired
- [ ] Manual smoke: Profile → Sign Out closes the backend session (check server logs); re-launch app lands on `/auth/login`
- [ ] Manual smoke: Open any verse → tap bookmark icon → icon fills; kill/re-launch app → bookmark persists (AsyncStorage via gitaStore `persist`)

https://claude.ai/code/session_01C7g9SKcbTaSw6t7iB759C8