### PR TITLE
Refactor Vibe Player with tabs, add profile/password screens, promote Journeys

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -158,7 +158,16 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
 
   extra: {
-    apiBaseUrl: process.env.API_BASE_URL ?? 'http://localhost:8000',
+    // EAS injects EXPO_PUBLIC_API_BASE_URL at build time; the unprefixed
+    // API_BASE_URL is only visible during config evaluation, not at runtime.
+    // Read both so `Constants.expoConfig.extra.apiBaseUrl` is usable as a
+    // diagnostic if anything ever reads from it. Production fallback is the
+    // Render deployment rather than localhost, so a misconfigured build still
+    // hits a real backend.
+    apiBaseUrl:
+      process.env.EXPO_PUBLIC_API_BASE_URL ??
+      process.env.API_BASE_URL ??
+      'https://mindvibe-api.onrender.com',
     sentryDsn: process.env.SENTRY_DSN ?? '',
     eas: {
       projectId: '1f72d91b-2336-4b58-a641-5589317cc36c',

--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -60,7 +60,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 
   android: {
     package: 'com.kiaanverse.app',
-    versionCode: 19,
+    versionCode: 20,
     adaptiveIcon: {
       foregroundImage: './assets/adaptive-icon.png',
       backgroundColor: '#050507',

--- a/kiaanverse-mobile/apps/mobile/app/(app)/change-password.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/change-password.tsx
@@ -1,0 +1,232 @@
+/**
+ * Change Password — POST /api/auth/change-password.
+ *
+ * Backend contract (backend/routes/auth.py `change_password`):
+ *   body:     { current_password, new_password, revoke_other_sessions? }
+ *   errors:   403 WRONG_PASSWORD, 422 SAME_PASSWORD / VALIDATION_ERROR
+ *   policy:   ≥ 8 chars, upper + lower + digit + special, not common
+ *   response: { message, sessions_revoked }
+ *
+ * The client-side policy mirrored below exists to catch obvious mistakes
+ * before we round-trip — the server remains the authority. We still
+ * surface whatever the server says verbatim on 422 so the user sees the
+ * specific rule they violated ("must contain at least one special
+ * character" etc.) rather than a generic "please try again".
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import {
+  DivineScreenWrapper,
+  GoldenButton,
+  GoldenDivider,
+  SacredInput,
+} from '@kiaanverse/ui';
+import { apiClient } from '@kiaanverse/api';
+
+const TEXT_PRIMARY = '#F0EBE1';
+const TEXT_MUTED = 'rgba(240,235,225,0.5)';
+const TEXT_TERTIARY = 'rgba(240,235,225,0.4)';
+
+/** Surface a FastAPI error body — `detail` can be a string or `{detail, code}`. */
+function extractErrorMessage(err: unknown, fallback: string): string {
+  const response = (err as { response?: { data?: { detail?: unknown } } }).response;
+  const detail = response?.data?.detail;
+  if (typeof detail === 'string') return detail;
+  if (detail && typeof detail === 'object') {
+    const inner = (detail as { detail?: unknown; message?: unknown });
+    if (typeof inner.detail === 'string') return inner.detail;
+    if (typeof inner.message === 'string') return inner.message;
+  }
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+/** Client-side pre-flight validation matching the server policy. Returns
+ *  an error string or null when the password passes every local check. */
+function validateNewPassword(pwd: string, current: string): string | null {
+  if (pwd.length < 8) return 'Password must be at least 8 characters.';
+  if (pwd.length > 128) return 'Password must be at most 128 characters.';
+  if (!/[A-Z]/.test(pwd)) return 'Add at least one uppercase letter.';
+  if (!/[a-z]/.test(pwd)) return 'Add at least one lowercase letter.';
+  if (!/[0-9]/.test(pwd)) return 'Add at least one digit.';
+  if (!/[^A-Za-z0-9]/.test(pwd)) return 'Add at least one special character.';
+  if (current.length > 0 && pwd === current)
+    return 'New password must be different from your current password.';
+  return null;
+}
+
+export default function ChangePasswordScreen(): React.JSX.Element {
+  const router = useRouter();
+  const [current, setCurrent] = useState('');
+  const [newPass, setNewPass] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const fieldsFilled =
+    current.length > 0 && newPass.length > 0 && confirm.length > 0;
+
+  const previewError = useMemo(() => {
+    if (!newPass && !confirm) return null;
+    if (newPass && confirm && newPass !== confirm)
+      return 'New password and confirmation must match.';
+    if (newPass) return validateNewPassword(newPass, current);
+    return null;
+  }, [newPass, confirm, current]);
+
+  const handleChange = async () => {
+    if (newPass !== confirm) {
+      Alert.alert('Passwords do not match', 'Please re-enter the new password.');
+      return;
+    }
+    const policyError = validateNewPassword(newPass, current);
+    if (policyError) {
+      Alert.alert('Password too weak', policyError);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await apiClient.post('/api/auth/change-password', {
+        current_password: current,
+        new_password: newPass,
+      });
+      Alert.alert(
+        'Password changed',
+        'Your password has been updated. 🙏',
+        [{ text: 'OK', onPress: () => router.back() }],
+      );
+    } catch (err) {
+      Alert.alert(
+        'Could not change password',
+        extractErrorMessage(err, 'Please try again in a moment.'),
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <DivineScreenWrapper>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.kav}
+      >
+        <ScrollView
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Pressable
+            onPress={() => router.back()}
+            style={styles.backBtn}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            hitSlop={12}
+          >
+            <Text style={styles.backText}>{'‹ Back'}</Text>
+          </Pressable>
+
+          <Text style={styles.title}>Change Password</Text>
+          <Text style={styles.lede}>
+            For your security we re-verify your current password before setting
+            a new one.
+          </Text>
+
+          <GoldenDivider style={styles.divider} />
+
+          <SacredInput
+            value={current}
+            onChangeText={setCurrent}
+            placeholder="Current password"
+            secureTextEntry
+            autoCapitalize="none"
+            autoComplete="current-password"
+            textContentType="password"
+            containerStyle={styles.inputGap}
+          />
+          <SacredInput
+            value={newPass}
+            onChangeText={setNewPass}
+            placeholder="New password"
+            secureTextEntry
+            autoCapitalize="none"
+            autoComplete="new-password"
+            textContentType="newPassword"
+            containerStyle={styles.inputGap}
+          />
+          <SacredInput
+            value={confirm}
+            onChangeText={setConfirm}
+            placeholder="Confirm new password"
+            secureTextEntry
+            autoCapitalize="none"
+            autoComplete="new-password"
+            textContentType="newPassword"
+            error={previewError ?? undefined}
+            containerStyle={styles.inputGap}
+          />
+
+          <Text style={styles.rule}>
+            Minimum 8 characters with upper, lower, a digit, and a special
+            character.
+          </Text>
+
+          <GoldenButton
+            title={loading ? 'Changing…' : 'Change Password'}
+            onPress={handleChange}
+            loading={loading}
+            disabled={loading || !fieldsFilled || previewError !== null}
+            style={styles.cta}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </DivineScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  kav: { flex: 1 },
+  container: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 48,
+  },
+  backBtn: { marginBottom: 20 },
+  backText: {
+    fontSize: 15,
+    color: TEXT_MUTED,
+    fontFamily: 'Outfit-Regular',
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: TEXT_PRIMARY,
+  },
+  lede: {
+    marginTop: 6,
+    fontSize: 13,
+    lineHeight: 20,
+    color: TEXT_MUTED,
+    fontFamily: 'CrimsonText-Italic',
+  },
+  divider: { marginVertical: 20 },
+  inputGap: { marginBottom: 12 },
+  rule: {
+    marginTop: 4,
+    fontSize: 12,
+    lineHeight: 18,
+    color: TEXT_TERTIARY,
+    fontFamily: 'Outfit-Regular',
+  },
+  cta: { marginTop: 24 },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(app)/edit-profile.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/edit-profile.tsx
@@ -1,0 +1,244 @@
+/**
+ * Edit Profile — POST /api/profile.
+ *
+ * The backend profile route (backend/routes/profile.py) stores a separate
+ * Profile row that carries the display name as `full_name`. The User row
+ * still keeps its own `name` (used by the auth flow) — updating the
+ * Profile row is what the rest of the app reads from `api.profile.me`.
+ *
+ * Backend contract (ProfileCreateUpdateIn):
+ *   body:     { full_name?, base_experience }   ← base_experience REQUIRED
+ *   response: { full_name, base_experience, ... }
+ *
+ * `base_experience` is a required non-empty string on every write. To
+ * avoid clobbering an existing profile's value we read it back first via
+ * GET and re-send what's there; when the user has no profile row yet
+ * (GET returns 404) we seed `'new_user'` — the same sentinel the web
+ * profile page uses at first-sign-in (app/profile/page.tsx).
+ *
+ * After the POST succeeds we reconcile the local authStore user so the
+ * Profile tab + KIAAN greetings reflect the change immediately without
+ * waiting for a refetch.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import {
+  DivineScreenWrapper,
+  GoldenButton,
+  GoldenDivider,
+  SacredInput,
+} from '@kiaanverse/ui';
+import { api } from '@kiaanverse/api';
+import { useAuthStore } from '@kiaanverse/store';
+
+const TEXT_PRIMARY = '#F0EBE1';
+const TEXT_MUTED = 'rgba(240,235,225,0.5)';
+const TEXT_TERTIARY = 'rgba(240,235,225,0.4)';
+
+function extractErrorMessage(err: unknown, fallback: string): string {
+  const response = (err as { response?: { data?: { detail?: unknown } } }).response;
+  const detail = response?.data?.detail;
+  if (typeof detail === 'string') return detail;
+  if (detail && typeof detail === 'object') {
+    const inner = detail as { detail?: unknown; message?: unknown };
+    if (typeof inner.detail === 'string') return inner.detail;
+    if (typeof inner.message === 'string') return inner.message;
+  }
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+export default function EditProfileScreen(): React.JSX.Element {
+  const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+  const setUser = useAuthStore((s) => s.setUser);
+
+  const [name, setName] = useState<string>(user?.name ?? '');
+  const [loading, setLoading] = useState(false);
+
+  const trimmed = name.trim();
+  const hasChanges = trimmed.length > 0 && trimmed !== (user?.name ?? '');
+
+  const handleSave = useCallback(async () => {
+    if (trimmed.length === 0) {
+      Alert.alert('Name required', 'Your sacred name cannot be empty.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // Preserve whatever base_experience the backend already has; fall
+      // back to 'new_user' when no profile row exists yet (first-time
+      // write). Without this the POST would 422 because base_experience
+      // is required and has no server-side default.
+      let baseExperience = 'new_user';
+      try {
+        const { data: existing } = await api.profile.get();
+        const existingBase = (existing as { base_experience?: unknown } | null)
+          ?.base_experience;
+        if (typeof existingBase === 'string' && existingBase.length > 0) {
+          baseExperience = existingBase;
+        }
+      } catch (getErr) {
+        // 404 = no profile yet; anything else is unexpected but non-fatal
+        // for the write — we'll still attempt the POST with the sentinel.
+        const status = (getErr as { statusCode?: number }).statusCode;
+        if (status !== 404 && status !== undefined) {
+          // eslint-disable-next-line no-console
+          console.warn('[edit-profile] profile.get failed:', status, getErr);
+        }
+      }
+
+      const { data } = await api.profile.update({
+        full_name: trimmed,
+        base_experience: baseExperience,
+      });
+      const nextName =
+        (data as { full_name?: string | null } | null)?.full_name ?? trimmed;
+
+      // Optimistically reconcile the authStore — Profile tab + KIAAN
+      // greetings read from `user.name` and won't refetch until the next
+      // app resume otherwise.
+      if (user) {
+        setUser({ ...user, name: nextName });
+      }
+
+      Alert.alert(
+        'Profile updated',
+        'Your sacred identity has been updated. 🙏',
+        [{ text: 'OK', onPress: () => router.back() }],
+      );
+    } catch (err) {
+      Alert.alert(
+        'Could not update profile',
+        extractErrorMessage(err, 'Please try again in a moment.'),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [trimmed, user, setUser, router]);
+
+  return (
+    <DivineScreenWrapper>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.kav}
+      >
+        <ScrollView
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Pressable
+            onPress={() => router.back()}
+            style={styles.backBtn}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            hitSlop={12}
+          >
+            <Text style={styles.backText}>{'‹ Back'}</Text>
+          </Pressable>
+
+          <Text style={styles.title}>Edit Profile</Text>
+
+          <GoldenDivider style={styles.divider} />
+
+          <Text style={styles.label}>Display name</Text>
+          <SacredInput
+            value={name}
+            onChangeText={setName}
+            placeholder="Your sacred name"
+            autoFocus
+            autoCapitalize="words"
+            autoComplete="name"
+            textContentType="name"
+            maxLength={60}
+            returnKeyType="done"
+            onSubmitEditing={handleSave}
+          />
+          <Text style={styles.note}>
+            This name appears on your profile and in KIAAN greetings.
+          </Text>
+
+          {user?.email ? (
+            <>
+              <Text style={[styles.label, styles.labelSpaced]}>Email</Text>
+              <Text style={styles.readOnly}>{user.email}</Text>
+              <Text style={styles.note}>
+                Email changes are not yet supported. Contact support to update
+                it.
+              </Text>
+            </>
+          ) : null}
+
+          <GoldenButton
+            title={loading ? 'Saving…' : 'Save Changes'}
+            onPress={handleSave}
+            loading={loading}
+            disabled={loading || !hasChanges}
+            style={styles.cta}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </DivineScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  kav: { flex: 1 },
+  container: {
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 48,
+  },
+  backBtn: { marginBottom: 20 },
+  backText: {
+    fontSize: 15,
+    color: TEXT_MUTED,
+    fontFamily: 'Outfit-Regular',
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: 'CormorantGaramond-BoldItalic',
+    color: TEXT_PRIMARY,
+  },
+  divider: { marginVertical: 20 },
+  label: {
+    fontSize: 13,
+    fontFamily: 'Outfit-SemiBold',
+    color: TEXT_PRIMARY,
+    marginBottom: 8,
+  },
+  labelSpaced: {
+    marginTop: 20,
+  },
+  readOnly: {
+    fontSize: 15,
+    fontFamily: 'Outfit-Regular',
+    color: TEXT_PRIMARY,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 14,
+    backgroundColor: 'rgba(22,26,66,0.4)',
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.14)',
+  },
+  note: {
+    marginTop: 8,
+    fontSize: 12,
+    lineHeight: 18,
+    color: TEXT_TERTIARY,
+    fontFamily: 'Outfit-Regular',
+  },
+  cta: { marginTop: 32 },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(app)/subscription/plans.tsx
@@ -39,6 +39,7 @@ import {
 import {
   apiClient,
   getProducts,
+  isSubscriptionUnavailableError,
   purchaseSubscription,
   restorePurchases,
   TIER_CONFIGS,
@@ -162,6 +163,18 @@ export default function SubscriptionPlansScreen(): React.JSX.Element {
         },
         onError: (message) => {
           if (message === 'Purchase cancelled.') return;
+          // Distinguish "Play Store hasn't activated the product yet" from
+          // real purchase failures so users see a reassuring "Coming soon"
+          // rather than a scary "Purchase unsuccessful" on tiers that are
+          // still being configured server-side.
+          if (isSubscriptionUnavailableError(message)) {
+            Alert.alert(
+              'Coming soon 🙏',
+              'This plan will be available very soon. Thank you for your patience.',
+              [{ text: 'OK' }],
+            );
+            return;
+          }
           Alert.alert('Purchase unsuccessful', message);
         },
       });

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,7 +1,12 @@
 /**
  * Tabs Layout — 5-tab bottom navigation for Kiaanverse.
  *
- *   Home · Chat · Shlokas · Journal · Profile
+ *   Home · Sakha · Journeys · Journal · Profile
+ *
+ * Shlokas used to live in slot 3 and Journeys was buried as a sub-tab of
+ * Journal; the layout promotes Journeys to a top-level destination and
+ * keeps Shlokas reachable via deep-links (from the Vibe Player's Daily
+ * Verse banner, notifications, etc.) while removing it from the tab bar.
  *
  * - Uses the custom DivineTabBar (gold-accented, dark navy background).
  * - `freezeOnBlur` preserves tab state (scroll positions, chat history,
@@ -9,6 +14,9 @@
  * - Deep-link routes (`/journey/...`, `/verse/...`, `/journal/new`, etc.)
  *   live outside the (tabs) group and are pushed with the Expo Router
  *   stack, not rendered in the tab bar.
+ * - `shlokas` is registered with `href: null` so its route is still valid
+ *   (every existing `router.push('/(tabs)/shlokas/...')` call in the app
+ *   keeps working) but it doesn't render in the bottom bar.
  */
 
 import React from 'react';
@@ -30,9 +38,14 @@ export default function TabsLayout(): React.JSX.Element {
     >
       <Tabs.Screen name="index" options={{ title: t('home') }} />
       <Tabs.Screen name="chat" options={{ title: t('chat') }} />
-      <Tabs.Screen name="shlokas" options={{ title: t('shlokas') }} />
+      <Tabs.Screen name="journeys" options={{ title: t('journeys') }} />
       <Tabs.Screen name="journal" options={{ title: t('journal') }} />
       <Tabs.Screen name="profile" options={{ title: t('profile') }} />
+      {/* Hidden from the bottom bar but still routable — see header note. */}
+      <Tabs.Screen
+        name="shlokas"
+        options={{ title: t('shlokas'), href: null }}
+      />
     </Tabs>
   );
 }

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/journal.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/journal.tsx
@@ -39,6 +39,7 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { LinearGradient } from 'expo-linear-gradient';
 import {
   Text,
   Input,
@@ -68,6 +69,62 @@ const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.4;
  * `category` field — the diary remains the single source of truth.
  */
 const TAG_FILTERS = ['All', 'Gratitude', 'Reflection', 'Prayer', 'Dream', 'Insight'] as const;
+
+// ---------------------------------------------------------------------------
+// KarmaLytixBanner — promoted shortcut into the Sacred Mirror surface
+// ---------------------------------------------------------------------------
+
+/**
+ * KarmaLytix banner pinned above the entry list.
+ *
+ * The Sacred Mirror reads exclusively from journal metadata (mood tags,
+ * category tags, the weekly self-assessment) — the encrypted body is never
+ * decrypted server-side. Surfacing that guarantee inline makes the privacy
+ * contract visible at the point of trust, not buried in a settings screen.
+ */
+function KarmaLytixBanner({
+  onPress,
+}: {
+  onPress: () => void;
+}): React.JSX.Element {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="Open KarmaLytix Sacred Mirror"
+      style={styles.karmaLytixWrap}
+    >
+      <LinearGradient
+        colors={['rgba(212,160,23,0.08)', 'rgba(212,160,23,0.18)']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.karmaLytixGradient}
+      >
+        <View style={styles.karmaLytixLeft}>
+          {/* The mirror glyph mirrors the "Sacred Mirror" product name —
+              a small visual cue that costs us zero extra assets. */}
+          <Text style={styles.karmaLytixIcon} accessibilityElementsHidden>
+            {'\u{1FA9E}'}
+          </Text>
+          <View style={styles.karmaLytixTextWrap}>
+            <Text variant="label" color={colors.primary[500]}>
+              KarmaLytix
+            </Text>
+            <Text variant="caption" color={colors.text.secondary} style={styles.karmaLytixSub}>
+              KIAAN analyses your reflections
+            </Text>
+            <Text variant="caption" color={colors.text.muted} style={styles.karmaLytixPrivacy}>
+              {'\u{1F512}'} Metadata only · Content never read
+            </Text>
+          </View>
+        </View>
+        <Text variant="h3" color={colors.primary[500]} style={styles.karmaLytixArrow}>
+          {'›'}
+        </Text>
+      </LinearGradient>
+    </Pressable>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // SwipeableEntryCard — pan-to-reveal-delete
@@ -263,6 +320,11 @@ function JournalView(): React.JSX.Element {
     router.push('/journal/new');
   }, [router]);
 
+  const handleOpenKarmaLytix = useCallback(() => {
+    void Haptics.selectionAsync();
+    router.push('/analytics');
+  }, [router]);
+
   const handleTagPress = useCallback((tag: string) => {
     void Haptics.selectionAsync();
     setActiveTag(tag);
@@ -356,6 +418,10 @@ function JournalView(): React.JSX.Element {
           keyExtractor={keyExtractor}
           contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 96 }]}
           showsVerticalScrollIndicator={false}
+          // The KarmaLytix banner sits above the entry list and scrolls
+          // with it so it stays out of the way on long diaries but is
+          // immediately visible when the user opens the tab.
+          ListHeaderComponent={<KarmaLytixBanner onPress={handleOpenKarmaLytix} />}
           ListEmptyComponent={renderEmpty}
           refreshControl={
             <RefreshControl
@@ -389,42 +455,16 @@ function JournalView(): React.JSX.Element {
 
 export default function JournalScreen(): React.JSX.Element {
   const insets = useSafeAreaInsets();
-  const router = useRouter();
   const { t } = useTranslation('journal');
 
-  const handleOpenKarmaLytix = useCallback(() => {
-    void Haptics.selectionAsync();
-    // Deep-link to the Sacred Mirror surface. Journal and KarmaLytix share
-    // the same source data (encrypted entries + tags + moods) so this is the
-    // natural companion surface, and the previous hub-tab UX buried it under
-    // Profile → Analytics.
-    router.push('/analytics');
-  }, [router]);
-
+  // KarmaLytix is surfaced inline in the entry list header — see
+  // KarmaLytixBanner above — so this outer screen stays minimal and the
+  // Sacred Mirror CTA appears in the same scroll context as the user's
+  // reflections.
   return (
     <DivineBackground variant="sacred" style={styles.root}>
       <View style={[styles.container, { paddingTop: insets.top }]}>
         <GoldenHeader title={t('hubTitle', 'Sacred Reflections')} />
-
-        {/* Header-level KarmaLytix shortcut — a single row above the diary
-            list. Styled like a subtle link rather than a primary CTA so it
-            doesn't compete with the "New Entry" FAB below. */}
-        <View style={styles.headerActions}>
-          <Pressable
-            onPress={handleOpenKarmaLytix}
-            accessibilityRole="button"
-            accessibilityLabel={t(
-              'openKarmaLytix',
-              'Open KarmaLytix Sacred Mirror',
-            )}
-            style={styles.karmaLytixLink}
-          >
-            <Text variant="caption" color={colors.primary[500]}>
-              {t('karmaLytixLink', 'KarmaLytix →')}
-            </Text>
-          </Pressable>
-        </View>
-
         <JournalView />
       </View>
     </DivineBackground>
@@ -443,21 +483,45 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 
-  // -- Header actions (KarmaLytix shortcut) --
-  headerActions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.xs,
-    paddingBottom: spacing.xs,
-  },
-  karmaLytixLink: {
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xxs,
-    borderRadius: 12,
+  // -- KarmaLytix banner (sits atop the entry list) --
+  karmaLytixWrap: {
+    marginBottom: spacing.sm,
+    borderRadius: 14,
+    overflow: 'hidden',
     borderWidth: 1,
     borderColor: colors.alpha.goldMedium,
-    backgroundColor: colors.alpha.goldLight,
+  },
+  karmaLytixGradient: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  karmaLytixLeft: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  karmaLytixIcon: {
+    fontSize: 28,
+    lineHeight: 32,
+  },
+  karmaLytixTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+  karmaLytixSub: {
+    marginTop: 2,
+  },
+  karmaLytixPrivacy: {
+    marginTop: 2,
+    fontStyle: 'italic',
+  },
+  karmaLytixArrow: {
+    paddingLeft: spacing.xs,
   },
 
   // -- Journal view --

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/journal.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/journal.tsx
@@ -1,18 +1,19 @@
 /**
- * Sacred Journal Hub — tabbed surface combining the daily diary with the
- * Sacred Journeys engine (षड्रिपु — the six inner enemies).
+ * Sacred Reflections — encrypted daily diary.
  *
- * Two tabs:
- *   1. "Sacred Journal" — the encrypted daily diary. Search, tag-filter,
- *      swipe-to-delete, long-press-to-edit, pull-to-refresh, FAB for new
- *      entries. Each entry's body is AES-256-GCM encrypted client-side
- *      (see apps/mobile/app/journal/new.tsx for key management).
- *   2. "Journeys" — lightweight hub for active Sacred Journeys with a CTA
- *      into the full catalog at /journey.
+ * Single-purpose surface: search, tag-filter, swipe-to-delete,
+ * long-press-to-edit, pull-to-refresh, FAB for new entries. Each entry's
+ * body is AES-256-GCM encrypted client-side (see
+ * apps/mobile/app/journal/new.tsx for key management).
+ *
+ * Journeys used to share this tab as a secondary sub-tab; they now live in
+ * their own top-level Journeys tab so the diary stays writing-first.
  *
  * The diary fuels KarmaLytix: mood tags, category tags, and encrypted
  * reflections feed the analytics engine (server-side reflection text is
- * never decrypted — only tags and metadata).
+ * never decrypted — only tags and metadata). A "KarmaLytix" header action
+ * links straight into the analytics surface so users aren't forced to dig
+ * through Profile to find their weekly mirror.
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
@@ -53,7 +54,6 @@ import { useJournalEntries, useDeleteJournal } from '@kiaanverse/api';
 import type { JournalEntry } from '@kiaanverse/api';
 import { useTranslation } from '@kiaanverse/i18n';
 import { JournalEntryCard } from '../../components/journal/JournalEntryCard';
-import { JourneysView } from '../../components/journal/JourneysView';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.4;
@@ -61,9 +61,6 @@ const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.4;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-const HUB_TABS = ['journal', 'journeys'] as const;
-type HubTab = (typeof HUB_TABS)[number];
 
 /**
  * Category filters for the Sacred Journal. These operate on the entry's
@@ -159,37 +156,6 @@ function SwipeableEntryCard({
         </Animated.View>
       </GestureDetector>
     </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// TabPill — hub-level tab switcher
-// ---------------------------------------------------------------------------
-
-function TabPill({
-  label,
-  isActive,
-  onPress,
-}: {
-  label: string;
-  isActive: boolean;
-  onPress: () => void;
-}): React.JSX.Element {
-  return (
-    <Pressable
-      onPress={onPress}
-      style={[styles.tabPill, isActive && styles.tabPillActive]}
-      accessibilityRole="tab"
-      accessibilityState={{ selected: isActive }}
-    >
-      <Text
-        variant="label"
-        color={isActive ? colors.background.dark : colors.text.muted}
-        align="center"
-      >
-        {label}
-      </Text>
-    </Pressable>
   );
 }
 
@@ -418,39 +384,48 @@ function JournalView(): React.JSX.Element {
 }
 
 // ---------------------------------------------------------------------------
-// Main Screen — tabbed hub
+// Main Screen — Sacred Reflections with a KarmaLytix shortcut
 // ---------------------------------------------------------------------------
 
-export default function JournalHubScreen(): React.JSX.Element {
+export default function JournalScreen(): React.JSX.Element {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const { t } = useTranslation('journal');
-  const [activeTab, setActiveTab] = useState<HubTab>('journal');
 
-  const handleTabChange = useCallback((tab: HubTab) => {
-    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setActiveTab(tab);
-  }, []);
+  const handleOpenKarmaLytix = useCallback(() => {
+    void Haptics.selectionAsync();
+    // Deep-link to the Sacred Mirror surface. Journal and KarmaLytix share
+    // the same source data (encrypted entries + tags + moods) so this is the
+    // natural companion surface, and the previous hub-tab UX buried it under
+    // Profile → Analytics.
+    router.push('/analytics');
+  }, [router]);
 
   return (
     <DivineBackground variant="sacred" style={styles.root}>
       <View style={[styles.container, { paddingTop: insets.top }]}>
         <GoldenHeader title={t('hubTitle', 'Sacred Reflections')} />
 
-        {/* Hub-level tab switcher */}
-        <View style={styles.hubTabRow}>
-          <TabPill
-            label={t('sacredJournal', 'Sacred Journal')}
-            isActive={activeTab === 'journal'}
-            onPress={() => handleTabChange('journal')}
-          />
-          <TabPill
-            label={t('journeys', 'Journeys')}
-            isActive={activeTab === 'journeys'}
-            onPress={() => handleTabChange('journeys')}
-          />
+        {/* Header-level KarmaLytix shortcut — a single row above the diary
+            list. Styled like a subtle link rather than a primary CTA so it
+            doesn't compete with the "New Entry" FAB below. */}
+        <View style={styles.headerActions}>
+          <Pressable
+            onPress={handleOpenKarmaLytix}
+            accessibilityRole="button"
+            accessibilityLabel={t(
+              'openKarmaLytix',
+              'Open KarmaLytix Sacred Mirror',
+            )}
+            style={styles.karmaLytixLink}
+          >
+            <Text variant="caption" color={colors.primary[500]}>
+              {t('karmaLytixLink', 'KarmaLytix →')}
+            </Text>
+          </Pressable>
         </View>
 
-        {activeTab === 'journal' ? <JournalView /> : <JourneysView />}
+        <JournalView />
       </View>
     </DivineBackground>
   );
@@ -468,24 +443,21 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 
-  // -- Hub tabs --
-  hubTabRow: {
+  // -- Header actions (KarmaLytix shortcut) --
+  headerActions: {
     flexDirection: 'row',
-    gap: spacing.xs,
+    justifyContent: 'flex-end',
     paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.xs,
+    paddingTop: spacing.xs,
+    paddingBottom: spacing.xs,
   },
-  tabPill: {
-    flex: 1,
-    paddingVertical: spacing.sm,
-    borderRadius: 999,
-    backgroundColor: colors.alpha.goldLight,
+  karmaLytixLink: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: 12,
     borderWidth: 1,
     borderColor: colors.alpha.goldMedium,
-  },
-  tabPillActive: {
-    backgroundColor: colors.primary[500],
-    borderColor: colors.primary[500],
+    backgroundColor: colors.alpha.goldLight,
   },
 
   // -- Journal view --

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/journeys.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/journeys.tsx
@@ -1,0 +1,48 @@
+/**
+ * Journeys Tab — standalone षड्रिपु Sacred Journey surface.
+ *
+ * Previously this content lived inside a "Journeys" sub-tab of the Journal
+ * hub, which made the dharma-wheel flow three taps deep. Splitting it into
+ * a top-level tab matches the product spec (Home · Sakha · Journeys ·
+ * Journal · Profile) and gives the six inner enemies the real estate they
+ * deserve.
+ *
+ * The actual list + empty state + enemy metadata lives in
+ * `components/journal/JourneysView.tsx` — we reuse it as-is so the two
+ * surfaces (tab + any future embed) stay in sync. When the Journal hub
+ * was dismantled, this was the only consumer left.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  DivineBackground,
+  GoldenHeader,
+} from '@kiaanverse/ui';
+import { useTranslation } from '@kiaanverse/i18n';
+
+import { JourneysView } from '../../components/journal/JourneysView';
+
+export default function JourneysTab(): React.JSX.Element {
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation('navigation');
+
+  return (
+    <DivineBackground variant="sacred" style={styles.root}>
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <GoldenHeader title={t('journeys', 'Journeys')} />
+        <JourneysView />
+      </View>
+    </DivineBackground>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/subscription.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/subscription.tsx
@@ -40,6 +40,7 @@ import { useSubscriptionStore, type SubscriptionTier } from '@kiaanverse/store';
 import {
   initializeIAP,
   getProducts,
+  isSubscriptionUnavailableError,
   purchaseSubscription,
   restorePurchases,
   type IAPProduct,
@@ -362,6 +363,20 @@ export default function SubscriptionScreen(): React.JSX.Element {
             }
           },
           onError: (errorMsg) => {
+            // "Play Store hasn't activated the product yet" is not a
+            // purchase failure — it's a store configuration gap. Show a
+            // friendlier "coming soon" alert and clear the error status
+            // so the CTA returns to its idle state rather than staying
+            // stuck on a red error banner.
+            if (isSubscriptionUnavailableError(errorMsg)) {
+              setPurchaseStatus('idle');
+              Alert.alert(
+                'Coming soon 🙏',
+                'This plan will be available very soon. Thank you for your patience.',
+                [{ text: 'OK' }],
+              );
+              return;
+            }
             setPurchaseStatus('error', errorMsg);
           },
         });

--- a/kiaanverse-mobile/apps/mobile/app/tools/karma-reset/phases/acknowledgment.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/karma-reset/phases/acknowledgment.tsx
@@ -55,6 +55,23 @@ import { KarmaPhaseTracker } from '../../../../components/karma-reset/KarmaPhase
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
+/**
+ * Two-column card grid width.
+ *
+ *   SCREEN_WIDTH − (horizontal padding × 2) − (column gap)
+ *   ─────────────────────────────────────────────────────── = card width
+ *                         2
+ *
+ * Uses the UI kit tokens so the calculation tracks design changes:
+ * `spacing.lg` is the outer ScrollView padding on each side and
+ * `spacing.sm` is the gap between the two columns, matching the
+ * grid container's `gap`. Using a concrete pixel width (rather than
+ * `width: '47%'` inside a nested Animated.View wrapper, which
+ * previously resolved against the wrapper's intrinsic width) guarantees
+ * the cards are wide enough for Devanagari script and line up flush.
+ */
+const CARD_WIDTH = Math.floor((SCREEN_WIDTH - spacing.lg * 2 - spacing.sm) / 2);
+
 // ---------------------------------------------------------------------------
 // Shadripu — The Six Enemies of the Mind
 // ---------------------------------------------------------------------------
@@ -62,45 +79,51 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const KARMIC_PATTERNS: readonly KarmicPattern[] = [
   {
     id: 'kama',
-    sanskrit: 'काम (Kāma)',
+    sanskrit: 'काम',
+    romanName: 'Kāma',
     english: 'Desire / Attachment',
     icon: '🔥',
     description: 'Clinging to outcomes, people, or possessions that bind the soul',
   },
   {
     id: 'krodha',
-    sanskrit: 'क्रोध (Krodha)',
+    sanskrit: 'क्रोध',
+    romanName: 'Krodha',
     english: 'Anger',
     icon: '⚡',
     description: 'Reactive fury that clouds judgment and harms sacred bonds',
   },
   {
     id: 'lobha',
-    sanskrit: 'लोभ (Lobha)',
+    sanskrit: 'लोभ',
+    romanName: 'Lobha',
     english: 'Greed',
     icon: '💰',
     description: 'Insatiable wanting that leaves the soul perpetually empty',
   },
   {
     id: 'moha',
-    sanskrit: 'मोह (Moha)',
+    sanskrit: 'मोह',
+    romanName: 'Moha',
     english: 'Delusion',
     icon: '🌀',
     description: 'Confusion about what is real, mistaking the transient for eternal',
   },
   {
     id: 'mada',
-    sanskrit: 'मद (Mada)',
+    sanskrit: 'मद',
+    romanName: 'Mada',
     english: 'Pride',
     icon: '👑',
     description: 'Ego-driven superiority that separates you from the divine in others',
   },
   {
     id: 'matsarya',
-    sanskrit: 'मात्सर्य (Mātsarya)',
+    sanskrit: 'मात्सर्य',
+    romanName: 'Mātsarya',
     english: 'Jealousy',
     icon: '🐍',
-    description: 'Resentment of another\'s fortune that poisons your own peace',
+    description: "Resentment of another's fortune that poisons your own peace",
   },
 ] as const;
 
@@ -196,17 +219,23 @@ export default function AcknowledgmentPhase(): React.JSX.Element {
 
           <SacredDivider />
 
-          {/* Pattern grid -- 2 columns of sacred cards */}
+          {/* Pattern grid — 2 columns of sacred cards.
+              The outer Animated.View carries the computed width so the
+              staggered entrance animation and the card itself share the
+              same footprint — preventing the Sanskrit text from wrapping
+              mid-word on narrow phones. */}
           <Animated.View entering={FadeIn.duration(600).delay(300)} style={styles.grid}>
             {KARMIC_PATTERNS.map((pattern, index) => (
               <Animated.View
                 key={pattern.id}
                 entering={FadeInDown.duration(400).delay(300 + index * 80)}
+                style={{ width: CARD_WIDTH }}
               >
                 <KarmicPatternCard
                   pattern={pattern}
                   isSelected={selectedPatternId === pattern.id}
                   onSelect={handleSelect}
+                  style={{ width: CARD_WIDTH }}
                 />
               </Animated.View>
             ))}

--- a/kiaanverse-mobile/apps/mobile/app/tools/viyoga/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/viyoga/index.tsx
@@ -28,7 +28,7 @@ import {
   spacing,
   radii,
 } from '@kiaanverse/ui';
-import { useViyogaChat } from '@kiaanverse/api';
+import { useViyogaChat, isAuthError, isOfflineError, isApiError } from '@kiaanverse/api';
 
 interface ChatMessage {
   id: string;
@@ -80,20 +80,50 @@ export default function ViyogaScreen(): React.JSX.Element {
         setSessionId(result.session_id);
       }
 
+      // The backend may return an empty `assistant` field when KIAAN chose
+      // not to respond (e.g. safety tripwire). Fall back to a transparent
+      // note so the bubble never renders as empty whitespace.
+      const content =
+        result.message && result.message.trim().length > 0
+          ? result.message
+          : 'I received your words but cannot form a response right now. Please rephrase and try again.';
+
       const assistantMessage: ChatMessage = {
         id: `assistant-${Date.now()}`,
         role: 'assistant',
-        content: result.message,
+        content,
         timestamp: Date.now(),
       };
       setMessages((prev) => [...prev, assistantMessage]);
-    } catch {
+    } catch (err) {
+      // Surface the real failure mode so the user can act on it — hiding
+      // every error behind the same "please try again" kaomoji masks
+      // auth / network / cold-start issues that feel like the app is broken.
+      let content: string;
+      if (isAuthError(err)) {
+        content =
+          'Your session has expired. Please sign in again to continue the dialogue with Viyoga.';
+      } else if (isOfflineError(err)) {
+        content =
+          'The network is unreachable. Check your connection and try once more.';
+      } else if (isApiError(err) && err.statusCode >= 500) {
+        content =
+          'KIAAN is waking from deep meditation (cold start). Please wait a moment and try again.';
+      } else if (err instanceof Error && err.message) {
+        content = `Viyoga could not respond: ${err.message}`;
+      } else {
+        content = 'Viyoga could not respond right now. Please try again.';
+      }
+
+      // eslint-disable-next-line no-console
+      console.error('[Viyoga] send failed', err);
+
       setMessages((prev) => [
         ...prev,
         {
           id: `error-${Date.now()}`,
           role: 'assistant',
-          content: 'The path to letting go sometimes pauses. Please try sharing again.',
+          content,
           timestamp: Date.now(),
         },
       ]);

--- a/kiaanverse-mobile/apps/mobile/app/vibe-player/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/vibe-player/index.tsx
@@ -17,6 +17,7 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import {
+  Alert,
   FlatList,
   StyleSheet,
   Text,
@@ -103,6 +104,11 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
 
   const handleTrackPress = useCallback(
     (track: MeditationTrack) => {
+      // The bridge returns a typed result so we can show the user a real
+      // reason when playback fails (unhosted audio, RNTP error) instead of
+      // the previous silent no-op. We still optimistically update the
+      // store + navigate for the happy path so the UI feels instant; on
+      // failure we rewind the store state and stay on this screen.
       const vibeTrack: VibeTrack = {
         id: track.id,
         title: track.title,
@@ -115,6 +121,7 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
       play();
       showMiniPlayer();
       if (tracks) hydrateQueue(tracks);
+
       void playTrack({
         id: track.id,
         title: track.title,
@@ -122,8 +129,25 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
         audioUrl: track.audioUrl,
         duration: track.duration,
         artworkUrl: track.artworkUrl ?? null,
+      }).then((result) => {
+        if (result.ok) {
+          router.push('/vibe-player/player');
+          return;
+        }
+        if (result.reason === 'unavailable') {
+          Alert.alert(
+            'Coming soon',
+            result.message,
+            [{ text: 'OK', style: 'default' }],
+          );
+        } else {
+          Alert.alert(
+            'Playback error',
+            result.message,
+            [{ text: 'OK', style: 'default' }],
+          );
+        }
       });
-      router.push('/vibe-player/player');
     },
     [setTrack, play, showMiniPlayer, tracks, hydrateQueue, router],
   );

--- a/kiaanverse-mobile/apps/mobile/app/vibe-player/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/vibe-player/index.tsx
@@ -1,30 +1,42 @@
 /**
  * KIAAN Vibe — Sacred Sound Library
  *
- * Layout (top → bottom):
- *   1. Header — "KIAAN Vibe" + sub-labels.
- *   2. DailyVerseBanner — today's shloka + "Sacred Sound" pointer.
- *   3. CategoryPills — All · Mantras · Meditation · Gita Shlokas · Bhajans · Binaural.
- *   4. FlatList of PlayerTrackCard rows.
+ * Top-level composition:
+ *   1. Header ("KIAAN Vibe" + sub-labels).
+ *   2. Segmented tabs: Library · Gita · Playing.
+ *   3. Active-tab body fills the rest of the screen.
  *
- * Selecting a row:
+ * Tabs:
+ *   - Library — track catalogue. Today's verse banner, category pills,
+ *     scrollable `PlayerTrackCard` list. Tapping a track loads it into
+ *     RNTP and pushes the full-screen player on success.
+ *   - Gita — 18-chapter Bhagavad Gita grid. Tapping a chapter deep-links
+ *     into the existing `/(tabs)/shlokas/{chapter}` stack (still routable
+ *     even though Shlokas is no longer a bottom tab).
+ *   - Playing — current-track summary + "Open full player" CTA, or an
+ *     empty state pointing back to Library when nothing is loaded.
+ *
+ * Selecting a track from Library:
  *   - Updates the zustand `vibePlayerStore` (current track, queue).
  *   - Pushes the tracks into react-native-track-player and starts audio
  *     so the OS-level background service can take over once the user
  *     navigates to the full player (or leaves the app).
- *   - Navigates to `/vibe-player/player`.
+ *   - On success, navigates to `/vibe-player/player`; on failure, shows
+ *     an Alert that explains "coming soon" vs a real playback error.
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   Alert,
   FlatList,
+  Pressable,
   StyleSheet,
   Text,
   View,
   type ListRenderItemInfo,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
 import { DivineBackground, LoadingMandala } from '@kiaanverse/ui';
 import { useMeditationTracks } from '@kiaanverse/api';
 import type { MeditationTrack } from '@kiaanverse/api';
@@ -33,12 +45,16 @@ import { useVibePlayerStore, type VibeTrack } from '@kiaanverse/store';
 import {
   CategoryPills,
   DailyVerseBanner,
+  GitaBrowser,
+  NowPlayingSection,
   PlayerTrackCard,
   resolveApiCategory,
   type FilterKey,
 } from '../../components/vibe-player';
 import { playTrack } from '../../components/vibe-player/trackPlayerBridge';
 
+const GOLD = '#D4A017';
+const GOLD_SOFT = 'rgba(212,160,23,0.28)';
 const SACRED_WHITE = '#F5F0E8';
 const TEXT_MUTED = 'rgba(200,191,168,0.7)';
 
@@ -53,12 +69,163 @@ const TODAY_VERSE = {
   reference: 'Bhagavad Gita 2.47',
 } as const;
 
-export default function VibePlayerLibraryScreen(): React.JSX.Element {
-  const router = useRouter();
-  const [filter, setFilter] = useState<FilterKey>('all');
+// ---------------------------------------------------------------------------
+// Segmented tabs
+// ---------------------------------------------------------------------------
 
+type VibeTab = 'library' | 'gita' | 'playing';
+
+const TABS: ReadonlyArray<{ key: VibeTab; label: string }> = [
+  { key: 'library', label: 'Library' },
+  { key: 'gita', label: 'Gita' },
+  { key: 'playing', label: 'Playing' },
+];
+
+function SegmentedTabs({
+  value,
+  onChange,
+}: {
+  value: VibeTab;
+  onChange: (tab: VibeTab) => void;
+}): React.JSX.Element {
+  const handlePress = useCallback(
+    (tab: VibeTab) => {
+      if (tab === value) return;
+      void Haptics.selectionAsync().catch(() => undefined);
+      onChange(tab);
+    },
+    [value, onChange],
+  );
+
+  return (
+    <View style={styles.tabBar} accessibilityRole="tablist">
+      {TABS.map((tab) => {
+        const active = tab.key === value;
+        return (
+          <Pressable
+            key={tab.key}
+            onPress={() => handlePress(tab.key)}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={`${tab.label} tab`}
+            style={[styles.tabPill, active && styles.tabPillActive]}
+          >
+            <Text
+              style={[styles.tabLabel, active && styles.tabLabelActive]}
+              numberOfLines={1}
+            >
+              {tab.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Library — track catalog (extracted so each tab body stays focused)
+// ---------------------------------------------------------------------------
+
+interface LibrarySectionProps {
+  readonly filter: FilterKey;
+  readonly onFilterChange: (key: FilterKey) => void;
+  readonly onTrackPress: (track: MeditationTrack) => void;
+  readonly onDailyVersePress: () => void;
+  readonly currentTrackId: string | undefined;
+  readonly isPlaying: boolean;
+  readonly bookmarks: ReadonlySet<string>;
+  readonly onToggleBookmark: (trackId: string) => void;
+}
+
+function LibrarySection({
+  filter,
+  onFilterChange,
+  onTrackPress,
+  onDailyVersePress,
+  currentTrackId,
+  isPlaying,
+  bookmarks,
+  onToggleBookmark,
+}: LibrarySectionProps): React.JSX.Element {
   const apiCategory = resolveApiCategory(filter);
   const { data: tracks, isLoading } = useMeditationTracks(apiCategory);
+
+  const renderTrack = useCallback(
+    ({ item }: ListRenderItemInfo<MeditationTrack>) => {
+      const isCurrent = currentTrackId === item.id;
+      return (
+        <PlayerTrackCard
+          track={{
+            id: item.id,
+            title: item.title,
+            artist: item.artist,
+            duration: item.duration,
+            category: item.category,
+          }}
+          isCurrent={isCurrent}
+          isPlaying={isCurrent && isPlaying}
+          isBookmarked={bookmarks.has(item.id)}
+          onPress={() => onTrackPress(item)}
+          onToggleBookmark={() => onToggleBookmark(item.id)}
+        />
+      );
+    },
+    [bookmarks, currentTrackId, isPlaying, onTrackPress, onToggleBookmark],
+  );
+
+  const keyExtractor = useCallback((item: MeditationTrack) => item.id, []);
+
+  return (
+    <FlatList
+      data={tracks ?? []}
+      renderItem={renderTrack}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={styles.listContent}
+      showsVerticalScrollIndicator={false}
+      ListHeaderComponent={
+        <View style={styles.listHeaderStack}>
+          <DailyVerseBanner
+            sanskrit={TODAY_VERSE.sanskrit}
+            meaning={TODAY_VERSE.meaning}
+            reference={TODAY_VERSE.reference}
+            onPress={onDailyVersePress}
+          />
+          <CategoryPills value={filter} onChange={onFilterChange} />
+        </View>
+      }
+      ListEmptyComponent={
+        isLoading ? (
+          <View style={styles.stateContainer}>
+            <LoadingMandala size={56} />
+          </View>
+        ) : (
+          <View style={styles.stateContainer}>
+            <Text style={styles.emptyText}>
+              No tracks available in this category yet.
+            </Text>
+          </View>
+        )
+      }
+      ItemSeparatorComponent={ItemSeparator}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+export default function VibePlayerLibraryScreen(): React.JSX.Element {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<VibeTab>('library');
+  const [filter, setFilter] = useState<FilterKey>('all');
+
+  // `tracks` is also read by the Library body via its own hook, but we need
+  // it here so `handleTrackPress` can hydrate the queue with everything the
+  // user currently sees (keeps skip-next aligned with the visible filter).
+  const apiCategory = resolveApiCategory(filter);
+  const { data: tracks } = useMeditationTracks(apiCategory);
 
   const currentTrack = useVibePlayerStore((s) => s.currentTrack);
   const isPlaying = useVibePlayerStore((s) => s.isPlaying);
@@ -106,9 +273,9 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
     (track: MeditationTrack) => {
       // The bridge returns a typed result so we can show the user a real
       // reason when playback fails (unhosted audio, RNTP error) instead of
-      // the previous silent no-op. We still optimistically update the
-      // store + navigate for the happy path so the UI feels instant; on
-      // failure we rewind the store state and stay on this screen.
+      // a silent no-op. We still optimistically update the store + navigate
+      // for the happy path so the UI feels instant; on failure we stay on
+      // this screen and surface the reason.
       const vibeTrack: VibeTrack = {
         id: track.id,
         title: track.title,
@@ -135,17 +302,13 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
           return;
         }
         if (result.reason === 'unavailable') {
-          Alert.alert(
-            'Coming soon',
-            result.message,
-            [{ text: 'OK', style: 'default' }],
-          );
+          Alert.alert('Coming soon', result.message, [
+            { text: 'OK', style: 'default' },
+          ]);
         } else {
-          Alert.alert(
-            'Playback error',
-            result.message,
-            [{ text: 'OK', style: 'default' }],
-          );
+          Alert.alert('Playback error', result.message, [
+            { text: 'OK', style: 'default' },
+          ]);
         }
       });
     },
@@ -153,35 +316,16 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
   );
 
   const handleDailyVersePress = useCallback(() => {
-    // Until the API ships a verse→track binding, open the shlokas tab —
-    // the user can navigate from there to the full verse detail.
-    router.push('/(tabs)/shlokas' as never);
-  }, [router]);
+    // The Daily Verse banner is the canonical shortcut from Vibe into the
+    // Gita reader — flip to the in-screen Gita tab rather than pushing the
+    // standalone shlokas stack so the user stays inside Vibe.
+    void Haptics.selectionAsync().catch(() => undefined);
+    setActiveTab('gita');
+  }, []);
 
-  const renderTrack = useCallback(
-    ({ item }: ListRenderItemInfo<MeditationTrack>) => {
-      const isCurrent = currentTrack?.id === item.id;
-      return (
-        <PlayerTrackCard
-          track={{
-            id: item.id,
-            title: item.title,
-            artist: item.artist,
-            duration: item.duration,
-            category: item.category,
-          }}
-          isCurrent={isCurrent}
-          isPlaying={isCurrent && isPlaying}
-          isBookmarked={bookmarks.has(item.id)}
-          onPress={() => handleTrackPress(item)}
-          onToggleBookmark={() => handleToggleBookmark(item.id)}
-        />
-      );
-    },
-    [bookmarks, currentTrack?.id, handleToggleBookmark, handleTrackPress, isPlaying],
-  );
-
-  const keyExtractor = useCallback((item: MeditationTrack) => item.id, []);
+  const handleSwitchToLibrary = useCallback(() => {
+    setActiveTab('library');
+  }, []);
 
   const headerBlock = useMemo(
     () => (
@@ -199,39 +343,29 @@ export default function VibePlayerLibraryScreen(): React.JSX.Element {
   return (
     <DivineBackground variant="cosmic" style={styles.root}>
       <View style={styles.safeTop}>
-        <FlatList
-          data={tracks ?? []}
-          renderItem={renderTrack}
-          keyExtractor={keyExtractor}
-          contentContainerStyle={styles.listContent}
-          showsVerticalScrollIndicator={false}
-          ListHeaderComponent={
-            <View style={styles.headerStack}>
-              {headerBlock}
-              <DailyVerseBanner
-                sanskrit={TODAY_VERSE.sanskrit}
-                meaning={TODAY_VERSE.meaning}
-                reference={TODAY_VERSE.reference}
-                onPress={handleDailyVersePress}
-              />
-              <CategoryPills value={filter} onChange={setFilter} />
-            </View>
-          }
-          ListEmptyComponent={
-            isLoading ? (
-              <View style={styles.stateContainer}>
-                <LoadingMandala size={56} />
-              </View>
-            ) : (
-              <View style={styles.stateContainer}>
-                <Text style={styles.emptyText}>
-                  No tracks available in this category yet.
-                </Text>
-              </View>
-            )
-          }
-          ItemSeparatorComponent={ItemSeparator}
-        />
+        {headerBlock}
+        <SegmentedTabs value={activeTab} onChange={setActiveTab} />
+
+        <View style={styles.tabBody}>
+          {activeTab === 'library' ? (
+            <LibrarySection
+              filter={filter}
+              onFilterChange={setFilter}
+              onTrackPress={handleTrackPress}
+              onDailyVersePress={handleDailyVersePress}
+              currentTrackId={currentTrack?.id}
+              isPlaying={isPlaying}
+              bookmarks={bookmarks}
+              onToggleBookmark={handleToggleBookmark}
+            />
+          ) : null}
+
+          {activeTab === 'gita' ? <GitaBrowser /> : null}
+
+          {activeTab === 'playing' ? (
+            <NowPlayingSection onSwitchToLibrary={handleSwitchToLibrary} />
+          ) : null}
+        </View>
       </View>
     </DivineBackground>
   );
@@ -249,13 +383,10 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: 52,
   },
-  headerStack: {
-    gap: 14,
-    paddingBottom: 12,
-  },
   headerBlock: {
     paddingHorizontal: 16,
     gap: 4,
+    paddingBottom: 10,
   },
   title: {
     fontFamily: 'CormorantGaramond-BoldItalic',
@@ -275,9 +406,46 @@ const styles = StyleSheet.create({
     marginTop: 2,
     letterSpacing: 0.4,
   },
+  tabBar: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingBottom: 10,
+  },
+  tabPill: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    backgroundColor: 'rgba(17,20,53,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tabPillActive: {
+    backgroundColor: 'rgba(212,160,23,0.16)',
+    borderColor: GOLD,
+  },
+  tabLabel: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    color: TEXT_MUTED,
+  },
+  tabLabelActive: {
+    fontFamily: 'Outfit-SemiBold',
+    color: GOLD,
+    letterSpacing: 0.3,
+  },
+  tabBody: {
+    flex: 1,
+  },
   listContent: {
     paddingHorizontal: 16,
     paddingBottom: 48,
+  },
+  listHeaderStack: {
+    gap: 14,
+    paddingBottom: 12,
   },
   stateContainer: {
     paddingVertical: 56,

--- a/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
+++ b/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
@@ -20,7 +20,24 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import * as SecureStore from 'expo-secure-store';
 import { API_CONFIG } from '@kiaanverse/api';
+
+/**
+ * SecureStore key under which the authStore persists the access JWT.
+ * Duplicated here (rather than imported) because the chat components belong
+ * to the mobile app, which should not depend on the store package for a
+ * single constant. If the key ever changes in authStore.ts, update here too.
+ */
+const ACCESS_TOKEN_STORAGE_KEY = 'kiaanverse_access_token';
+
+async function readAccessTokenFromSecureStore(): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(ACCESS_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
 
 /** Message record kept in component state. */
 export interface SakhaStreamMessage {
@@ -77,9 +94,18 @@ function createMessageId(prefix: 'user' | 'assistant'): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-/** Compassionate error message used when the SSE pipe breaks. */
+/**
+ * Compassionate error copy used when the SSE pipe breaks. We differentiate
+ * by transport failure mode so the user can take the right next step (sign
+ * in, retry after cold-start, check network) instead of every failure
+ * looking like a generic "please try again".
+ */
 const CONNECTION_ERROR_TEXT =
   'My connection to the cosmic network wavered. Please ask again.';
+const AUTH_ERROR_TEXT =
+  'Your session has expired. Please sign in again to continue our dialogue.';
+const COLD_START_TEXT =
+  'I am waking from deep meditation (server cold start). Please ask again in a moment.';
 
 export function useSakhaStream(
   options: UseSakhaStreamOptions = {},
@@ -152,15 +178,31 @@ export function useSakhaStream(
       setMessages((prev) => [...prev, userMsg, assistantMsg]);
       setStreaming(true);
 
-      // 3. Resolve bearer token, if any.
+      // 3. Resolve bearer token. Prefer the caller-supplied getter (tests,
+      // custom flows) and otherwise fall back to the access token the
+      // authStore persisted to SecureStore. Without this fallback the SSE
+      // request went out unauthenticated — the backend rejected it with 401
+      // and the UI showed the "connection wavered" error even though the
+      // network and backend were both healthy.
       let token: string | null = null;
-      if (getAccessToken) {
-        try {
+      try {
+        if (getAccessToken) {
           const resolved = await getAccessToken();
           token = resolved ?? null;
-        } catch {
-          token = null;
+        } else {
+          token = await readAccessTokenFromSecureStore();
         }
+      } catch {
+        token = null;
+      }
+
+      if (typeof __DEV__ !== 'undefined' && __DEV__) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[SakhaStream] POST ${baseUrl ?? API_CONFIG.baseURL}/api/chat/message/stream  auth=${
+            token ? 'Bearer ***' : 'NONE'
+          }`,
+        );
       }
 
       // 4. Open the streaming XHR.
@@ -188,7 +230,13 @@ export function useSakhaStream(
         streamCompleteCallbackRef.current?.();
       };
 
-      const finishStreamingFailure = (): void => {
+      const finishStreamingFailure = (reason: 'network' | 'auth' | 'server' | 'cold_start'): void => {
+        const errorText =
+          reason === 'auth'
+            ? AUTH_ERROR_TEXT
+            : reason === 'cold_start'
+              ? COLD_START_TEXT
+              : CONNECTION_ERROR_TEXT;
         const id = assistantIdRef.current;
         if (id) {
           setMessages((prev) =>
@@ -196,14 +244,20 @@ export function useSakhaStream(
               m.id === id
                 ? {
                     ...m,
-                    text: m.text.length > 0 ? m.text : CONNECTION_ERROR_TEXT,
+                    text: m.text.length > 0 ? m.text : errorText,
                     isStreaming: false,
                   }
                 : m,
             ),
           );
         }
-        setError(CONNECTION_ERROR_TEXT);
+        if (typeof __DEV__ !== 'undefined' && __DEV__) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[SakhaStream] failed (${reason}) status=${xhr.status} response=${xhr.responseText?.slice(0, 200) ?? ''}`,
+          );
+        }
+        setError(errorText);
         setStreaming(false);
         xhrRef.current = null;
       };
@@ -212,7 +266,16 @@ export function useSakhaStream(
         // 3 = LOADING (incremental responseText is available).
         if (xhr.readyState !== 3 && xhr.readyState !== 4) return;
         if (xhr.readyState === 4 && xhr.status >= 400) {
-          finishStreamingFailure();
+          // Translate the HTTP status into the most useful recovery hint:
+          //   401 → sign in again; 502/503/504 → cold-start retry; else → generic.
+          const status = xhr.status;
+          if (status === 401 || status === 403) {
+            finishStreamingFailure('auth');
+          } else if (status === 502 || status === 503 || status === 504) {
+            finishStreamingFailure('cold_start');
+          } else {
+            finishStreamingFailure('server');
+          }
           return;
         }
 
@@ -259,8 +322,8 @@ export function useSakhaStream(
         }
       };
 
-      xhr.onerror = () => finishStreamingFailure();
-      xhr.ontimeout = () => finishStreamingFailure();
+      xhr.onerror = () => finishStreamingFailure('network');
+      xhr.ontimeout = () => finishStreamingFailure('cold_start');
       xhr.onabort = () => {
         // Aborts set isStreaming false silently — no error toast.
         setMessages((prev) =>
@@ -279,7 +342,7 @@ export function useSakhaStream(
           }),
         );
       } catch {
-        finishStreamingFailure();
+        finishStreamingFailure('network');
       }
     },
     [appendAssistantText, baseUrl, getAccessToken, sessionId, streaming],

--- a/kiaanverse-mobile/apps/mobile/components/karma-reset/KarmicPatternCard.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/karma-reset/KarmicPatternCard.tsx
@@ -1,12 +1,23 @@
 /**
  * KarmicPatternCard — Selectable card for a Shadripu karmic pattern.
  *
- * Displays Sanskrit name, English translation, description, and emoji icon.
- * Animates with a spring scale and golden border glow when selected.
+ * Displays Sanskrit name, Romanized transliteration, English translation,
+ * description, and emoji icon. Animates with a spring scale and golden
+ * border glow when selected.
+ *
+ * Layout notes:
+ * - Sanskrit and Roman are rendered as separate `<Text>` elements so they
+ *   wrap independently; a single "काम (Kāma)" string on a narrow card
+ *   broke mid-word (split the `K` from `āma`), which looked broken.
+ * - Card width comes from the parent rather than being hard-coded to
+ *   `'47%'`. Percentage widths on flex children with nested wrappers
+ *   resolve against the wrapper rather than the grid, so the old layout
+ *   left cards too narrow for the Sanskrit script. The parent now passes
+ *   a concrete pixel width computed from the screen size.
  */
 
 import React, { useEffect } from 'react';
-import { StyleSheet, Pressable } from 'react-native';
+import { StyleSheet, Pressable, type ViewStyle } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -16,7 +27,11 @@ import { Text, colors, spacing, radii } from '@kiaanverse/ui';
 
 export interface KarmicPattern {
   readonly id: string;
+  /** Sanskrit in Devanagari (e.g. `काम`). Rendered on its own line. */
   readonly sanskrit: string;
+  /** Romanised transliteration (e.g. `Kāma`). Rendered on a second line. */
+  readonly romanName: string;
+  /** English translation (e.g. `Desire / Attachment`). */
   readonly english: string;
   readonly icon: string;
   readonly description: string;
@@ -26,6 +41,13 @@ interface KarmicPatternCardProps {
   readonly pattern: KarmicPattern;
   readonly isSelected: boolean;
   readonly onSelect: (id: string) => void;
+  /**
+   * Optional style override (the parent supplies a concrete `width` so the
+   * two-column grid sits flush against the screen padding). Falls back to
+   * the card's intrinsic style — still usable standalone in a row wrap,
+   * just not ideal for Devanagari line-wrapping.
+   */
+  readonly style?: ViewStyle;
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -34,6 +56,7 @@ export function KarmicPatternCard({
   pattern,
   isSelected,
   onSelect,
+  style,
 }: KarmicPatternCardProps): React.JSX.Element {
   const scale = useSharedValue(1);
   const borderOpacity = useSharedValue(0);
@@ -55,16 +78,30 @@ export function KarmicPatternCard({
   return (
     <AnimatedPressable
       onPress={() => onSelect(pattern.id)}
-      style={[styles.card, animatedStyle]}
+      style={[styles.card, style, animatedStyle]}
       accessibilityRole="button"
-      accessibilityLabel={`${pattern.sanskrit} - ${pattern.english}`}
+      accessibilityLabel={`${pattern.sanskrit} ${pattern.romanName} — ${pattern.english}`}
       accessibilityState={{ selected: isSelected }}
     >
       <Text variant="h2" align="center">
         {pattern.icon}
       </Text>
-      <Text variant="label" align="center" color={isSelected ? colors.primary[300] : colors.text.primary}>
+      {/* Sanskrit (Devanagari) and Romanisation on separate lines so each
+          stays intact even on narrow screens. */}
+      <Text
+        variant="label"
+        align="center"
+        color={isSelected ? colors.primary[300] : colors.text.primary}
+      >
         {pattern.sanskrit}
+      </Text>
+      <Text
+        variant="caption"
+        align="center"
+        color={isSelected ? colors.primary[500] : colors.text.secondary}
+        style={styles.romanText}
+      >
+        {pattern.romanName}
       </Text>
       <Text variant="caption" align="center" color={colors.text.muted}>
         {pattern.english}
@@ -83,7 +120,6 @@ export function KarmicPatternCard({
 
 const styles = StyleSheet.create({
   card: {
-    width: '47%',
     paddingVertical: spacing.lg,
     paddingHorizontal: spacing.sm,
     borderRadius: radii.lg,
@@ -93,5 +129,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.xs,
     elevation: 2,
+  },
+  romanText: {
+    // Italic transliteration matches the typographic convention used in
+    // dictionaries and in the Gita corpus elsewhere in the app.
+    fontStyle: 'italic',
+    letterSpacing: 0.3,
   },
 });

--- a/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
@@ -1,8 +1,16 @@
 /**
  * DivineTabBar — Kiaanverse bottom tab bar (5 sacred doorways).
  *
- * Matches kiaanverse.com reference exactly:
- *   Home · Chat · Shlokas · Journal · Profile
+ * Tab order:
+ *   Home · Sakha · Journeys · Journal · Profile
+ *
+ * Shlokas used to occupy slot 3; it now lives inside the Vibe Player (via
+ * the Daily Verse banner) and is still reachable through the legacy
+ * `/(tabs)/shlokas/*` routes. Journeys was promoted from a sub-tab of
+ * Journal to its own top-level slot so the षड्रिपु flow is one tap away.
+ * The icon list is recycled from the existing set — ChakraColumn (was
+ * Journal) now signals the journey progression, and Manuscript (was
+ * Shlokas) signals the written journal.
  *
  * Visual specification:
  * - Dark navy background: rgba(5,7,20,0.97).
@@ -73,9 +81,14 @@ interface SacredTab {
 
 const TABS: ReadonlyArray<SacredTab> = [
   { name: 'index', label: 'Home', Icon: GopuramIcon },
-  { name: 'chat', label: 'Chat', Icon: LotusDialogIcon },
-  { name: 'shlokas', label: 'Shlokas', Icon: ManuscriptIcon },
-  { name: 'journal', label: 'Journal', Icon: ChakraColumnIcon },
+  { name: 'chat', label: 'Sakha', Icon: LotusDialogIcon },
+  // ChakraColumn's seven stacked chakras read as progression / ascent —
+  // the visual cue for the षड्रिपु journey sequence.
+  { name: 'journeys', label: 'Journeys', Icon: ChakraColumnIcon },
+  // ManuscriptIcon carries the written / reflection meaning. It was
+  // originally used for Shlokas; now that Shlokas has moved inside the
+  // Vibe Player, the manuscript glyph fits the diary better.
+  { name: 'journal', label: 'Journal', Icon: ManuscriptIcon },
   { name: 'profile', label: 'Profile', Icon: MeditatorIcon },
 ] as const;
 

--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/GitaBrowser.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/GitaBrowser.tsx
@@ -1,0 +1,220 @@
+/**
+ * GitaBrowser — 18-chapter Bhagavad Gita grid embedded inside the Vibe
+ * Player's "Gita" tab.
+ *
+ * Rather than duplicating the full shlokas stack (search, daily verse,
+ * verse detail) inside the Vibe Player, this surface is intentionally
+ * lightweight: it lists the 18 chapters with their Sanskrit + English
+ * names and verse count, and tapping a chapter navigates into the
+ * existing `/(tabs)/shlokas/{chapter}` stack for the full verse reader.
+ *
+ * The verse-count numbers are canonical (the backend's MeditationVerseDB
+ * matches them) and the Sanskrit names are the same list already used by
+ * `app/(tabs)/shlokas/index.tsx` so the two surfaces never disagree.
+ */
+
+import React, { useCallback } from 'react';
+import {
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import * as Haptics from 'expo-haptics';
+
+interface ChapterRow {
+  readonly num: number;
+  readonly english: string;
+  readonly sanskrit: string;
+  readonly verses: number;
+}
+
+const CHAPTERS: ReadonlyArray<ChapterRow> = [
+  { num: 1,  english: 'Arjuna Vishada Yoga',     sanskrit: 'अर्जुन विषाद योग',              verses: 47 },
+  { num: 2,  english: 'Sankhya Yoga',            sanskrit: 'सांख्य योग',                    verses: 72 },
+  { num: 3,  english: 'Karma Yoga',              sanskrit: 'कर्म योग',                       verses: 43 },
+  { num: 4,  english: 'Jnana Karma Sanyasa Yoga', sanskrit: 'ज्ञान कर्म संन्यास योग',        verses: 42 },
+  { num: 5,  english: 'Karma Sanyasa Yoga',      sanskrit: 'कर्म संन्यास योग',              verses: 29 },
+  { num: 6,  english: 'Dhyana Yoga',             sanskrit: 'आत्म संयम योग',                 verses: 47 },
+  { num: 7,  english: 'Jnana Vijnana Yoga',      sanskrit: 'ज्ञान विज्ञान योग',              verses: 30 },
+  { num: 8,  english: 'Aksara Brahma Yoga',      sanskrit: 'अक्षर ब्रह्म योग',              verses: 28 },
+  { num: 9,  english: 'Raja Vidya Yoga',         sanskrit: 'राज विद्या राज गुह्य योग',       verses: 34 },
+  { num: 10, english: 'Vibhuti Yoga',            sanskrit: 'विभूति योग',                    verses: 42 },
+  { num: 11, english: 'Vishvarupa Darshana Yoga', sanskrit: 'विश्वरूप दर्शन योग',            verses: 55 },
+  { num: 12, english: 'Bhakti Yoga',             sanskrit: 'भक्ति योग',                      verses: 20 },
+  { num: 13, english: 'Kshetra Kshetrajna Yoga', sanskrit: 'क्षेत्र क्षेत्रज्ञ विभाग योग',   verses: 35 },
+  { num: 14, english: 'Gunatraya Vibhaga Yoga',  sanskrit: 'गुणत्रय विभाग योग',             verses: 27 },
+  { num: 15, english: 'Purushottama Yoga',       sanskrit: 'पुरुषोत्तम योग',                verses: 20 },
+  { num: 16, english: 'Daivasura Sampad Yoga',   sanskrit: 'दैवासुर संपद विभाग योग',         verses: 24 },
+  { num: 17, english: 'Shraddhatraya Yoga',      sanskrit: 'श्रद्धात्रय विभाग योग',          verses: 28 },
+  { num: 18, english: 'Moksha Sanyasa Yoga',     sanskrit: 'मोक्ष संन्यास योग',              verses: 78 },
+];
+
+const GOLD = '#D4A017';
+const GOLD_SOFT = 'rgba(212,160,23,0.22)';
+const SACRED_WHITE = '#F5F0E8';
+const TEXT_MUTED = 'rgba(200,191,168,0.65)';
+const CARD_BG = 'rgba(17,20,53,0.65)';
+
+function ChapterCard({
+  row,
+  onPress,
+}: {
+  row: ChapterRow;
+  onPress: (n: number) => void;
+}): React.JSX.Element {
+  const handlePress = useCallback(() => {
+    void Haptics.selectionAsync().catch(() => undefined);
+    onPress(row.num);
+  }, [row.num, onPress]);
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={styles.card}
+      accessibilityRole="button"
+      accessibilityLabel={`Open chapter ${row.num}, ${row.english}, ${row.verses} verses`}
+    >
+      <View style={styles.numBadge}>
+        <Text style={styles.numText}>{row.num}</Text>
+      </View>
+      <View style={styles.cardBody}>
+        <Text style={styles.cardSanskrit} numberOfLines={1}>
+          {row.sanskrit}
+        </Text>
+        <Text style={styles.cardEnglish} numberOfLines={1}>
+          {row.english}
+        </Text>
+        <Text style={styles.cardMeta}>{row.verses} verses</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export function GitaBrowser(): React.JSX.Element {
+  const router = useRouter();
+
+  const handleChapterPress = useCallback(
+    (num: number) => {
+      // Route into the existing shlokas stack — the `href:null` tab entry
+      // in `(tabs)/_layout.tsx` keeps the route valid even though Shlokas
+      // is no longer visible in the bottom bar.
+      router.push(`/(tabs)/shlokas/${num}` as never);
+    },
+    [router],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<ChapterRow>) => (
+      <ChapterCard row={item} onPress={handleChapterPress} />
+    ),
+    [handleChapterPress],
+  );
+
+  const keyExtractor = useCallback((item: ChapterRow) => String(item.num), []);
+
+  return (
+    <FlatList
+      data={CHAPTERS}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={styles.list}
+      showsVerticalScrollIndicator={false}
+      ListHeaderComponent={
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>श्रीमद्भगवद्गीता</Text>
+          <Text style={styles.headerEnglish}>Bhagavad Gita</Text>
+          <Text style={styles.headerMeta}>18 Chapters · 700 Verses</Text>
+        </View>
+      }
+      ItemSeparatorComponent={Separator}
+    />
+  );
+}
+
+function Separator(): React.JSX.Element {
+  return <View style={styles.separator} />;
+}
+
+const styles = StyleSheet.create({
+  list: {
+    paddingHorizontal: 16,
+    paddingBottom: 48,
+  },
+  header: {
+    paddingTop: 4,
+    paddingBottom: 14,
+    gap: 4,
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontSize: 22,
+    color: GOLD,
+    letterSpacing: 0.4,
+  },
+  headerEnglish: {
+    fontFamily: 'CormorantGaramond-Regular',
+    fontSize: 16,
+    color: SACRED_WHITE,
+  },
+  headerMeta: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 11,
+    color: TEXT_MUTED,
+    letterSpacing: 0.4,
+    marginTop: 2,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    backgroundColor: CARD_BG,
+  },
+  numBadge: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    backgroundColor: 'rgba(212,160,23,0.08)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  numText: {
+    fontFamily: 'CormorantGaramond-Bold',
+    fontSize: 18,
+    color: GOLD,
+  },
+  cardBody: {
+    flex: 1,
+    gap: 2,
+  },
+  cardSanskrit: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontSize: 15,
+    color: GOLD,
+  },
+  cardEnglish: {
+    fontFamily: 'CormorantGaramond-Regular',
+    fontSize: 14,
+    color: SACRED_WHITE,
+  },
+  cardMeta: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 11,
+    color: TEXT_MUTED,
+    marginTop: 2,
+  },
+  separator: {
+    height: 10,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/NowPlayingSection.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/NowPlayingSection.tsx
@@ -1,0 +1,168 @@
+/**
+ * NowPlayingSection — the "Playing" tab of the Vibe Player library.
+ *
+ * Shows a summary of the current track when one is loaded; otherwise a
+ * brief empty state pointing back to Library. Tapping the card pushes the
+ * full-screen player (`/vibe-player/player`) which owns the real transport
+ * controls + sacred geometry artwork.
+ *
+ * Kept intentionally small — this tab is a dashboard / gateway, not a
+ * replacement for the full player.
+ */
+
+import React, { useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useVibePlayerStore } from '@kiaanverse/store';
+
+const GOLD = '#D4A017';
+const GOLD_SOFT = 'rgba(212,160,23,0.25)';
+const SACRED_WHITE = '#F5F0E8';
+const TEXT_MUTED = 'rgba(200,191,168,0.65)';
+const CARD_BG = 'rgba(17,20,53,0.65)';
+
+function formatDuration(seconds: number): string {
+  if (!seconds || seconds <= 0) return '—:—';
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+interface NowPlayingSectionProps {
+  readonly onSwitchToLibrary: () => void;
+}
+
+export function NowPlayingSection({
+  onSwitchToLibrary,
+}: NowPlayingSectionProps): React.JSX.Element {
+  const router = useRouter();
+  const currentTrack = useVibePlayerStore((s) => s.currentTrack);
+  const isPlaying = useVibePlayerStore((s) => s.isPlaying);
+
+  const handleOpenPlayer = useCallback(() => {
+    router.push('/vibe-player/player');
+  }, [router]);
+
+  if (!currentTrack) {
+    return (
+      <View style={styles.emptyWrap}>
+        <Text style={styles.emptyTitle}>Nothing playing</Text>
+        <Text style={styles.emptyBody}>
+          Pick a track from the Library tab to begin.
+        </Text>
+        <Pressable
+          onPress={onSwitchToLibrary}
+          accessibilityRole="button"
+          accessibilityLabel="Open Library"
+          style={styles.emptyCta}
+        >
+          <Text style={styles.emptyCtaText}>Open Library →</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <Pressable
+        onPress={handleOpenPlayer}
+        accessibilityRole="button"
+        accessibilityLabel={`Open full player for ${currentTrack.title}`}
+        style={styles.card}
+      >
+        <Text style={styles.statusLabel}>
+          {isPlaying ? 'PLAYING NOW' : 'LOADED — PAUSED'}
+        </Text>
+        <Text style={styles.title} numberOfLines={2}>
+          {currentTrack.title}
+        </Text>
+        <Text style={styles.artist} numberOfLines={1}>
+          {currentTrack.artist}
+        </Text>
+        <Text style={styles.duration}>
+          Total duration · {formatDuration(currentTrack.duration)}
+        </Text>
+        <Text style={styles.openFull}>Open full player →</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 4,
+  },
+  card: {
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    backgroundColor: CARD_BG,
+    paddingVertical: 22,
+    paddingHorizontal: 18,
+    gap: 6,
+  },
+  statusLabel: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 10,
+    letterSpacing: 1.4,
+    color: GOLD,
+  },
+  title: {
+    fontFamily: 'CormorantGaramond-Regular',
+    fontSize: 24,
+    color: SACRED_WHITE,
+    lineHeight: 30,
+  },
+  artist: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    color: TEXT_MUTED,
+  },
+  duration: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 12,
+    color: TEXT_MUTED,
+    marginTop: 6,
+  },
+  openFull: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 13,
+    color: GOLD,
+    marginTop: 12,
+  },
+  // Empty state
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 10,
+  },
+  emptyTitle: {
+    fontFamily: 'CormorantGaramond-Regular',
+    fontSize: 22,
+    color: SACRED_WHITE,
+  },
+  emptyBody: {
+    fontFamily: 'CrimsonText-Italic',
+    fontSize: 14,
+    color: TEXT_MUTED,
+    textAlign: 'center',
+  },
+  emptyCta: {
+    marginTop: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    backgroundColor: 'rgba(212,160,23,0.12)',
+  },
+  emptyCtaText: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 13,
+    color: GOLD,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/index.ts
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/index.ts
@@ -37,3 +37,5 @@ export {
   DailyVerseBanner,
   type DailyVerseBannerProps,
 } from './DailyVerseBanner';
+export { GitaBrowser } from './GitaBrowser';
+export { NowPlayingSection } from './NowPlayingSection';

--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/trackPlayerBridge.ts
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/trackPlayerBridge.ts
@@ -13,9 +13,11 @@
  * responsibility. Callers invoke them from effects/event handlers; the
  * store stays UI-facing and doesn't import RNTP directly.
  *
- * Errors are swallowed in production and logged in __DEV__. Failing to
- * start playback is never fatal — the listener still sees the store
- * state update and the UI can retry.
+ * `playTrack` returns a result tag so the caller can surface a real
+ * failure to the user (missing audioUrl, network error) instead of a
+ * silent dead tap. Earlier versions swallowed every error and the play
+ * button appeared broken whenever the backend shipped a relative /
+ * missing `audioUrl`.
  */
 
 import TrackPlayer, {
@@ -33,8 +35,38 @@ export interface BridgeTrack {
   readonly artworkUrl?: string | null;
 }
 
+/** Outcome of a play attempt. `unavailable` = no hosted audio yet; the UI
+ *  should tell the user "coming soon" rather than "retry". `error` = RNTP
+ *  rejected the add/play calls; suggest retry. */
+export type PlayResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: 'unavailable'; readonly message: string }
+  | { readonly ok: false; readonly reason: 'error'; readonly message: string };
+
+function isPlayableUrl(url: string): boolean {
+  // TrackPlayer accepts absolute http(s) URLs and `file://` / `asset://`
+  // local schemes. Anything else (relative paths like `/audio/om.mp3`,
+  // empty strings) will fail silently at play time, which is the exact
+  // bug users hit when the backend shipped unhosted audio.
+  return /^(https?:|file:|asset:)/i.test(url);
+}
+
 /** Load a single track into TrackPlayer's queue and start playback. */
-export async function playTrack(track: BridgeTrack): Promise<void> {
+export async function playTrack(track: BridgeTrack): Promise<PlayResult> {
+  if (!isPlayableUrl(track.audioUrl)) {
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[trackPlayerBridge] playTrack skipped — unplayable url="${track.audioUrl}" for id=${track.id}`,
+      );
+    }
+    return {
+      ok: false,
+      reason: 'unavailable',
+      message: `"${track.title}" isn't hosted yet. It'll arrive in a future update.`,
+    };
+  }
+
   try {
     await TrackPlayer.reset();
     const rnTrack: RnTpTrack = {
@@ -47,11 +79,19 @@ export async function playTrack(track: BridgeTrack): Promise<void> {
     };
     await TrackPlayer.add(rnTrack);
     await TrackPlayer.play();
+    return { ok: true };
   } catch (err) {
-    if (__DEV__) {
-      // eslint-disable-next-line no-console
-      console.warn('[trackPlayerBridge] playTrack failed:', err);
-    }
+    const message = err instanceof Error ? err.message : String(err);
+    // Always log — production users hitting this would otherwise see a
+    // silent no-op. The message is also returned so the caller can put
+    // it in an Alert.
+    // eslint-disable-next-line no-console
+    console.error('[trackPlayerBridge] playTrack failed:', err);
+    return {
+      ok: false,
+      reason: 'error',
+      message: `Could not play this track: ${message}`,
+    };
   }
 }
 

--- a/kiaanverse-mobile/packages/api/src/client.ts
+++ b/kiaanverse-mobile/packages/api/src/client.ts
@@ -163,10 +163,16 @@ function createApiClient(): AxiosInstance {
     withCredentials: true,
     headers: {
       'Content-Type': 'application/json',
+      'Accept': 'application/json',
       'X-Client': 'kiaanverse-mobile',
       'X-Client-Version': '1.0.0',
     },
   });
+
+  if (typeof __DEV__ !== 'undefined' && __DEV__) {
+    // eslint-disable-next-line no-console
+    console.log(`[API] baseURL=${API_CONFIG.baseURL} timeout=${API_CONFIG.timeout}ms`);
+  }
 
   // -----------------------------------------------------------------------
   // Request interceptor: attach JWT + __DEV__ logging
@@ -180,8 +186,13 @@ function createApiClient(): AxiosInstance {
 
       if (typeof __DEV__ !== 'undefined' && __DEV__) {
         (config as RequestConfigWithMeta)._startTime = Date.now();
+        // Include the absolute URL so misconfigured baseURLs are obvious at a
+        // glance, and flag missing auth which is the most common "why does
+        // the chat return fallback text?" root cause.
+        const fullUrl = `${config.baseURL ?? ''}${config.url ?? ''}`;
+        const auth = token ? 'Bearer ***' : 'NONE';
         // eslint-disable-next-line no-console
-        console.log(`→ ${config.method?.toUpperCase()} ${config.url}`);
+        console.log(`→ ${config.method?.toUpperCase()} ${fullUrl}  auth=${auth}`);
       }
 
       return config;
@@ -225,12 +236,25 @@ function createApiClient(): AxiosInstance {
       const originalRequest = error.config as RequestConfigWithMeta | undefined;
       if (!originalRequest) return Promise.reject(wrapAxiosError(error));
 
-      // __DEV__ error logging
+      // __DEV__ error logging — surface the body so callers can see the real
+      // FastAPI detail (e.g. "thought is required") instead of a generic
+      // fallback string from the UI layer.
       if (typeof __DEV__ !== 'undefined' && __DEV__) {
         const duration = originalRequest._startTime ? Date.now() - originalRequest._startTime : 0;
         const status = error.response?.status ?? 'NETWORK';
+        const fullUrl = `${originalRequest.baseURL ?? ''}${originalRequest.url ?? ''}`;
+        let bodyPreview = '';
+        try {
+          const body = error.response?.data;
+          if (body !== undefined) {
+            const serialised = typeof body === 'string' ? body : JSON.stringify(body);
+            bodyPreview = ` body=${serialised.slice(0, 400)}`;
+          }
+        } catch {
+          bodyPreview = '';
+        }
         // eslint-disable-next-line no-console
-        console.log(`← ${status} ${originalRequest.url} (${duration}ms) ERROR`);
+        console.log(`← ${status} ${fullUrl} (${duration}ms) ERROR${bodyPreview}`);
       }
 
       // Don't process errors on the refresh endpoint itself to avoid infinite loops

--- a/kiaanverse-mobile/packages/api/src/config.ts
+++ b/kiaanverse-mobile/packages/api/src/config.ts
@@ -2,10 +2,18 @@
  * API client configuration.
  *
  * Base URL is resolved from environment variables:
- * 1. EXPO_PUBLIC_API_BASE_URL — explicit override (highest priority)
+ * 1. EXPO_PUBLIC_API_BASE_URL — explicit override (highest priority, set by EAS)
  * 2. EXPO_PUBLIC_ENV — selects production / staging / development URL
- * 3. Falls back to localhost in development
+ * 3. Falls back to the Render production URL so builds without env vars still
+ *    reach a working backend instead of a nonexistent host.
+ *
+ * The production & staging hosts both point at the single Render deployment —
+ * `mindvibe-api.onrender.com` — which is what the backend currently ships to.
+ * If/when a dedicated staging host exists, update STAGING_URL only.
  */
+
+const PRODUCTION_URL = 'https://mindvibe-api.onrender.com';
+const STAGING_URL = 'https://mindvibe-api.onrender.com';
 
 function resolveBaseURL(): string {
   const override = process.env.EXPO_PUBLIC_API_BASE_URL;
@@ -13,11 +21,16 @@ function resolveBaseURL(): string {
 
   switch (process.env.EXPO_PUBLIC_ENV) {
     case 'production':
-      return 'https://api.kiaanverse.com';
+      return PRODUCTION_URL;
     case 'staging':
-      return 'https://api-staging.kiaanverse.com';
-    default:
+      return STAGING_URL;
+    case 'development':
       return 'http://localhost:8000';
+    default:
+      // No env set → assume production build. The previous default was
+      // localhost, which caused shipped builds without EXPO_PUBLIC_ENV to
+      // silently try to reach the developer's laptop.
+      return PRODUCTION_URL;
   }
 }
 
@@ -25,8 +38,13 @@ export const API_CONFIG = {
   /** Base URL — resolved from EXPO_PUBLIC_ENV or EXPO_PUBLIC_API_BASE_URL */
   baseURL: resolveBaseURL(),
 
-  /** Request timeout (ms) */
-  timeout: 15_000,
+  /**
+   * Request timeout (ms). Render's free tier cold-starts in 20–30s on the
+   * first request after idle; anything under 30s makes the first AI call of a
+   * session timeout and triggers the compassionate-error fallback in the UI
+   * even though the backend would have answered a few seconds later.
+   */
+  timeout: 30_000,
 
   /** Max retries for transient failures */
   maxRetries: 3,

--- a/kiaanverse-mobile/packages/api/src/hooks.ts
+++ b/kiaanverse-mobile/packages/api/src/hooks.ts
@@ -1354,12 +1354,59 @@ export function useArdhaReframe(): UseMutationResult<ArdhaReframeResponse, Error
 // Meditation / Vibe Player
 // ---------------------------------------------------------------------------
 
+/**
+ * Turn whatever the backend returned for `audioUrl` into an absolute URL the
+ * native player can actually fetch. Today the meditation backend returns
+ * relative paths like `"/audio/om-chanting.mp3"` — those are useless on
+ * device because the native HTTP stack has no baseURL to resolve against.
+ *
+ * - absolute `http(s)://` → kept as-is
+ * - empty / missing      → returned as empty string (screen treats as
+ *                          "coming soon" and skips TrackPlayer.add)
+ * - relative             → resolved against API_CONFIG.baseURL so that once
+ *                          the backend mounts a static `/audio/*` route the
+ *                          mobile app automatically starts playing without
+ *                          needing another release.
+ */
+function _normalizeTrackAudioUrl(raw: unknown): string {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return '';
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  // Relative path — prepend the configured API base. Strip a leading slash
+  // so we don't double it when baseURL already ends with one.
+  const base = API_CONFIG.baseURL.replace(/\/$/, '');
+  const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return `${base}${path}`;
+}
+
 export function useMeditationTracks(category?: string): UseQueryResult<MeditationTrack[]> {
   return useQuery({
     queryKey: queryKeys.meditationTracks(category),
     queryFn: async () => {
       const { data } = await api.meditation.tracks(category);
-      return data as MeditationTrack[];
+      const raw = Array.isArray(data) ? data : [];
+      // Normalise `audioUrl` and defensively coerce the other fields — the
+      // backend sometimes ships null / missing values that would otherwise
+      // break TrackPlayer.add() at play time instead of surfacing a clean
+      // "coming soon" message at list-render time.
+      return raw.map((t): MeditationTrack => {
+        const row = t as Record<string, unknown>;
+        return {
+          id: String(row.id ?? ''),
+          title: String(row.title ?? 'Untitled'),
+          artist: String(row.artist ?? 'KIAAN Vibe'),
+          duration: Number(row.duration ?? 0),
+          category: (row.category as MeditationTrack['category']) ?? 'meditation',
+          audioUrl: _normalizeTrackAudioUrl(row.audioUrl ?? row.audio_url),
+          ...(typeof row.artworkUrl === 'string' && row.artworkUrl.length > 0
+            ? { artworkUrl: row.artworkUrl }
+            : {}),
+          ...(typeof row.description === 'string'
+            ? { description: row.description }
+            : {}),
+        };
+      });
     },
     staleTime: 1000 * 60 * 30,
   });

--- a/kiaanverse-mobile/packages/api/src/hooks.ts
+++ b/kiaanverse-mobile/packages/api/src/hooks.ts
@@ -198,20 +198,80 @@ export function useGitaChapter(chapterId: number): UseQueryResult<ChapterDetail>
   });
 }
 
+/**
+ * A verse is considered "placeholder" when the seed corpus has not yet been
+ * populated with real content. The seed generator wrote `sanskrit: "॥ X.Y ॥"`
+ * and `english: "Bhagavad Gita Chapter X, Verse Y teaches wisdom on <theme>."`
+ * for most verses; the backend returns that text verbatim. Treat those rows
+ * as missing so the UI can show a real fallback instead of the generated
+ * copy — otherwise the home screen literally reads
+ * "teaches wisdom on devotion" in place of the shloka.
+ */
+function isPlaceholderVerse(v: {
+  sanskrit?: string | null;
+  english?: string | null;
+  transliteration?: string | null;
+}): boolean {
+  const eng = (v.english ?? '').toLowerCase();
+  const sanskrit = (v.sanskrit ?? '').trim();
+  const translit = (v.transliteration ?? '').trim();
+  if (eng.includes('teaches wisdom on')) return true;
+  if (/^verse \d+\.\d+$/i.test(translit)) return true;
+  // Sanskrit that is just the verse-number marker "॥ 12.6 ॥" — shorter than
+  // any real shloka, contains only digits, the danda character, and spaces.
+  if (/^॥\s*\d+\.\d+\s*॥$/u.test(sanskrit)) return true;
+  return false;
+}
+
+/** Real BG 2.47 used as the last-resort fallback when the requested verse
+ *  is a seed-data placeholder. This is the verse every Gita-reader knows —
+ *  "karmaṇy-evādhikāras te mā phaleṣhu kadāchana". */
+const BG_2_47_FALLBACK: GitaVerse = {
+  id: '2.47',
+  chapter: 2,
+  verse: 47,
+  sanskrit:
+    'कर्मण्येवाधिकारस्ते मा फलेषु कदाचन।\nमा कर्मफलहेतुर्भूर्मा ते सङ्गोऽस्त्वकर्मणि॥',
+  transliteration:
+    "karmaṇy-evādhikāras te mā phaleṣhu kadāchana\nmā karma-phala-hetur bhūr mā te saṅgo 'stv akarmaṇi",
+  translation:
+    'You have the right to perform your prescribed duties, but you are not entitled to the fruits of your actions. Never consider yourself to be the cause of the results, nor be attached to inaction.',
+};
+
 export function useGitaVerse(chapter: number, verse: number): UseQueryResult<GitaVerse> {
   return useQuery({
     queryKey: queryKeys.gitaVerse(chapter, verse),
     queryFn: () =>
       fetchWithGitaCache(`verse:${chapter}:${verse}`, async () => {
         const { data } = await api.gita.verse(chapter, verse);
-        const raw = data as { verse: { chapter: number; verse: number; verse_id: string; sanskrit: string; english: string; hindi: string; theme: string } };
+        // The backend may or may not include transliteration (it is in the
+        // Pydantic VerseSummary but not VerseDetail as of today); read it
+        // either way so the UI picks it up once the backend ships it.
+        const raw = data as {
+          verse: {
+            chapter: number;
+            verse: number;
+            verse_id: string;
+            sanskrit: string;
+            english: string;
+            hindi: string;
+            theme: string;
+            transliteration?: string | null;
+          };
+        };
         const v = raw.verse;
+        if (isPlaceholderVerse(v)) {
+          // Remap to BG 2.47 rather than returning the placeholder. The
+          // user sees a real shloka; analytics can still detect the remap
+          // via the returned `id` differing from the requested chapter.verse.
+          return BG_2_47_FALLBACK;
+        }
         return {
           id: v.verse_id,
           chapter: v.chapter,
           verse: v.verse,
           sanskrit: v.sanskrit,
-          transliteration: '',
+          transliteration: v.transliteration ?? '',
           translation: v.english,
         } as GitaVerse;
       }),

--- a/kiaanverse-mobile/packages/api/src/index.ts
+++ b/kiaanverse-mobile/packages/api/src/index.ts
@@ -53,6 +53,7 @@ export {
   setIapAccountTag,
   openManageSubscription,
   IAPError,
+  isSubscriptionUnavailableError,
   type IAPProduct,
   type PurchaseResult,
 } from './subscription';

--- a/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
+++ b/kiaanverse-mobile/packages/api/src/subscription/iapService.ts
@@ -106,6 +106,46 @@ export class IAPError extends Error {
   }
 }
 
+/**
+ * Recognises the "Play Store hasn't activated the product yet" failure
+ * mode. Covers:
+ *   - `E_OFFER_UNAVAILABLE` — our own IAPError when the cached
+ *     SubscriptionAndroid exists but has no offerToken
+ *   - `E_PRODUCT_NOT_FOUND` — raw code from react-native-iap when the
+ *     sku is entirely unknown to Play
+ *   - Message substrings — covers both the IAPError copy above and
+ *     any string relayed via onError callbacks, which only surfaces the
+ *     message (no code) to the UI layer.
+ *
+ * Used by screens to show a "Coming soon" alert rather than the scary
+ * "Purchase unsuccessful" copy when the real reason is store
+ * configuration.
+ */
+export function isSubscriptionUnavailableError(
+  err: unknown,
+): boolean {
+  const code =
+    err instanceof IAPError
+      ? err.code
+      : ((err as { code?: unknown })?.code as string | undefined) ?? '';
+  if (code === 'E_OFFER_UNAVAILABLE' || code === 'E_PRODUCT_NOT_FOUND') return true;
+
+  const message =
+    typeof err === 'string'
+      ? err
+      : err instanceof Error
+        ? err.message
+        : '';
+  return (
+    message.toLowerCase().includes('not available') ||
+    message.includes('E_PRODUCT_NOT_FOUND') ||
+    message.includes('E_OFFER_UNAVAILABLE') ||
+    // react-native-iap sometimes surfaces "SKU not found" on Android when
+    // the sku list passed to getSubscriptions doesn't match what's live.
+    message.toLowerCase().includes('sku not found')
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------

--- a/kiaanverse-mobile/packages/api/src/subscription/index.ts
+++ b/kiaanverse-mobile/packages/api/src/subscription/index.ts
@@ -25,6 +25,7 @@ export {
   setIapAccountTag,
   openManageSubscription,
   IAPError,
+  isSubscriptionUnavailableError,
   type IAPProduct,
   type PurchaseResult,
   type ReceiptVerificationPayload,

--- a/kiaanverse-mobile/packages/i18n/src/loadMessages.ts
+++ b/kiaanverse-mobile/packages/i18n/src/loadMessages.ts
@@ -55,8 +55,12 @@ const englishMessages: Record<TranslationNamespace, TranslationMessages> = {
   },
   navigation: {
     home: 'Home',
-    chat: 'Chat',
+    chat: 'Sakha',
+    // `shlokas` is kept for back-compat — the route still exists and is
+    // reachable from the Vibe Player's Daily Verse banner, but it is no
+    // longer a bottom-tab item.
     shlokas: 'Shlokas',
+    journeys: 'Journeys',
     journal: 'Journal',
     profile: 'Profile',
   },

--- a/kiaanverse-mobile/packages/store/src/gitaStore.ts
+++ b/kiaanverse-mobile/packages/store/src/gitaStore.ts
@@ -26,11 +26,53 @@ export interface VerseRef {
   verse: number;
 }
 
-// Chapter verse counts (1-indexed) for random verse generation
-const CHAPTER_VERSE_COUNTS: Record<number, number> = {
-  1: 47, 2: 72, 3: 43, 4: 42, 5: 29, 6: 47, 7: 30, 8: 28, 9: 34,
-  10: 42, 11: 55, 12: 20, 13: 35, 14: 27, 15: 20, 16: 24, 17: 28, 18: 78,
-};
+/**
+ * Curated list of verses that ship with real Sanskrit + English in the
+ * backend Gita corpus (data/gita/chapters/*.json). Most verses in the seed
+ * corpus are placeholders — `"english": "Bhagavad Gita Chapter X, Verse Y
+ * teaches wisdom on <theme>."` — so a naive random pick across all 700
+ * verses lands on a placeholder ~96 % of the time and the home screen
+ * shows "teaches wisdom on devotion" instead of a real shloka.
+ *
+ * Every entry below was verified against the corpus at the time this list
+ * was added. When the backend ships real translations for the remaining
+ * verses, expand this list (or delete it and pick across all verses).
+ */
+const CURATED_VOD_VERSES: ReadonlyArray<VerseRef> = [
+  { chapter: 1, verse: 1 },
+  { chapter: 1, verse: 47 },
+  { chapter: 2, verse: 14 },
+  { chapter: 2, verse: 47 },
+  { chapter: 2, verse: 48 },
+  { chapter: 2, verse: 56 },
+  { chapter: 2, verse: 62 },
+  { chapter: 2, verse: 63 },
+  { chapter: 2, verse: 70 },
+  { chapter: 3, verse: 19 },
+  { chapter: 3, verse: 35 },
+  { chapter: 4, verse: 38 },
+  { chapter: 5, verse: 21 },
+  { chapter: 6, verse: 5 },
+  { chapter: 6, verse: 17 },
+  { chapter: 6, verse: 35 },
+  { chapter: 12, verse: 13 },
+  { chapter: 12, verse: 14 },
+  { chapter: 16, verse: 1 },
+  { chapter: 16, verse: 2 },
+  { chapter: 16, verse: 3 },
+  { chapter: 18, verse: 45 },
+  { chapter: 18, verse: 46 },
+  { chapter: 18, verse: 48 },
+  { chapter: 18, verse: 66 },
+];
+
+/**
+ * O(1) membership check against the curated list. Used to detect stale
+ * persisted VOD refs saved before the curated list shipped.
+ */
+const CURATED_VOD_KEYS = new Set(
+  CURATED_VOD_VERSES.map((v) => `${v.chapter}.${v.verse}`),
+);
 
 /** Maximum number of recently viewed verses to keep */
 const MAX_RECENTLY_VIEWED = 20;
@@ -75,22 +117,24 @@ function todayString(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-/** Pick a deterministic-ish random verse based on today's date. */
-function pickRandomVerse(): { chapter: number; verse: number } {
+/**
+ * Pick today's verse deterministically from the curated list of verses with
+ * real content. Uses the same date-hash pattern as before so a given calendar
+ * day always resolves to the same verse for all users, but selects only from
+ * CURATED_VOD_VERSES so the home screen never lands on a "teaches wisdom on
+ * devotion" placeholder.
+ */
+function pickDailyVerse(): VerseRef {
   const today = todayString();
-  // Simple hash from date string for deterministic daily selection
   let hash = 0;
   for (let i = 0; i < today.length; i++) {
     hash = (hash * 31 + today.charCodeAt(i)) | 0;
   }
   hash = Math.abs(hash);
-
-  // Pick chapter (1-18)
-  const chapter = (hash % 18) + 1;
-  const maxVerse = CHAPTER_VERSE_COUNTS[chapter] ?? 20;
-  const verse = (hash % maxVerse) + 1;
-
-  return { chapter, verse };
+  const picked = CURATED_VOD_VERSES[hash % CURATED_VOD_VERSES.length];
+  // TypeScript can't prove the modulo index is in-bounds for a readonly
+  // tuple, but CURATED_VOD_VERSES is guaranteed non-empty by construction.
+  return picked ?? { chapter: 2, verse: 47 };
 }
 
 // ---------------------------------------------------------------------------
@@ -128,11 +172,25 @@ export const useGitaStore = create<GitaState & GitaActions>()(
         },
 
         refreshVerseOfTheDay: () => {
-          const { vodDate } = get();
+          const { vodDate, vodChapter, vodVerse } = get();
           const today = todayString();
-          if (vodDate === today) return; // Already fresh
 
-          const { chapter, verse } = pickRandomVerse();
+          // Re-pick when either (a) the stored ref is stale (yesterday's
+          // verse) or (b) the persisted ref was chosen before the curated
+          // list shipped and points at a placeholder verse. Without the
+          // second check, existing users would be stuck on a "teaches
+          // wisdom on devotion" card until midnight.
+          const persistedKey =
+            vodChapter != null && vodVerse != null
+              ? `${vodChapter}.${vodVerse}`
+              : null;
+          const isFreshAndCurated =
+            vodDate === today &&
+            persistedKey !== null &&
+            CURATED_VOD_KEYS.has(persistedKey);
+          if (isFreshAndCurated) return;
+
+          const { chapter, verse } = pickDailyVerse();
           set((state) => {
             state.vodChapter = chapter;
             state.vodVerse = verse;


### PR DESCRIPTION
## Summary

This PR restructures the Vibe Player library into a three-tab interface (Library · Gita · Playing), adds dedicated Edit Profile and Change Password screens, promotes the Journeys feature to a top-level tab, and improves error handling across multiple surfaces.

### Key Changes

**Vibe Player Refactor**
- Converted the flat track list into a segmented tab interface with three sections:
  - **Library**: Track catalogue with today's verse banner, category filters, and scrollable track list (existing functionality)
  - **Gita**: 18-chapter Bhagavad Gita grid that deep-links into the existing shlokas stack
  - **Playing**: Current track summary with CTA to full player, or empty state pointing back to Library
- Extracted `LibrarySection` component to keep each tab body focused
- Added `GitaBrowser` component with canonical chapter metadata (Sanskrit names, verse counts)
- Added `NowPlayingSection` component for the Playing tab
- Improved `playTrack` error handling with typed `PlayResult` to distinguish "coming soon" (unavailable audio) from real playback errors
- Added haptic feedback on tab selection

**Profile & Authentication**
- Added `edit-profile.tsx` screen with full_name update via POST /api/profile
- Preserves existing `base_experience` on write; seeds 'new_user' for first-time profiles
- Optimistically reconciles authStore after successful update
- Added `change-password.tsx` screen with client-side validation mirroring server policy (≥8 chars, upper+lower+digit+special)
- Both screens extract and surface detailed error messages from FastAPI responses

**Navigation & Tab Structure**
- Promoted Journeys from a sub-tab of Journal to a top-level tab (slot 3)
- Shlokas moved from tab 3 into the Vibe Player's Gita tab; legacy routes remain routable
- Updated tab bar labels: "Chat" → "Sakha"
- Updated i18n messages to reflect new navigation structure

**Journal Improvements**
- Simplified journal.tsx to single-purpose diary (removed Journeys sub-tab)
- Added `KarmaLytixBanner` with direct link to Sacred Mirror analytics
- Reuses existing `JourneysView` component in new top-level journeys.tsx tab

**Data & Store Updates**
- Replaced naive random verse generation with curated list of 25 real verses (avoiding 96% placeholder rate)
- Added `isPlaceholderVerse` detection and BG 2.47 fallback for seed-data placeholders
- Updated gitaStore with curated VOD list and membership check for stale persisted refs

**Chat & API Improvements**
- Enhanced `useSakhaStream` with secure token retrieval and differentiated error messages (auth, cold-start, connection)
- Improved `useViyogaChat` to handle empty assistant responses gracefully
- Added Accept header and __DEV__ logging to API client
- Updated API config documentation for environment variable resolution

**UI & Layout Fixes**
- Fixed `KarmicPatternCard` width calculation for Devanagari script rendering (concrete pixel width instead of percentage)
- Added proper card width computation in karma-reset acknowledgment phase
- Improved accessibility labels and roles throughout

## Checklist
- [x] CI passes (tests run successfully)
- [x] No private keys are committed
- [x] Documentation updated (inline comments for new components and logic)
- [x] License and Code of Conduct included

## Testing

- Vibe Player tab switching and track selection verified with existing test infrastructure
- Profile update tested with mock API responses (success, 404 for new profile, validation errors)
- Password change tested with client-side validation and server error extraction
- Gita chapter navigation tested against existing shlokas stack routing
- Curated verse list verified against backend corpus; fallback to BG 2.47 tested for placeholders
- Chat error handling tested with auth/offline/cold-start scenarios
- Layout fixes verified on narrow screens with Devanagari text

https://claude.ai/code/session_01BYFcUB3x63USeJ6UThQ9q8