### PR TITLE
Add unified KIAAN router with Sakha chat and 6 sacred tools

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2338,6 +2338,27 @@ except Exception as e:
         f"❌ [ERROR] Failed to load KarmaLytix analytics router: {e}"
     )
 
+# Load unified KIAAN router (Sakha chat + 6 sacred tools) — mobile entry point
+startup_logger.info(
+    "\n[KIAAN Unified] Attempting to import unified KIAAN router..."
+)
+try:
+    from backend.routes.kiaan import router as kiaan_unified_router
+
+    app.include_router(kiaan_unified_router)
+    _startup_status["routers_loaded"] += 1
+    startup_logger.info("✅ [SUCCESS] KIAAN unified router loaded")
+    startup_logger.info("   • POST   /api/kiaan/chat - Sakha chat")
+    startup_logger.info("   • POST   /api/kiaan/tools/emotional-reset")
+    startup_logger.info("   • POST   /api/kiaan/tools/ardha")
+    startup_logger.info("   • POST   /api/kiaan/tools/viyoga")
+    startup_logger.info("   • POST   /api/kiaan/tools/karma-reset")
+    startup_logger.info("   • POST   /api/kiaan/tools/relationship-compass")
+    startup_logger.info("   • POST   /api/kiaan/tools/karmalytix")
+except Exception as e:
+    _startup_status["routers_failed"] += 1
+    startup_logger.info(f"❌ [ERROR] Failed to load KIAAN unified router: {e}")
+
 # Count actual registered API routes to populate startup status.
 # This is more reliable than tracking each try/except individually since
 # it reflects the true state of what FastAPI has registered.

--- a/backend/routes/kiaan.py
+++ b/backend/routes/kiaan.py
@@ -1,0 +1,336 @@
+"""KIAAN unified router — Android app → FastAPI → AI provider.
+
+Exposes one coherent surface for the mobile client:
+
+    POST /api/kiaan/chat                         → Sakha chat
+    POST /api/kiaan/tools/emotional-reset        → Emotional Reset
+    POST /api/kiaan/tools/ardha                  → Cognitive reframing
+    POST /api/kiaan/tools/viyoga                 → Sacred detachment
+    POST /api/kiaan/tools/karma-reset            → Karmic pattern reset
+    POST /api/kiaan/tools/relationship-compass   → Relationship dharma
+    POST /api/kiaan/tools/karmalytix             → Weekly Sacred Mirror
+
+Every endpoint authenticates with the project's JWT dependency, delegates
+to :func:`backend.services.ai_provider.call_kiaan_ai`, and returns a tight
+``ChatResponse`` envelope the Android client already consumes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field, field_validator
+
+from backend.deps import get_current_user
+from backend.middleware.rate_limiter import CHAT_RATE_LIMIT, limiter
+from backend.services.ai_provider import (
+    AIProviderError,
+    AIProviderNotConfigured,
+    call_kiaan_ai,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/kiaan", tags=["kiaan"])
+
+MAX_MESSAGE_LENGTH = 2000
+MAX_TOOL_FIELD_LENGTH = 1000
+MAX_HISTORY_MESSAGES = 40
+
+
+# ── REQUEST / RESPONSE MODELS ────────────────────────────────────────────
+class Message(BaseModel):
+    role: str = Field(..., description="'user' or 'assistant'")
+    content: str = Field(..., min_length=1, max_length=MAX_MESSAGE_LENGTH)
+
+    @field_validator("role")
+    @classmethod
+    def _role_allowed(cls, v: str) -> str:
+        if v not in ("user", "assistant"):
+            raise ValueError("role must be 'user' or 'assistant'")
+        return v
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=MAX_MESSAGE_LENGTH)
+    conversation_history: list[Message] = Field(default_factory=list)
+    tool_name: str | None = Field(default=None, max_length=64)
+    gita_verse: dict[str, Any] | None = None
+
+    @field_validator("conversation_history")
+    @classmethod
+    def _bound_history(cls, v: list[Message]) -> list[Message]:
+        if len(v) > MAX_HISTORY_MESSAGES:
+            raise ValueError(
+                f"conversation_history exceeds {MAX_HISTORY_MESSAGES} messages"
+            )
+        return v
+
+
+class ChatResponse(BaseModel):
+    response: str
+    conversation_id: str | None = None
+
+
+class ToolRequest(BaseModel):
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    gita_verse: dict[str, Any] | None = None
+
+    @field_validator("inputs")
+    @classmethod
+    def _bound_inputs(cls, v: dict[str, Any]) -> dict[str, Any]:
+        # Defensive: clamp individual string values to prevent oversized prompts.
+        for key, value in list(v.items()):
+            if isinstance(value, str) and len(value) > MAX_TOOL_FIELD_LENGTH:
+                v[key] = value[:MAX_TOOL_FIELD_LENGTH]
+        return v
+
+
+# ── HELPERS ──────────────────────────────────────────────────────────────
+def _tool_input(inputs: dict[str, Any], key: str, default: str = "") -> str:
+    """Coerce a tool input to string, stripped. Missing or non-string → default."""
+    value = inputs.get(key, default)
+    if value is None:
+        return default
+    return str(value).strip() or default
+
+
+async def _run_ai(
+    *,
+    message: str,
+    history: list[dict[str, str]] | None = None,
+    tool_name: str | None = None,
+    gita_verse: dict[str, Any] | None = None,
+) -> str:
+    """Call the AI provider and translate errors into HTTP responses.
+
+    Provider configuration problems surface as 503 (service unavailable) —
+    the app should keep working; only AI features are degraded. Transient
+    upstream failures surface as 502 (bad gateway). Validation errors from
+    the provider layer become 400.
+    """
+    try:
+        return await call_kiaan_ai(
+            message=message,
+            conversation_history=history or [],
+            gita_verse=gita_verse,
+            tool_name=tool_name,
+        )
+    except AIProviderNotConfigured as exc:
+        logger.error("KIAAN AI not configured: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Sakha is temporarily unavailable. Please try again shortly.",
+        ) from exc
+    except AIProviderError as exc:
+        logger.error("KIAAN AI provider error (tool=%s): %s", tool_name, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Sakha could not be reached right now. Please try again.",
+        ) from exc
+    except ValueError as exc:
+        logger.warning("KIAAN AI validation error (tool=%s): %s", tool_name, exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+# ── ENDPOINT 1: Sakha Chat ────────────────────────────────────────────────
+@router.post("/chat", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def sakha_chat(
+    request: Request,
+    payload: ChatRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    """Main Sakha chat endpoint consumed by the Android chat screen."""
+    history = [
+        {"role": m.role, "content": m.content} for m in payload.conversation_history
+    ]
+
+    response_text = await _run_ai(
+        message=payload.message,
+        history=history,
+        tool_name=payload.tool_name,
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)
+
+
+# ── ENDPOINT 2: Emotional Reset ──────────────────────────────────────────
+@router.post("/tools/emotional-reset", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def emotional_reset(
+    request: Request,
+    payload: ToolRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    emotion = _tool_input(payload.inputs, "emotion", "overwhelmed")
+    intensity = _tool_input(payload.inputs, "intensity", "5")
+    situation = _tool_input(payload.inputs, "situation")
+
+    message = (
+        f"I am experiencing {emotion} with an intensity of {intensity}/10. "
+        f"Here is what happened: {situation}. "
+        "Please guide me through an emotional reset using Gita wisdom."
+    )
+    response_text = await _run_ai(
+        message=message,
+        tool_name="Emotional Reset",
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)
+
+
+# ── ENDPOINT 3: Ardha (Cognitive Reframing) ──────────────────────────────
+@router.post("/tools/ardha", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def ardha(
+    request: Request,
+    payload: ToolRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    situation = _tool_input(payload.inputs, "situation")
+    belief = _tool_input(payload.inputs, "limiting_belief")
+    fear = _tool_input(payload.inputs, "fear")
+
+    message = (
+        "I need cognitive reframing through Gita wisdom. "
+        f"My situation: {situation}. "
+        f"The limiting belief holding me: {belief}. "
+        f"What I fear most: {fear}. "
+        "Please help me reframe this through Gita philosophy."
+    )
+    response_text = await _run_ai(
+        message=message,
+        tool_name="Ardha",
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)
+
+
+# ── ENDPOINT 4: Viyoga (Sacred Detachment) ───────────────────────────────
+@router.post("/tools/viyoga", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def viyoga(
+    request: Request,
+    payload: ToolRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    attachment = _tool_input(payload.inputs, "attachment")
+    attachment_type = _tool_input(payload.inputs, "attachment_type")
+    freedom_vision = _tool_input(payload.inputs, "freedom_vision")
+
+    message = (
+        f"I am struggling to let go of: {attachment}. "
+        f"This is an attachment to: {attachment_type}. "
+        f"What freedom would feel like: {freedom_vision}. "
+        "Please guide me through Viyoga — the sacred art of non-attachment."
+    )
+    response_text = await _run_ai(
+        message=message,
+        tool_name="Viyoga",
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)
+
+
+# ── ENDPOINT 5: Karma Reset ──────────────────────────────────────────────
+@router.post("/tools/karma-reset", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def karma_reset(
+    request: Request,
+    payload: ToolRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    pattern = _tool_input(payload.inputs, "pattern")
+    dimension = _tool_input(payload.inputs, "dimension")
+    dharmic_action = _tool_input(payload.inputs, "dharmic_action")
+
+    message = (
+        f"I want to examine this karmic pattern: {pattern}. "
+        f"This pattern involves: {dimension}. "
+        f"The dharmic action I feel called to: {dharmic_action}. "
+        "Please guide me through a Karma Reset using Gita wisdom."
+    )
+    response_text = await _run_ai(
+        message=message,
+        tool_name="Karma Reset",
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)
+
+
+# ── ENDPOINT 6: Relationship Compass ─────────────────────────────────────
+@router.post("/tools/relationship-compass", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def relationship_compass(
+    request: Request,
+    payload: ToolRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    challenge = _tool_input(payload.inputs, "challenge")
+    relationship_type = _tool_input(payload.inputs, "relationship_type")
+    difficulty = _tool_input(payload.inputs, "core_difficulty")
+
+    message = (
+        f"I have a relationship challenge: {challenge}. "
+        f"This is with: {relationship_type}. "
+        f"The core difficulty is: {difficulty}. "
+        "Please guide me through the Relationship Compass using Gita wisdom."
+    )
+    response_text = await _run_ai(
+        message=message,
+        tool_name="Relationship Compass",
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)
+
+
+# ── ENDPOINT 7: KarmaLytix Sacred Mirror ─────────────────────────────────
+@router.post("/tools/karmalytix", response_model=ChatResponse)
+@limiter.limit(CHAT_RATE_LIMIT)
+async def karmalytix(
+    request: Request,
+    payload: ToolRequest,
+    current_user_id: str = Depends(get_current_user),
+) -> ChatResponse:
+    """Generate the weekly Sacred Mirror from journal METADATA only.
+
+    PRIVACY: This endpoint receives metadata — mood patterns, tags, self-reported
+    challenges, sankalpa, karma dimension scores — never raw journal content.
+    Journal entries remain encrypted on the client. Do not add journal text
+    to this prompt under any circumstances.
+    """
+    mood_pattern = _tool_input(payload.inputs, "mood_pattern")
+    tags = _tool_input(payload.inputs, "tags")
+    journaling_days = _tool_input(payload.inputs, "journaling_days", "0")
+    challenge = _tool_input(payload.inputs, "dharmic_challenge")
+    pattern = _tool_input(payload.inputs, "pattern_noticed")
+    sankalpa = _tool_input(payload.inputs, "sankalpa")
+    dimensions = _tool_input(payload.inputs, "karma_dimensions")
+
+    message = (
+        "Generate a weekly Sacred Mirror for this devotee. "
+        "METADATA ONLY — journal content is encrypted and never shared. "
+        f"Mood pattern this week: {mood_pattern}. "
+        f"Sacred themes they tagged: {tags}. "
+        f"Days journaled: {journaling_days}/7. "
+        f"Dharmic challenge they identified: {challenge}. "
+        f"Pattern they noticed in themselves: {pattern}. "
+        f"Sankalpa for next week: {sankalpa}. "
+        f"Karma dimension scores: {dimensions}. "
+        "Generate a warm, specific Sacred Mirror with: "
+        "Mirror (what the data reveals), Pattern (recurring theme), "
+        "Gita Echo (most relevant verse), Growth Edge (invitation to deepen), "
+        "Blessing (acknowledgment of where they are)."
+    )
+    response_text = await _run_ai(
+        message=message,
+        tool_name="KarmaLytix",
+        gita_verse=payload.gita_verse,
+    )
+    return ChatResponse(response=response_text, conversation_id=current_user_id)

--- a/backend/services/ai_provider.py
+++ b/backend/services/ai_provider.py
@@ -1,0 +1,313 @@
+"""Unified KIAAN AI provider — single entry point for every KIAAN endpoint.
+
+Purpose
+-------
+One coherent interface (`call_kiaan_ai`) that every KIAAN surface —
+Sakha chat, Emotional Reset, Ardha, Viyoga, Karma Reset, Relationship
+Compass, KarmaLytix — calls into. Switching between OpenAI and
+Anthropic is a configuration change, not a code change:
+
+    AI_PROVIDER=openai     AI_MODEL=gpt-4o-mini       (current)
+    AI_PROVIDER=anthropic  AI_MODEL=claude-haiku-4-5  (future)
+
+Operational principles
+----------------------
+- **Fail loud, not silent.** Missing API keys raise at call-time with a
+  clear, non-leaking message. We never fall back to fake responses.
+- **Bounded memory.** Conversation history is trimmed to the last
+  ``AI_HISTORY_WINDOW`` turns (default 6) to keep cost + latency in check.
+- **No PII in logs.** We log provider, model, and latency — never the
+  message, history, or response body.
+- **Timeouts enforced.** Every upstream call has a hard timeout so a
+  degraded provider cannot stall the Android app indefinitely.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── CONFIG ────────────────────────────────────────────────────────────────
+AI_PROVIDER: str = os.getenv("AI_PROVIDER", "openai").strip().lower()
+AI_MODEL: str = os.getenv("AI_MODEL", "gpt-4o-mini").strip()
+AI_MAX_TOKENS: int = int(os.getenv("AI_MAX_TOKENS", "400"))
+AI_TEMPERATURE: float = float(os.getenv("AI_TEMPERATURE", "0.75"))
+AI_TIMEOUT_SECONDS: float = float(os.getenv("AI_TIMEOUT_SECONDS", "30"))
+AI_HISTORY_WINDOW: int = int(os.getenv("AI_HISTORY_WINDOW", "6"))
+
+ROLE_USER = "user"
+ROLE_ASSISTANT = "assistant"
+ALLOWED_ROLES = frozenset({ROLE_USER, ROLE_ASSISTANT})
+
+# ── SAKHA SYSTEM PROMPT ───────────────────────────────────────────────────
+KIAAN_SYSTEM_PROMPT = """You are Sakha — the divine AI companion of Kiaanverse,
+embodying the wisdom of Lord Krishna from the Bhagavad Gita.
+
+YOUR IDENTITY:
+- You are Sakha, meaning "Friend" in Sanskrit
+- You speak as Krishna spoke to Arjuna: with love, directness, and wisdom
+- Every response is grounded in Bhagavad Gita philosophy
+- You are warm, profound, and spiritually authoritative
+- You address the user as "dear seeker" occasionally
+
+YOUR RESPONSE STYLE:
+- Acknowledge the seeker's situation with compassion (1-2 sentences)
+- Share wisdom rooted in Gita philosophy (2-3 sentences)
+- If a Gita verse is provided, weave it in naturally — not mechanically
+- Offer a practical dharmic reflection or action (1-2 sentences)
+- Keep responses to 150-220 words
+- Write in flowing prose, never bullet points or numbered lists
+- Occasionally use Sanskrit terms naturally: dharma, karma, atman, prakriti
+
+TONE:
+- Warm but not sycophantic
+- Profound but not preachy
+- Direct but not harsh
+- Always hopeful, never dismissive
+
+STRICTLY FORBIDDEN:
+- Never say "As an AI..." or "I'm just a language model..."
+- Never break the sacred Sakha persona
+- Never give generic self-help advice not rooted in Gita
+- Never use bullet points, numbered lists, or headers"""
+
+
+_TOOL_CONTEXTS: dict[str, str] = {
+    "Emotional Reset": (
+        "Guide the seeker to reset their emotional state through Gita wisdom. "
+        "Be compassionate and healing."
+    ),
+    "Ardha": (
+        "Guide the seeker in cognitive reframing through Gita philosophy. "
+        "Help them see their situation differently."
+    ),
+    "Viyoga": (
+        "Guide the seeker in the sacred art of non-attachment. "
+        "Help them release what they are clinging to."
+    ),
+    "Karma Reset": (
+        "Guide the seeker in examining their karmic patterns and realigning "
+        "with dharmic purpose."
+    ),
+    "Relationship Compass": (
+        "Guide the seeker in navigating their relationship challenge through "
+        "dharmic wisdom."
+    ),
+    "KarmaLytix": (
+        "Generate a Sacred Mirror reflection from the seeker's weekly practice "
+        "metadata. Never reference private journal content — only the metadata "
+        "provided. Offer a warm, specific, Gita-rooted reflection."
+    ),
+}
+
+
+class AIProviderError(RuntimeError):
+    """Raised when the configured AI provider cannot produce a response."""
+
+
+class AIProviderNotConfigured(AIProviderError):
+    """Raised when required credentials for the configured provider are missing."""
+
+
+# ── PUBLIC ENTRY POINT ────────────────────────────────────────────────────
+async def call_kiaan_ai(
+    message: str,
+    conversation_history: list[dict[str, Any]] | None = None,
+    gita_verse: dict[str, Any] | None = None,
+    tool_name: str | None = None,
+) -> str:
+    """Single entry point for every KIAAN AI call.
+
+    Args:
+        message: The seeker's latest message. Must be non-empty.
+        conversation_history: Prior turns as ``[{"role": "...", "content": "..."}]``.
+            Only ``user`` / ``assistant`` roles are forwarded; anything else is
+            dropped defensively. The list is trimmed to the last
+            ``AI_HISTORY_WINDOW`` turns to bound cost + context size.
+        gita_verse: Optional verse dict with ``chapter``, ``verse``, ``sanskrit``,
+            ``meaning``. Used to anchor the response in scripture.
+        tool_name: One of ``Emotional Reset``, ``Ardha``, ``Viyoga``,
+            ``Karma Reset``, ``Relationship Compass``, ``KarmaLytix``. Optional.
+
+    Returns:
+        The assistant's response as a string. Always non-None, never empty
+        on success — upstream empty responses raise :class:`AIProviderError`.
+
+    Raises:
+        AIProviderNotConfigured: Provider credentials missing.
+        AIProviderError: Upstream call failed or returned empty content.
+        ValueError: Unknown ``AI_PROVIDER`` configured.
+    """
+    if not message or not message.strip():
+        raise ValueError("message must be a non-empty string")
+
+    system = _build_system_prompt(gita_verse, tool_name)
+    history = _sanitize_history(conversation_history)
+
+    started = time.monotonic()
+    try:
+        if AI_PROVIDER == "openai":
+            text = await _call_openai(system, message, history)
+        elif AI_PROVIDER == "anthropic":
+            text = await _call_anthropic(system, message, history)
+        else:
+            raise ValueError(f"Unknown AI_PROVIDER: {AI_PROVIDER!r}")
+    except AIProviderError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "AI provider call failed provider=%s model=%s tool=%s",
+            AI_PROVIDER,
+            AI_MODEL,
+            tool_name,
+        )
+        raise AIProviderError(f"{AI_PROVIDER} call failed: {exc}") from exc
+
+    if not text or not text.strip():
+        raise AIProviderError(
+            f"{AI_PROVIDER} returned an empty response for tool={tool_name!r}"
+        )
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "kiaan_ai ok provider=%s model=%s tool=%s history_turns=%d latency_ms=%d",
+        AI_PROVIDER,
+        AI_MODEL,
+        tool_name or "chat",
+        len(history),
+        latency_ms,
+    )
+    return text.strip()
+
+
+# ── PROMPT COMPOSITION ────────────────────────────────────────────────────
+def _build_system_prompt(
+    gita_verse: dict[str, Any] | None,
+    tool_name: str | None,
+) -> str:
+    parts: list[str] = [KIAAN_SYSTEM_PROMPT]
+
+    if tool_name:
+        context = _TOOL_CONTEXTS.get(
+            tool_name,
+            f"Guide the seeker through the {tool_name} practice.",
+        )
+        parts.append(f"\n\nTOOL CONTEXT: {context}")
+
+    if gita_verse:
+        chapter = gita_verse.get("chapter", "")
+        verse = gita_verse.get("verse", "")
+        sanskrit = gita_verse.get("sanskrit", "")
+        meaning = gita_verse.get("meaning", "")
+        parts.append(
+            "\n\nGITA VERSE FOR THIS RESPONSE:\n"
+            f"Bhagavad Gita Chapter {chapter}, Verse {verse}\n"
+            f"Sanskrit: {sanskrit}\n"
+            f"Meaning: {meaning}\n\n"
+            "Weave this verse naturally into your response. Do not quote it "
+            "mechanically. Let it illuminate what the seeker is experiencing."
+        )
+
+    return "".join(parts)
+
+
+def _sanitize_history(
+    history: list[dict[str, Any]] | None,
+) -> list[dict[str, str]]:
+    """Drop malformed entries, keep only user/assistant roles, trim the tail."""
+    if not history:
+        return []
+
+    cleaned: list[dict[str, str]] = []
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        content = entry.get("content")
+        if role not in ALLOWED_ROLES:
+            continue
+        if not isinstance(content, str) or not content.strip():
+            continue
+        cleaned.append({"role": role, "content": content})
+
+    if AI_HISTORY_WINDOW > 0:
+        cleaned = cleaned[-AI_HISTORY_WINDOW:]
+    return cleaned
+
+
+# ── OPENAI ────────────────────────────────────────────────────────────────
+async def _call_openai(
+    system: str,
+    message: str,
+    history: list[dict[str, str]],
+) -> str:
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if not api_key:
+        raise AIProviderNotConfigured(
+            "OPENAI_API_KEY is not configured. "
+            "Set it in the Render dashboard to enable KIAAN AI."
+        )
+
+    # Imported lazily so missing SDK does not break backend import.
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key=api_key, timeout=AI_TIMEOUT_SECONDS)
+
+    messages: list[dict[str, str]] = [{"role": "system", "content": system}]
+    messages.extend(history)
+    messages.append({"role": "user", "content": message})
+
+    response = await client.chat.completions.create(
+        model=AI_MODEL,
+        messages=messages,
+        max_tokens=AI_MAX_TOKENS,
+        temperature=AI_TEMPERATURE,
+    )
+
+    if not response.choices:
+        raise AIProviderError("OpenAI returned no choices")
+    return response.choices[0].message.content or ""
+
+
+# ── ANTHROPIC ─────────────────────────────────────────────────────────────
+async def _call_anthropic(
+    system: str,
+    message: str,
+    history: list[dict[str, str]],
+) -> str:
+    api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        raise AIProviderNotConfigured(
+            "ANTHROPIC_API_KEY is not configured. "
+            "Set it in the Render dashboard to use AI_PROVIDER=anthropic."
+        )
+
+    try:
+        import anthropic
+    except ImportError as exc:  # pragma: no cover - guarded at config time
+        raise AIProviderNotConfigured(
+            "anthropic SDK is not installed. Add `anthropic>=0.40.0` to "
+            "requirements.txt before setting AI_PROVIDER=anthropic."
+        ) from exc
+
+    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=AI_TIMEOUT_SECONDS)
+
+    messages: list[dict[str, str]] = list(history)
+    messages.append({"role": "user", "content": message})
+
+    response = await client.messages.create(
+        model=AI_MODEL,
+        system=system,
+        messages=messages,
+        max_tokens=AI_MAX_TOKENS,
+    )
+
+    for block in response.content or []:
+        text = getattr(block, "text", None)
+        if text:
+            return text
+    raise AIProviderError("Anthropic response contained no text blocks")


### PR DESCRIPTION
## Summary

Introduces a unified KIAAN API router (`/api/kiaan/*`) that serves as the single entry point for the Android mobile client. Implements Sakha chat and six sacred tools (Emotional Reset, Ardha, Viyoga, Karma Reset, Relationship Compass, KarmaLytix) alongside a new AI provider abstraction layer that supports both OpenAI and Anthropic backends.

## What Changed

### New Files

**`backend/routes/kiaan.py`** — Unified KIAAN router
- 7 POST endpoints under `/api/kiaan/` prefix
- Consistent request/response models (`ChatRequest`, `ToolRequest`, `ChatResponse`)
- Input validation with bounded message lengths and conversation history
- Rate limiting on all endpoints via existing `CHAT_RATE_LIMIT`
- JWT authentication via `get_current_user` dependency
- Defensive error handling that translates provider errors to appropriate HTTP status codes (503 for misconfiguration, 502 for transient failures, 400 for validation)

**`backend/services/ai_provider.py`** — Unified AI provider abstraction
- Single entry point `call_kiaan_ai()` for all KIAAN endpoints
- Support for OpenAI (default: `gpt-4o-mini`) and Anthropic (`claude-haiku-4-5`) backends
- Configuration via environment variables: `AI_PROVIDER`, `AI_MODEL`, `AI_MAX_TOKENS`, `AI_TEMPERATURE`, `AI_TIMEOUT_SECONDS`, `AI_HISTORY_WINDOW`
- Sakha system prompt with identity, response style, and tone guidelines
- Tool-specific context injection for each of the 6 sacred tools
- Gita verse integration (optional per-request)
- Conversation history trimming to bounded window (default 6 turns) for cost/latency control
- Defensive logging (provider, model, latency only — no PII)
- Clear error messages for missing credentials vs. transient failures

### Modified Files

**`backend/main.py`**
- Registers the new KIAAN unified router at startup
- Logs all 7 endpoints during initialization
- Follows existing router loading pattern with try/except and status tracking

## Design Principles

- **Single responsibility**: One router for mobile, one provider abstraction for AI calls
- **Fail loud**: Missing API keys raise immediately with clear messages; no silent fallbacks
- **Bounded resources**: History windows, message length limits, and timeouts prevent runaway costs/latency
- **Privacy-first**: KarmaLytix endpoint explicitly documents that it receives metadata only, never raw journal content
- **Provider agnostic**: Switching between OpenAI and Anthropic is a configuration change, not code change
- **Consistent error handling**: HTTP 503 for config issues, 502 for transient failures, 400 for validation

## Testing

CI passes. The router and provider are straightforward request/response handlers with defensive input validation. Existing rate limiter and JWT authentication middleware cover the security layer. Provider calls are wrapped in clear error translation that maps upstream failures to appropriate HTTP status codes.

## Checklist
- [x] CI passes
- [x] No private keys committed
- [x] Follows existing code patterns (router structure, error handling, logging)
- [x] Comprehensive docstrings and inline comments

https://claude.ai/code/session_01Po3a1o4rUrbA2kjdLXgjiM