### PR TITLE
chore(mobile): silence lint on intentional RNTrackPlayer require

### DIFF
--- a/kiaanverse-mobile/apps/mobile/services/trackPlayerSetup.ts
+++ b/kiaanverse-mobile/apps/mobile/services/trackPlayerSetup.ts
@@ -60,6 +60,7 @@ export function registerPlaybackService(): void {
     // module uses `module.exports = async function …`, so the CommonJS
     // require returns the ServiceHandler directly; the cast documents the
     // contract (Metro's `require` is typed as `any`).
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     () => require('./playbackService') as unknown as ServiceHandler,
   );
 }


### PR DESCRIPTION
## Summary

Surfaced while running the pre-build checklist on `main` (`pnpm -r lint`):

```
services/trackPlayerSetup.ts
  63:11  error  Require statement not part of import statement  @typescript-eslint/no-var-requires
```

The `require` at that line is **intentional** — `react-native-track-player`'s headless JS contract requires a factory that `require`s the playback service at call time. Eager `import()` caches handlers against the main JS context and loses them when the OS spins up a new headless JS task post-kill. The surrounding comment already documents this.

Fix: add a targeted `eslint-disable-next-line @typescript-eslint/no-var-requires` on that exact line. Every other `no-var-requires` callsite stays covered by the rule.

After this change: `pnpm -r lint` reports **0 errors** (44 pre-existing warnings remain — not in scope here).

## Test plan

- [x] `pnpm -r typecheck` → 0 errors (unchanged)
- [x] `pnpm -r lint` → 0 errors (was 1 before)
- [x] `pnpm -r test` → 222/222 passing (unchanged)
- [x] No runtime change — just a lint comment

https://claude.ai/code/session_01C7g9SKcbTaSw6t7iB759C8