### PR TITLE
fix(vibe-player/uploads): declare __DEV__ for RN typecheck

### DIFF
--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/UploadsSection.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/UploadsSection.tsx
@@ -33,6 +33,9 @@ import {
   type UserTrack,
 } from './userUploads';
 
+// React Native/Expo global — available at runtime, not in @types/react-native.
+declare const __DEV__: boolean;
+
 const GOLD = '#D4A017';
 const GOLD_SOFT = 'rgba(212,160,23,0.28)';
 const SACRED_WHITE = '#F5F0E8';


### PR DESCRIPTION
## Summary

Follow-up to #1605 (merged). Declares the `__DEV__` global in `UploadsSection.tsx` so the mobile app's TypeScript check accepts it — matching the pattern already used in the sibling `trackPlayerBridge.ts`.

`__DEV__` is injected by Metro at runtime but is not part of `@types/react-native`, so every file that references it needs its own `declare const __DEV__: boolean` at module scope. Without this, `pnpm typecheck` inside `kiaanverse-mobile/apps/mobile` fails with `Cannot find name '__DEV__'`.

## Why it wasn't caught in #1605
The root repo's `tsc` project (`tsconfig.json`) doesn't include the mobile workspace — that sub-app is typechecked via its own `tsconfig.json` which we can't run in this sandbox without a full `pnpm install`. The failure only surfaces once the RN workspace is set up.

## Test plan
- [ ] `cd kiaanverse-mobile/apps/mobile && pnpm typecheck` passes
- [ ] EAS build picks up the change and succeeds

## Scope
One file, three lines.

```
kiaanverse-mobile/apps/mobile/components/vibe-player/UploadsSection.tsx | 3 +++
```

https://claude.ai/code/session_014tLui7TBhA6Xgp61XmMRAL

---
_Generated by [Claude Code](https://claude.ai/code/session_014tLui7TBhA6Xgp61XmMRAL)_