### PR TITLE
Add mobile OTA update workflow and fix service worker cache

### DIFF
--- a/.github/workflows/mobile-ota-update.yml
+++ b/.github/workflows/mobile-ota-update.yml
@@ -1,0 +1,103 @@
+name: Mobile OTA Update
+
+# Publishes a JavaScript-only EAS Update to the `production` channel on every
+# push to `main` that touches mobile sources.
+#
+# WHY THIS EXISTS:
+#   Without this workflow, merging PRs to `main` does NOT reach installed
+#   APKs/IPAs. `mobile-production-release.yml` only fires on `v*.*.*` tag
+#   pushes (full store submission), so JS-only changes that landed via PR
+#   merge stay invisible on devices until someone manually tags a release.
+#   That's the "merged a new PR but the app shows the old build" symptom.
+#
+# WHAT IT DOES:
+#   `eas update --branch production --channel production` publishes the new
+#   JS bundle. The app's `expo-updates` module (configured in
+#   `apps/mobile/app.config.ts` with `runtimeVersion: { policy: 'appVersion' }`)
+#   downloads it on next cold start and reloads with the fresh code.
+#
+# WHAT IT DOES NOT DO:
+#   Native changes (new permissions, native modules, version bump, app icon,
+#   splash, anything in `app.config.ts` `ios`/`android` blocks) are NOT
+#   shippable as OTA — they require a new APK/IPA via the existing
+#   `mobile-production-release.yml` (push a `v*.*.*` tag).
+#
+#   To skip OTA on a commit that's purely native / non-functional, include
+#   `[skip ota]` in the commit message.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'kiaanverse-mobile/**'
+      - '!kiaanverse-mobile/**/*.md'
+      - '!kiaanverse-mobile/**/README*'
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Update message (defaults to commit subject)'
+        required: false
+        type: string
+
+concurrency:
+  group: mobile-ota-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish EAS Update
+    if: ${{ !contains(github.event.head_commit.message, '[skip ota]') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: kiaanverse-mobile/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: kiaanverse-mobile
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Verify EXPO_TOKEN is set
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::EXPO_TOKEN secret is not configured. OTA updates cannot be published."
+            exit 1
+          fi
+
+      - name: Publish OTA update to production channel
+        working-directory: kiaanverse-mobile/apps/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          INPUT_MESSAGE: ${{ github.event.inputs.message }}
+        run: |
+          if [ -n "$INPUT_MESSAGE" ]; then
+            MSG="$INPUT_MESSAGE"
+          else
+            # Fall back to the commit subject for traceability in EAS dashboard.
+            MSG=$(git log -1 --pretty=%s)
+          fi
+          echo "Publishing EAS update: $MSG"
+          eas update \
+            --branch production \
+            --channel production \
+            --message "$MSG" \
+            --non-interactive

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
  * - Images: cache-first (30 days)
  */
 
-const CACHE_VERSION = 'mindvibe-v19.0-account-profile-rebuild';
+const CACHE_VERSION = 'mindvibe-v20.0-stale-build-fix';
 const CACHE_STATIC = `${CACHE_VERSION}-static`;
 const CACHE_DYNAMIC = `${CACHE_VERSION}-dynamic`;
 const CACHE_API = `${CACHE_VERSION}-api`;


### PR DESCRIPTION
## Summary

This PR adds automated over-the-air (OTA) updates for the mobile app and fixes a service worker cache versioning issue.

### Changes

1. **New Mobile OTA Update Workflow** (`.github/workflows/mobile-ota-update.yml`)
   - Automatically publishes JavaScript-only EAS Updates to the production channel on every push to `main` that touches mobile sources
   - Enables installed APKs/IPAs to receive JS-only changes without requiring a full store submission
   - Includes safeguards: skips OTA if commit message contains `[skip ota]` (for native-only changes)
   - Supports manual triggering via `workflow_dispatch` with optional custom update message
   - Verifies `EXPO_TOKEN` secret is configured before attempting publish

2. **Service Worker Cache Version Update** (`public/sw.js`)
   - Bumped cache version from `mindvibe-v19.0-account-profile-rebuild` to `mindvibe-v20.0-stale-build-fix`
   - Ensures browsers clear stale cached assets and fetch fresh versions

## Why This Matters

Previously, merging PRs to `main` with JS-only changes didn't reach installed mobile apps until someone manually tagged a release. This workflow bridges that gap by automatically publishing OTA updates, while the cache version bump ensures web clients receive fresh assets.

## Checklist
- [x] CI passes (workflow syntax valid)
- [x] No private keys committed
- [x] Workflow includes documentation explaining purpose and limitations
- [x] EXPO_TOKEN secret validation included

## Testing

The workflow will be tested on the next push to `main` that touches `kiaanverse-mobile/` sources. Manual testing can be performed via `workflow_dispatch` input. The service worker cache version change is automatically applied on next browser visit.

https://claude.ai/code/session_011wPuHZFtmKKn51SwyQpSv2