### PR TITLE
chore(mobile): bump to 1.2.0 / versionCode 19 for Play release

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -11,7 +11,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: 'Kiaanverse',
   slug: 'kiaanverse',
-  version: '1.1.0',
+  version: '1.2.0',
   orientation: 'portrait',
   icon: './assets/icon.png',
   scheme: 'kiaanverse',
@@ -60,7 +60,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 
   android: {
     package: 'com.kiaanverse.app',
-    versionCode: 18,
+    versionCode: 19,
     adaptiveIcon: {
       foregroundImage: './assets/adaptive-icon.png',
       backgroundColor: '#050507',


### PR DESCRIPTION
## Summary

Release candidate for **v1.2.0 / versionCode 19**, rolling up everything merged since `1.1.0 / versionCode 18`:

- Home tab rebuild on `@kiaanverse/ui` primitives (#1578)
- Journey enemy filter alignment with canonical shadripu (#1579)
- Profile sign-out routed through `authStore.logout()` + verse bookmark toggle (#1583)

### Changes

- `apps/mobile/app.config.ts`: `version: '1.1.0'` → `'1.2.0'`
- `apps/mobile/app.config.ts`: `android.versionCode: 18` → `19`

`EXPO_PUBLIC_API_BASE_URL` for the production profile already points to
`https://mindvibe-api.onrender.com` — no `eas.json` change needed.

### Pre-build checklist run on `main` (before bump commit)

- [x] `pnpm -r typecheck` → all 5 projects pass, 0 errors
- [x] `pnpm -r lint` → 0 errors, 44 pre-existing warnings *(after #1584 lands; #1584 fixes a single `no-var-requires` error on an intentional `require` in `trackPlayerSetup.ts`)*
- [x] `pnpm -r test` → **222/222 passing** (api: 15, ui: 30, store: 100, mobile: 77)

### Post-merge — build & release

Gate this on **#1584** landing first so `pnpm -r lint` is clean. Then:

```bash
cd kiaanverse-mobile/apps/mobile
eas build --platform android --profile production --clear-cache
```

**Critical reconciliation** (flagged in the release checklist):
The EAS dashboard's "Git commit" must match the merge commit of this PR on
`main`. If they differ, EAS built stale code — do NOT download the `.aab`.

### Play Console release notes (suggested)

> 1.2.0 — Complete Feature Parity
>
> All sacred tools, KIAAN Vibe Player, Journeys, KarmaLytix, Karma
> Footprint, subscription via Play Billing.

## Test plan

- [x] `pnpm -r typecheck` passes after bump
- [ ] Manual: confirm Play Console upload shows versionCode **19**
- [ ] Manual: EAS dashboard "Git commit" matches `main` merge commit of this PR
- [ ] Manual: on-device smoke (cold launch, tools hub, audio, journey flow, sadhana, sign-out, etc.)

https://claude.ai/code/session_01C7g9SKcbTaSw6t7iB759C8