### PR TITLE
Add unified KIAAN client for sacred tools and voice flows

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/hooks/useSacredFlow.ts
+++ b/kiaanverse-mobile/apps/mobile/app/hooks/useSacredFlow.ts
@@ -1,29 +1,55 @@
 /**
  * useSacredFlow — lightweight state container for multi-step sacred tool flows.
  *
- * Each flow (viyoga, ardha, etc.) owns a bucket of string answers collected
- * across its input screens plus an `aiResponse` the submission screen fills
- * after calling Sakha. Storage is in-memory only — these flows are transient
- * by design (a user should not resume a half-finished reflection after
- * killing the app; they should arrive fresh).
+ * Each flow (viyoga, ardha, karma-reset, emotional-reset, relationship-compass)
+ * owns a bucket of string answers collected across its input screens plus a
+ * response payload the submission screen fills after calling KIAAN.
+ * Storage is in-memory only — these flows are transient by design (a user
+ * should not resume a half-finished reflection after killing the app; they
+ * should arrive fresh).
+ *
+ * Submission:
+ *   - `viyoga` still posts to the dedicated `/api/viyoga/chat` route so the
+ *     existing meditation → release → fire screens keep their richer
+ *     `ViyogaTransmission` (karma_yoga_insight, citations). The structured
+ *     shape is shaped into five accordion sections + screen-local copy
+ *     defaults for the transmission screen.
+ *   - The other four flows call the unified `/api/kiaan/tools/*` surface
+ *     (see `kiaan/client.ts`). They receive a single `response` string
+ *     which is stored as `plainText` on the bucket; the tool's complete
+ *     screen renders it verbatim inside a SakhaResponse card.
  *
  * Usage:
  *   const { answers, updateAnswer, submitFlow, status, flow } =
- *     useSacredFlow('viyoga');
- *   updateAnswer('separation_type', 'divine');
+ *     useSacredFlow('ardha');
+ *   updateAnswer('situation', 'I keep missing deadlines');
+ *   updateAnswer('limiting_belief', "I'm not disciplined enough");
+ *   updateAnswer('fear', 'Everyone will stop trusting me');
  *   await submitFlow();
- *   console.log(flow.aiResponse);
+ *   console.log(flow.plainText); // KIAAN's reframe
  */
 
 import { useCallback } from 'react';
 import { create } from 'zustand';
-import { api } from '@kiaanverse/api';
+import {
+  api,
+  kiaan,
+  isAuthError,
+  isOfflineError,
+  isApiError,
+  type KiaanGitaVerse,
+} from '@kiaanverse/api';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type FlowName = 'viyoga' | 'ardha' | 'karma-reset' | 'emotional-reset';
+export type FlowName =
+  | 'viyoga'
+  | 'ardha'
+  | 'karma-reset'
+  | 'emotional-reset'
+  | 'relationship-compass';
 
 export type FlowStatus = 'idle' | 'calling' | 'done' | 'error';
 
@@ -62,14 +88,23 @@ export interface FlowBucket {
   readonly answers: FlowAnswers;
   readonly status: FlowStatus;
   readonly error: string | null;
+  /** Viyoga-only structured transmission. Null for other flows. */
   readonly aiResponse: FlowAIResponse;
+  /** Raw KIAAN response text for ardha / karma-reset / emotional-reset /
+   *  relationship-compass. Null for Viyoga (which uses `aiResponse`). */
+  readonly plainText: string | null;
+  /** Verse the user surfaced from WisdomCore before submitting; echoed to
+   *  the backend so its grounding matches what the user saw. */
+  readonly verse: KiaanGitaVerse | null;
 }
 
 interface SacredFlowState {
   flows: Record<string, FlowBucket>;
   setAnswer: (flow: FlowName, key: string, value: string) => void;
+  setVerse: (flow: FlowName, verse: KiaanGitaVerse | null) => void;
   setStatus: (flow: FlowName, status: FlowStatus, error?: string | null) => void;
   setAIResponse: (flow: FlowName, response: FlowAIResponse) => void;
+  setPlainText: (flow: FlowName, text: string | null) => void;
   reset: (flow: FlowName) => void;
 }
 
@@ -82,6 +117,8 @@ const EMPTY_BUCKET: FlowBucket = {
   status: 'idle',
   error: null,
   aiResponse: null,
+  plainText: null,
+  verse: null,
 };
 
 const useSacredFlowStore = create<SacredFlowState>((set) => ({
@@ -97,6 +134,17 @@ const useSacredFlowStore = create<SacredFlowState>((set) => ({
             ...current,
             answers: { ...current.answers, [key]: value },
           },
+        },
+      };
+    }),
+
+  setVerse: (flow, verse) =>
+    set((state) => {
+      const current = state.flows[flow] ?? EMPTY_BUCKET;
+      return {
+        flows: {
+          ...state.flows,
+          [flow]: { ...current, verse },
         },
       };
     }),
@@ -119,6 +167,17 @@ const useSacredFlowStore = create<SacredFlowState>((set) => ({
         flows: {
           ...state.flows,
           [flow]: { ...current, aiResponse: response },
+        },
+      };
+    }),
+
+  setPlainText: (flow, text) =>
+    set((state) => {
+      const current = state.flows[flow] ?? EMPTY_BUCKET;
+      return {
+        flows: {
+          ...state.flows,
+          [flow]: { ...current, plainText: text },
         },
       };
     }),
@@ -248,6 +307,101 @@ function shapeTransmission(
 }
 
 // ---------------------------------------------------------------------------
+// Unified KIAAN submission — ardha / karma-reset / emotional-reset /
+// relationship-compass. Returns the raw `response` string or throws.
+// ---------------------------------------------------------------------------
+
+/** Pick a string answer, trim, and fall back to `fallback` if empty. */
+function pickAnswer(answers: FlowAnswers, key: string, fallback = ''): string {
+  const v = answers[key];
+  if (typeof v !== 'string') return fallback;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+async function submitKiaanTool(
+  flow: Exclude<FlowName, 'viyoga'>,
+  answers: FlowAnswers,
+  verse: KiaanGitaVerse | null,
+): Promise<string> {
+  const v = verse ?? undefined;
+
+  switch (flow) {
+    case 'ardha': {
+      const res = await kiaan.tools.ardha(
+        {
+          situation: pickAnswer(answers, 'situation'),
+          limiting_belief: pickAnswer(answers, 'limiting_belief'),
+          fear: pickAnswer(answers, 'fear'),
+        },
+        v,
+      );
+      return res.response;
+    }
+    case 'karma-reset': {
+      const res = await kiaan.tools.karmaReset(
+        {
+          pattern: pickAnswer(answers, 'pattern'),
+          dimension: pickAnswer(answers, 'dimension', 'action'),
+          dharmic_action: pickAnswer(answers, 'dharmic_action'),
+        },
+        v,
+      );
+      return res.response;
+    }
+    case 'emotional-reset': {
+      const res = await kiaan.tools.emotionalReset(
+        {
+          emotion: pickAnswer(answers, 'emotion', 'overwhelmed'),
+          intensity: pickAnswer(answers, 'intensity', '5'),
+          situation: pickAnswer(answers, 'situation'),
+        },
+        v,
+      );
+      return res.response;
+    }
+    case 'relationship-compass': {
+      const res = await kiaan.tools.relationshipCompass(
+        {
+          challenge: pickAnswer(answers, 'challenge'),
+          relationship_type: pickAnswer(answers, 'relationship_type', 'partner'),
+          core_difficulty: pickAnswer(answers, 'core_difficulty'),
+        },
+        v,
+      );
+      return res.response;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error → compassionate user-facing string. Callers can still inspect the
+// status sentinel (`AUTH_EXPIRED`) to trigger a sign-in redirect.
+// ---------------------------------------------------------------------------
+
+const AUTH_EXPIRED_SENTINEL = 'AUTH_EXPIRED';
+
+function humaniseError(err: unknown): string {
+  if (isAuthError(err)) return AUTH_EXPIRED_SENTINEL;
+  if (isOfflineError(err))
+    return "Saved. Sakha will reply when you're online.";
+  if (isApiError(err)) {
+    if (err.statusCode === 429)
+      return 'Pause, breathe — too many requests. Try in a minute.';
+    if (err.statusCode === 502 || err.statusCode === 503 || err.statusCode === 504)
+      return 'Sakha is collecting herself. Your words are saved locally; try again.';
+    if (err.statusCode >= 500)
+      return 'Something went wrong. Your words are safe.';
+    if (err.message) return err.message;
+  }
+  if (err instanceof Error && err.message.length > 0) return err.message;
+  return 'Sakha could not respond right now.';
+}
+
+/** Exported so tool screens can detect auth failures and redirect. */
+export const FLOW_AUTH_EXPIRED = AUTH_EXPIRED_SENTINEL;
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -257,6 +411,7 @@ export interface UseSacredFlowResult {
   readonly error: string | null;
   readonly flow: FlowBucket;
   readonly updateAnswer: (key: string, value: string) => void;
+  readonly setVerse: (verse: KiaanGitaVerse | null) => void;
   readonly submitFlow: () => Promise<void>;
   readonly resetFlow: () => void;
 }
@@ -264,16 +419,21 @@ export interface UseSacredFlowResult {
 /**
  * Access the collected state for a given sacred flow.
  *
- * `submitFlow()` actually fires the backend call for Viyoga (the others
- * are no-op for now and just flip the status machine so a loading screen
- * can show a transitional state). The shaped `aiResponse` lives on the
- * `flow` bucket for the transmission screen to read.
+ * `submitFlow()` routes by flow name:
+ *   - `viyoga` → `/api/viyoga/chat` (rich structured transmission).
+ *   - others  → `/api/kiaan/tools/<tool>` (plain response string).
+ *
+ * Errors are humanised on the bucket's `error` field. The `AUTH_EXPIRED`
+ * sentinel (exported as `FLOW_AUTH_EXPIRED`) lets screens redirect to
+ * sign-in without catching the error themselves.
  */
 export function useSacredFlow(flow: FlowName): UseSacredFlowResult {
   const bucket = useSacredFlowStore((state) => state.flows[flow] ?? EMPTY_BUCKET);
   const setAnswer = useSacredFlowStore((state) => state.setAnswer);
+  const setVerseFn = useSacredFlowStore((state) => state.setVerse);
   const setStatus = useSacredFlowStore((state) => state.setStatus);
   const setAIResponse = useSacredFlowStore((state) => state.setAIResponse);
+  const setPlainText = useSacredFlowStore((state) => state.setPlainText);
   const reset = useSacredFlowStore((state) => state.reset);
 
   const updateAnswer = useCallback(
@@ -283,41 +443,48 @@ export function useSacredFlow(flow: FlowName): UseSacredFlowResult {
     [flow, setAnswer],
   );
 
+  const setVerse = useCallback(
+    (verse: KiaanGitaVerse | null) => {
+      setVerseFn(flow, verse);
+    },
+    [flow, setVerseFn],
+  );
+
   const submitFlow = useCallback(async (): Promise<void> => {
     setStatus(flow, 'calling');
-
-    // Only Viyoga submits to a backend today. Other flows just
-    // acknowledge and return — keeps the API surface consistent so
-    // callers don't branch on flow name.
-    if (flow !== 'viyoga') {
-      setStatus(flow, 'done');
-      return;
-    }
 
     // Read the latest answers directly from the store so we don't hold
     // a stale closure snapshot from render time.
     const latest = useSacredFlowStore.getState().flows[flow] ?? EMPTY_BUCKET;
 
     try {
-      const { data } = await api.viyoga.chat(buildViyogaPrompt(latest.answers));
-      const raw = (data ?? {}) as ViyogaBackendResponse;
+      if (flow === 'viyoga') {
+        const { data } = await api.viyoga.chat(buildViyogaPrompt(latest.answers));
+        const raw = (data ?? {}) as ViyogaBackendResponse;
 
-      if (raw.error) {
-        throw new Error(raw.error);
+        if (raw.error) {
+          throw new Error(raw.error);
+        }
+
+        const transmission = shapeTransmission(raw, latest.answers);
+        setAIResponse(flow, transmission);
+        // Mirror the raw assistant text onto plainText as well so
+        // callers that don't care about the five-section shape can
+        // still access it (e.g. a "copy to journal" affordance).
+        setPlainText(flow, (raw.assistant ?? '').trim());
+        setStatus(flow, 'done');
+        return;
       }
 
-      const transmission = shapeTransmission(raw, latest.answers);
-      setAIResponse(flow, transmission);
+      const text = await submitKiaanTool(flow, latest.answers, latest.verse);
+      setPlainText(flow, text);
       setStatus(flow, 'done');
     } catch (err) {
-      const message =
-        err instanceof Error && err.message.length > 0
-          ? err.message
-          : 'Sakha could not respond right now.';
+      const message = humaniseError(err);
       setStatus(flow, 'error', message);
       throw err;
     }
-  }, [flow, setStatus, setAIResponse]);
+  }, [flow, setStatus, setAIResponse, setPlainText]);
 
   const resetFlow = useCallback(() => {
     reset(flow);
@@ -329,6 +496,7 @@ export function useSacredFlow(flow: FlowName): UseSacredFlowResult {
     error: bucket.error,
     flow: bucket,
     updateAnswer,
+    setVerse,
     submitFlow,
     resetFlow,
   };

--- a/kiaanverse-mobile/packages/api/src/index.ts
+++ b/kiaanverse-mobile/packages/api/src/index.ts
@@ -7,6 +7,28 @@ export { apiClient, setTokenManager } from './client';
 export { api } from './endpoints';
 export { API_CONFIG } from './config';
 
+// Unified KIAAN surface — `/api/kiaan/*` endpoints (see kiaan/client.ts).
+export {
+  kiaan,
+  type KiaanClient,
+  type KiaanMessage,
+  type KiaanGitaVerse,
+  type KiaanChatRequest,
+  type KiaanChatResponse,
+  type KiaanToolRequest,
+  type EmotionalResetInputs as KiaanEmotionalResetInputs,
+  type ArdhaInputs as KiaanArdhaInputs,
+  type ViyogaInputs as KiaanViyogaInputs,
+  type KarmaResetInputs as KiaanKarmaResetInputs,
+  type RelationshipCompassInputs as KiaanRelationshipCompassInputs,
+  type KarmaLytixMetadata as KiaanKarmaLytixMetadata,
+  useKiaanRoomChat,
+  useKiaanVoice,
+  type KiaanRoomChatMessage,
+  type UseKiaanRoomChatResult,
+  type UseKiaanVoiceResult,
+} from './kiaan';
+
 // Error classes and type guards
 export {
   ApiError,

--- a/kiaanverse-mobile/packages/api/src/kiaan/client.ts
+++ b/kiaanverse-mobile/packages/api/src/kiaan/client.ts
@@ -1,0 +1,296 @@
+/**
+ * Unified KIAAN client — thin wrapper over the backend's
+ * `/api/kiaan/*` surface.
+ *
+ *   POST /api/kiaan/chat                         → Sakha chat
+ *   POST /api/kiaan/tools/emotional-reset        → Emotional Reset
+ *   POST /api/kiaan/tools/ardha                  → Cognitive reframing
+ *   POST /api/kiaan/tools/viyoga                 → Sacred detachment
+ *   POST /api/kiaan/tools/karma-reset            → Karmic pattern reset
+ *   POST /api/kiaan/tools/relationship-compass   → Relationship dharma
+ *   POST /api/kiaan/tools/karmalytix             → Weekly Sacred Mirror
+ *
+ * All endpoints return the tight `ChatResponse` envelope the backend's
+ * `routes/kiaan.py` defines: `{ response: string, conversation_id: string | null }`.
+ * Per-tool fields (sections, analysis, verse) are NOT part of the wire
+ * contract — the UI derives structure client-side from the single
+ * `response` string.
+ *
+ * Auth, retries and 401-refresh are inherited from `apiClient` (client.ts)
+ * so callers don't re-implement them.
+ *
+ * Privacy — KarmaLytix:
+ *   The backend explicitly documents "journal content is encrypted and
+ *   never shared". This client enforces that at the edge — passing
+ *   `content`, `body`, `text`, `entry` or `journal_text` in the metadata
+ *   map throws synchronously before any request is issued. That is a
+ *   belt-and-braces check; the primary guarantee is that callers never
+ *   include those fields in the first place.
+ */
+
+import { apiClient } from '../client';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface KiaanMessage {
+  readonly role: 'user' | 'assistant';
+  readonly content: string;
+}
+
+/**
+ * Structural shape of a Gita verse the backend grounds its answer on.
+ * Fields match `routes/kiaan.py`'s `gita_verse` pass-through (an
+ * untyped dict), not a strict pydantic model — they are optional and the
+ * backend echoes whatever shape the client sends. This mirror is the
+ * shape kiaanverse.com ships from its WisdomCore feed.
+ */
+export interface KiaanGitaVerse {
+  readonly chapter?: number;
+  readonly verse?: number;
+  readonly sanskrit?: string;
+  readonly transliteration?: string;
+  readonly translation?: string;
+  // Allow upstream fields without widening to `any`.
+  readonly [extra: string]: string | number | boolean | null | undefined;
+}
+
+export interface KiaanChatRequest {
+  readonly message: string;
+  readonly conversation_history?: readonly KiaanMessage[];
+  readonly tool_name?: string;
+  readonly gita_verse?: KiaanGitaVerse | null;
+  /** Backend accepts "chat" | "tool" | arbitrary ≤64 chars. */
+  readonly context?: string;
+  /** Wisdom Room bridge — preserved on the wire as `context` so the
+   *  system prompt can be tuned server-side. The backend only reads
+   *  `context` / `system_context`; we coerce room_context into `context`
+   *  for callers who use this alias. */
+  readonly room_context?: string;
+  /** Full replacement system prompt (max 4k chars on the backend). */
+  readonly system_context?: string;
+}
+
+export interface KiaanChatResponse {
+  readonly response: string;
+  readonly conversation_id: string | null;
+}
+
+export interface KiaanToolRequest<I extends Record<string, string> = Record<string, string>> {
+  readonly inputs: I;
+  readonly gita_verse?: KiaanGitaVerse | null;
+}
+
+// ── Per-tool input shapes (matching backend keys exactly) ─────────────────
+//
+// Every field name below comes from `backend/routes/kiaan.py` — do not
+// rename without updating the backend handler. Fields are free-form
+// strings because the backend coerces everything via `_tool_input` and
+// clamps to 1000 chars.
+
+export interface EmotionalResetInputs {
+  readonly emotion: string;     // "anger" | "fear" | "grief" | "anxiety" | "shame" | "overwhelm"
+  readonly intensity: string;   // "1".."10"
+  readonly situation: string;
+}
+
+export interface ArdhaInputs {
+  readonly situation: string;
+  readonly limiting_belief: string;
+  readonly fear: string;
+}
+
+/**
+ * Viyoga inputs — the backend reads `attachment`, `attachment_type` and
+ * `freedom_vision` (see `backend/routes/kiaan.py:256-258`). Keep this
+ * aligned with the Python handler; a mismatch silently becomes an empty
+ * string on the server because `_tool_input` defaults gracefully.
+ */
+export interface ViyogaInputs {
+  readonly attachment: string;
+  readonly attachment_type: string;
+  readonly freedom_vision: string;
+}
+
+export interface KarmaResetInputs {
+  readonly pattern: string;
+  readonly dimension: string;    // "speech" | "action" | "thought" | "relationship" | "work" | "body"
+  readonly dharmic_action: string;
+}
+
+export interface RelationshipCompassInputs {
+  readonly challenge: string;
+  readonly relationship_type: string;  // "partner" | "parent" | "child" | "friend" | "colleague" | "self"
+  readonly core_difficulty: string;
+}
+
+/**
+ * KarmaLytix metadata — NEVER include raw journal text. The backend
+ * prompt explicitly reminds itself of this boundary:
+ *   "METADATA ONLY — journal content is encrypted and never shared."
+ *
+ * Every field is a string because `_tool_input` coerces to str. Numeric
+ * summaries (days journaled, karma scores) must be stringified by the
+ * caller — we surface that in the types below.
+ */
+export interface KarmaLytixMetadata {
+  readonly mood_pattern?: string;
+  readonly tags?: string;
+  readonly journaling_days?: string;
+  readonly dharmic_challenge?: string;
+  readonly pattern_noticed?: string;
+  readonly sankalpa?: string;
+  /** JSON-stringified numeric scores keyed by dimension. */
+  readonly karma_dimensions?: string;
+}
+
+/**
+ * Fields that must never appear in a KarmaLytix request. Any caller that
+ * includes one of these is attempting (almost always accidentally) to
+ * upload raw journal text. Fail loudly.
+ */
+const KARMALYTIX_FORBIDDEN_KEYS: readonly string[] = [
+  'content',
+  'body',
+  'text',
+  'entry',
+  'journal_text',
+  'ciphertext',
+  'plaintext',
+];
+
+/** Dev-time guard. Always runs — cost is negligible and the blast radius
+ *  of a leak is severe (plaintext reflection content reaching the LLM). */
+function assertKarmaLytixSafe(metadata: Readonly<Record<string, unknown>>): void {
+  for (const key of KARMALYTIX_FORBIDDEN_KEYS) {
+    if (key in metadata) {
+      throw new Error(
+        `[KarmaLytix] "${key}" must never leave the device. ` +
+          'Only metadata is sent to the server.',
+      );
+    }
+  }
+}
+
+// ── Request helpers ───────────────────────────────────────────────────────
+
+function buildChatBody(request: KiaanChatRequest): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    message: request.message,
+    conversation_history: request.conversation_history ?? [],
+  };
+  if (request.tool_name !== undefined) body.tool_name = request.tool_name;
+  if (request.gita_verse) body.gita_verse = request.gita_verse;
+  if (request.system_context !== undefined) body.system_context = request.system_context;
+  // `room_context` is a friendlier alias the Wisdom Rooms UI uses — the
+  // backend only reads `context`, so fold it in. Explicit `context` wins
+  // if both are provided (caller knows best).
+  const context = request.context ?? (request.room_context ? `room:${request.room_context}` : undefined);
+  if (context !== undefined) body.context = context;
+  return body;
+}
+
+// ── Public surface ────────────────────────────────────────────────────────
+
+export const kiaan = {
+  /** Sakha chat — non-streaming. For the streaming UX the chat tab uses
+   *  `useSakhaStream` against `/api/chat/message/stream`; this endpoint
+   *  is the right choice for tool-adjacent callers that need a single
+   *  blocking response (e.g. Wisdom Rooms, voice companion). */
+  async chat(request: KiaanChatRequest): Promise<KiaanChatResponse> {
+    const { data } = await apiClient.post<KiaanChatResponse>(
+      '/api/kiaan/chat',
+      buildChatBody(request),
+    );
+    return data;
+  },
+
+  tools: {
+    async emotionalReset(
+      inputs: EmotionalResetInputs,
+      gitaVerse?: KiaanGitaVerse | null,
+    ): Promise<KiaanChatResponse> {
+      const { data } = await apiClient.post<KiaanChatResponse>(
+        '/api/kiaan/tools/emotional-reset',
+        { inputs, gita_verse: gitaVerse ?? null },
+      );
+      return data;
+    },
+
+    async ardha(
+      inputs: ArdhaInputs,
+      gitaVerse?: KiaanGitaVerse | null,
+    ): Promise<KiaanChatResponse> {
+      const { data } = await apiClient.post<KiaanChatResponse>(
+        '/api/kiaan/tools/ardha',
+        { inputs, gita_verse: gitaVerse ?? null },
+      );
+      return data;
+    },
+
+    async viyoga(
+      inputs: ViyogaInputs,
+      gitaVerse?: KiaanGitaVerse | null,
+    ): Promise<KiaanChatResponse> {
+      const { data } = await apiClient.post<KiaanChatResponse>(
+        '/api/kiaan/tools/viyoga',
+        { inputs, gita_verse: gitaVerse ?? null },
+      );
+      return data;
+    },
+
+    async karmaReset(
+      inputs: KarmaResetInputs,
+      gitaVerse?: KiaanGitaVerse | null,
+    ): Promise<KiaanChatResponse> {
+      const { data } = await apiClient.post<KiaanChatResponse>(
+        '/api/kiaan/tools/karma-reset',
+        { inputs, gita_verse: gitaVerse ?? null },
+      );
+      return data;
+    },
+
+    async relationshipCompass(
+      inputs: RelationshipCompassInputs,
+      gitaVerse?: KiaanGitaVerse | null,
+    ): Promise<KiaanChatResponse> {
+      const { data } = await apiClient.post<KiaanChatResponse>(
+        '/api/kiaan/tools/relationship-compass',
+        { inputs, gita_verse: gitaVerse ?? null },
+      );
+      return data;
+    },
+
+    async karmalytix(
+      metadata: KarmaLytixMetadata,
+      gitaVerse?: KiaanGitaVerse | null,
+    ): Promise<KiaanChatResponse> {
+      assertKarmaLytixSafe(metadata as Record<string, unknown>);
+      const { data } = await apiClient.post<KiaanChatResponse>(
+        '/api/kiaan/tools/karmalytix',
+        { inputs: metadata, gita_verse: gitaVerse ?? null },
+      );
+      return data;
+    },
+  },
+
+  /** Voice transcription — the audio companion flow calls this, then
+   *  feeds the transcript into `kiaan.chat`. Implementation delegates to
+   *  the existing `/api/kiaan/transcribe` route exposed via
+   *  `api.voice.transcribe`. Kept here so voice callers import one
+   *  namespace. */
+  async transcribeVoice(audio: FormData): Promise<{ transcript: string; confidence: number }> {
+    const { data } = await apiClient.post<{
+      text?: string;
+      transcript?: string;
+      confidence?: number;
+    }>('/api/kiaan/transcribe', audio, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return {
+      transcript: data.transcript ?? data.text ?? '',
+      confidence: data.confidence ?? 0,
+    };
+  },
+} as const;
+
+export type KiaanClient = typeof kiaan;

--- a/kiaanverse-mobile/packages/api/src/kiaan/hooks.ts
+++ b/kiaanverse-mobile/packages/api/src/kiaan/hooks.ts
@@ -1,0 +1,224 @@
+/**
+ * React hooks that wrap the unified KIAAN client for common UI patterns.
+ *
+ * Each hook is standalone (no TanStack Query dependency) — they're
+ * intended for imperative flows (voice recording, wisdom-room turns)
+ * where a caller triggers a single request and renders the response.
+ * For cache-aware data fetching (history, list endpoints) use
+ * `@tanstack/react-query` directly against `kiaan.chat(...)`.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  kiaan,
+  type KiaanChatResponse,
+  type KiaanGitaVerse,
+  type KiaanMessage,
+} from './client';
+import { isApiError, isAuthError, isOfflineError } from '../errors';
+
+// ── Shared error mapper ───────────────────────────────────────────────────
+
+/** Compassionate copy matching the rest of the app's error taxonomy. */
+function formatError(err: unknown): string {
+  if (isAuthError(err)) return 'AUTH_EXPIRED';
+  if (isOfflineError(err))
+    return "Saved. Sakha will reply when you're online.";
+  if (isApiError(err)) {
+    if (err.statusCode === 429)
+      return 'Pause, breathe — too many requests. Try in a minute.';
+    if (err.statusCode === 502 || err.statusCode === 503 || err.statusCode === 504)
+      return 'Sakha is collecting herself. Please try again.';
+    if (err.statusCode >= 500) return 'Something went wrong. Your words are safe.';
+    if (err.message) return err.message;
+  }
+  if (err instanceof Error && err.message.length > 0) return err.message;
+  return 'The connection wavered. Please try again.';
+}
+
+// ── useKiaanRoomChat — themed Sakha dialogue for Wisdom Rooms ─────────────
+
+export interface KiaanRoomChatMessage {
+  readonly id: string;
+  readonly role: 'user' | 'assistant';
+  readonly content: string;
+  readonly timestamp: number;
+}
+
+export interface UseKiaanRoomChatResult {
+  readonly messages: readonly KiaanRoomChatMessage[];
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly send: (prompt: string) => Promise<void>;
+  readonly reset: () => void;
+}
+
+/**
+ * Single-session themed chat that posts to `/api/kiaan/chat` with a
+ * `room_context` hint. The hook keeps the last 6 turns in its request
+ * so the backend can ground follow-ups.
+ *
+ * Intended for the "themed Sakha" reinterpretation of Wisdom Rooms — a
+ * lightweight alternative to the WebSocket group-chat room. If the
+ * product keeps group chat in the room, this hook can still power a
+ * private "ask Sakha" affordance inside it.
+ */
+export function useKiaanRoomChat(
+  roomContext: string,
+  options?: { readonly initialVerse?: KiaanGitaVerse | null },
+): UseKiaanRoomChatResult {
+  const [messages, setMessages] = useState<KiaanRoomChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // History ref mirrors `messages` without triggering renders during send.
+  const historyRef = useRef<KiaanMessage[]>([]);
+
+  const send = useCallback(
+    async (prompt: string): Promise<void> => {
+      const trimmed = prompt.trim();
+      if (!trimmed || isLoading) return;
+
+      setError(null);
+      setIsLoading(true);
+
+      const userMsg: KiaanRoomChatMessage = {
+        id: `user-${Date.now()}`,
+        role: 'user',
+        content: trimmed,
+        timestamp: Date.now(),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+      historyRef.current = [
+        ...historyRef.current,
+        { role: 'user', content: trimmed },
+      ];
+
+      try {
+        const res: KiaanChatResponse = await kiaan.chat({
+          message: trimmed,
+          conversation_history: historyRef.current.slice(-6),
+          room_context: roomContext,
+          gita_verse: options?.initialVerse ?? null,
+        });
+
+        const assistantMsg: KiaanRoomChatMessage = {
+          id: `assistant-${Date.now()}`,
+          role: 'assistant',
+          content: res.response,
+          timestamp: Date.now(),
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+        historyRef.current = [
+          ...historyRef.current,
+          { role: 'assistant', content: res.response },
+        ];
+      } catch (err) {
+        setError(formatError(err));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [isLoading, options?.initialVerse, roomContext],
+  );
+
+  const reset = useCallback(() => {
+    setMessages([]);
+    setError(null);
+    historyRef.current = [];
+  }, []);
+
+  return { messages, isLoading, error, send, reset };
+}
+
+// ── useKiaanVoice — record → transcribe → chat bridge ─────────────────────
+
+export interface UseKiaanVoiceResult {
+  readonly isTranscribing: boolean;
+  readonly isAwaiting: boolean;
+  readonly lastTranscript: string | null;
+  readonly lastResponse: string | null;
+  readonly error: string | null;
+  /** Submit a recorded audio file URI. Returns the assistant text, or
+   *  null on failure (see `error`). */
+  readonly submit: (recordingUri: string, mimeType?: string) => Promise<string | null>;
+  readonly reset: () => void;
+}
+
+/**
+ * Voice companion: transcribe an audio file, then feed the transcript
+ * to `kiaan.chat`. The caller is responsible for recording (expo-av)
+ * and passing the resulting file URI.
+ */
+export function useKiaanVoice(
+  options?: {
+    readonly conversationHistory?: readonly KiaanMessage[];
+    readonly gitaVerse?: KiaanGitaVerse | null;
+  },
+): UseKiaanVoiceResult {
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [isAwaiting, setIsAwaiting] = useState(false);
+  const [lastTranscript, setLastTranscript] = useState<string | null>(null);
+  const [lastResponse, setLastResponse] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = useCallback(
+    async (recordingUri: string, mimeType = 'audio/m4a'): Promise<string | null> => {
+      setError(null);
+      setIsTranscribing(true);
+      try {
+        const formData = new FormData();
+        // React Native FormData accepts the `{ uri, name, type }` shape;
+        // the typing is intentionally loose because FormData on RN is
+        // not identical to the DOM one.
+        formData.append('audio', {
+          uri: recordingUri,
+          name: 'voice.m4a',
+          type: mimeType,
+        } as unknown as Blob);
+
+        const { transcript } = await kiaan.transcribeVoice(formData);
+        setLastTranscript(transcript);
+
+        if (!transcript.trim()) {
+          setIsTranscribing(false);
+          return null;
+        }
+
+        setIsTranscribing(false);
+        setIsAwaiting(true);
+
+        const res = await kiaan.chat({
+          message: transcript,
+          conversation_history: options?.conversationHistory ?? [],
+          gita_verse: options?.gitaVerse ?? null,
+          context: 'voice',
+        });
+        setLastResponse(res.response);
+        return res.response;
+      } catch (err) {
+        setError(formatError(err));
+        return null;
+      } finally {
+        setIsTranscribing(false);
+        setIsAwaiting(false);
+      }
+    },
+    [options?.conversationHistory, options?.gitaVerse],
+  );
+
+  const reset = useCallback(() => {
+    setLastTranscript(null);
+    setLastResponse(null);
+    setError(null);
+  }, []);
+
+  return {
+    isTranscribing,
+    isAwaiting,
+    lastTranscript,
+    lastResponse,
+    error,
+    submit,
+    reset,
+  };
+}

--- a/kiaanverse-mobile/packages/api/src/kiaan/index.ts
+++ b/kiaanverse-mobile/packages/api/src/kiaan/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Barrel for the unified KIAAN client. Re-exports the `kiaan` namespace
+ * and all request/response types so consumers can import from
+ * `@kiaanverse/api` without reaching into the sub-path.
+ */
+
+export {
+  kiaan,
+  type KiaanClient,
+  type KiaanMessage,
+  type KiaanGitaVerse,
+  type KiaanChatRequest,
+  type KiaanChatResponse,
+  type KiaanToolRequest,
+  type EmotionalResetInputs,
+  type ArdhaInputs,
+  type ViyogaInputs,
+  type KarmaResetInputs,
+  type RelationshipCompassInputs,
+  type KarmaLytixMetadata,
+} from './client';
+
+export {
+  useKiaanRoomChat,
+  useKiaanVoice,
+  type KiaanRoomChatMessage,
+  type UseKiaanRoomChatResult,
+  type UseKiaanVoiceResult,
+} from './hooks';


### PR DESCRIPTION
## Summary

Introduces a unified KIAAN client (`kiaan/client.ts`) that wraps the backend's `/api/kiaan/*` surface, providing type-safe access to Sakha chat, five sacred tools (emotional-reset, ardha, viyoga, karma-reset, relationship-compass), KarmaLytix metadata analysis, and voice transcription. Includes React hooks for common patterns (room chat, voice companion) and integrates the new client into `useSacredFlow` to power tool submission flows.

## Changes

### New Files

- **`packages/api/src/kiaan/client.ts`** — Unified KIAAN client with:
  - `kiaan.chat()` for non-streaming Sakha dialogue
  - `kiaan.tools.*()` methods for each sacred tool (emotionalReset, ardha, viyoga, karmaReset, relationshipCompass, karmalytix)
  - `kiaan.transcribeVoice()` for audio-to-text
  - Type definitions for all request/response shapes (KiaanChatRequest, KiaanChatResponse, per-tool inputs)
  - Privacy guard: `assertKarmaLytixSafe()` prevents accidental inclusion of raw journal text in KarmaLytix requests

- **`packages/api/src/kiaan/hooks.ts`** — React hooks for imperative flows:
  - `useKiaanRoomChat()` — Single-session themed chat for Wisdom Rooms with conversation history
  - `useKiaanVoice()` — Record → transcribe → chat bridge for voice companion

- **`packages/api/src/kiaan/index.ts`** — Barrel export for the KIAAN namespace

### Modified Files

- **`packages/api/src/index.ts`** — Re-exports KIAAN client, types, and hooks at the package root

- **`apps/mobile/app/hooks/useSacredFlow.ts`** — Integrates KIAAN client:
  - Adds `relationship-compass` to supported flows
  - Implements `submitKiaanTool()` to route ardha, karma-reset, emotional-reset, and relationship-compass to `/api/kiaan/tools/*`
  - Viyoga continues using `/api/viyoga/chat` for its rich structured transmission
  - Adds `plainText` field to FlowBucket for storing raw KIAAN responses
  - Adds `verse` field to preserve user-selected Gita verses across submission
  - Implements `humaniseError()` for compassionate error messaging (auth expiry, offline, rate limits, server errors)
  - Exports `FLOW_AUTH_EXPIRED` sentinel so screens can detect auth failures and redirect

## Design Notes

- **Wire contract**: All KIAAN endpoints return `{ response: string, conversation_id: string | null }`. Per-tool structure (sections, analysis, verse) is derived client-side from the response string.
- **Privacy**: KarmaLytix enforces that journal content never leaves the device — the client throws synchronously if forbidden keys (content, body, text, entry, journal_text, etc.) appear in metadata.
- **Error handling**: Unified error mapper handles auth expiry, offline state, rate limits, and server errors with user-facing copy.
- **Viyoga exception**: Viyoga retains its dedicated `/api/viyoga/chat` route and rich `ViyogaTransmission` shape; other tools use the unified KIAAN surface.

## Testing

- CI passes (no new tests added; integration relies on existing API client infrastructure and error handling)
- Type safety enforced by TypeScript for all request/response shapes
- Privacy guard (`assertKarmaLytixSafe`) runs synchronously on every KarmaLytix call

## Checklist
- [x] CI passes
- [x] No private keys committed
- [x] Types and documentation included in code comments
- [x] Error handling and privacy guards in place

https://claude.ai/code/session_01Eihqi8DdkUK27j2rvNiHjU