### PR TITLE
fix(sadhana/mobile): unstick breath label, unclip CTA, un-cover keyboard

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/sadhana/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/sadhana/index.tsx
@@ -20,6 +20,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -253,12 +254,14 @@ export default function NityaSadhanaScreen(): React.JSX.Element {
         completed={completedIndices}
       />
 
-      {/* `padding` behavior works reliably on both platforms; `height` on
-          Android fights the soft-keyboard insets and causes layout jumps
-          mid-phase transition. */}
+      {/* Reserve the system gesture/nav bar inset so the bottom CTA on
+          every phase is always reachable, and the text fields on the
+          Reflection / Gratitude phases lift above the keyboard.
+          iOS needs `padding` because the window does not resize; Android
+          defaults to adjustResize, so `height` avoids a double-shift. */}
       <KeyboardAvoidingView
-        style={styles.body}
-        behavior="padding"
+        style={[styles.body, { paddingBottom: Math.max(insets.bottom, 12) }]}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         keyboardVerticalOffset={0}
       >
         <PhaseCeremony phaseKey={phase}>{renderPhase()}</PhaseCeremony>

--- a/kiaanverse-mobile/apps/mobile/components/sadhana/phases/GratitudePhase.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/sadhana/phases/GratitudePhase.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { DivineButton, SacredInput } from '@kiaanverse/ui';
 
@@ -67,7 +67,13 @@ function GratitudePhaseInner({
   const canFinish = mood !== null;
 
   return (
-    <View style={styles.wrap}>
+    <ScrollView
+      style={styles.wrap}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+    >
       <View style={styles.titleBlock}>
         <Text style={styles.phaseLabel} allowFontScaling={false}>
           PHASE VI
@@ -137,7 +143,7 @@ function GratitudePhaseInner({
           loading={isCompleting}
         />
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -147,9 +153,13 @@ export const GratitudePhase = React.memo(GratitudePhaseInner);
 const styles = StyleSheet.create({
   wrap: {
     flex: 1,
+  },
+  content: {
+    flexGrow: 1,
     paddingVertical: 24,
     paddingHorizontal: 20,
     gap: 18,
+    paddingBottom: 32,
   },
   titleBlock: {
     alignItems: 'center',

--- a/kiaanverse-mobile/apps/mobile/components/sadhana/phases/ReflectionPhase.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/sadhana/phases/ReflectionPhase.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { DivineButton, SacredInput } from '@kiaanverse/ui';
 
 const SACRED_WHITE = '#F5F0E8';
@@ -44,7 +44,13 @@ function ReflectionPhaseInner({
   }, [canComplete, onComplete]);
 
   return (
-    <View style={styles.wrap}>
+    <ScrollView
+      style={styles.wrap}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+    >
       <View style={styles.titleBlock}>
         <Text style={styles.phaseLabel} allowFontScaling={false}>
           PHASE IV
@@ -86,7 +92,7 @@ function ReflectionPhaseInner({
           disabled={!canComplete}
         />
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -96,9 +102,15 @@ export const ReflectionPhase = React.memo(ReflectionPhaseInner);
 const styles = StyleSheet.create({
   wrap: {
     flex: 1,
+  },
+  content: {
+    flexGrow: 1,
     paddingVertical: 24,
     paddingHorizontal: 20,
     gap: 16,
+    // Extra bottom breathing room so the "Complete Phase" button floats
+    // above the keyboard once it opens, rather than flush against it.
+    paddingBottom: 32,
   },
   titleBlock: {
     alignItems: 'center',
@@ -144,12 +156,10 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   inputWrap: {
-    flex: 1,
     gap: 6,
   },
   input: {
-    flex: 1,
-    minHeight: 160,
+    minHeight: 180,
   },
   encryptedHint: {
     fontFamily: 'Outfit-Regular',

--- a/kiaanverse-mobile/packages/ui/src/components/BreathingOrb.tsx
+++ b/kiaanverse-mobile/packages/ui/src/components/BreathingOrb.tsx
@@ -9,7 +9,7 @@
  * Phases: Inhale (gold) -> Hold In (cyan) -> Exhale (peacock blue) -> Hold Out (rest)
  */
 
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -70,8 +70,13 @@ function BreathingOrbComponent({
   /** Countdown seconds remaining in current phase */
   const countdown = useSharedValue(0);
 
-  const phaseLabel = useSharedValue<(typeof PHASE_LABELS)[number]>(PHASE_LABELS[0]);
+  // React state so the phase label re-renders as the breath walks through
+  // Inhale -> Hold -> Exhale -> Rest. A SharedValue alone does NOT drive
+  // React re-renders, which is why the label previously looked frozen at
+  // "Breathe In…" for the entire session.
+  const [visibleLabel, setVisibleLabel] = useState<string>(PHASE_LABELS[0]);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tickTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const activeRef = useRef(isActive);
   activeRef.current = isActive;
 
@@ -80,6 +85,10 @@ function BreathingOrbComponent({
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
+    for (const t of tickTimersRef.current) {
+      clearTimeout(t);
+    }
+    tickTimersRef.current = [];
   }, []);
 
   /** Run a single breathing cycle, then recurse if still active. */
@@ -94,9 +103,11 @@ function BreathingOrbComponent({
       const dur = durations[idx] ?? 0;
       const label = PHASE_LABELS[idx] ?? PHASE_LABELS[0];
 
-      // Update phase index and label
+      // Update phase index and label. The React state setter is what
+      // actually drives the UI — without this the <Text> below would be
+      // pinned at PHASE_LABELS[0] forever.
       phaseIndex.value = idx;
-      phaseLabel.value = label;
+      setVisibleLabel(label);
       colorProgress.value = withTiming(idx, { duration: dur, easing: Easing.inOut(Easing.ease) });
       countdown.value = Math.round(dur / 1000);
 
@@ -112,6 +123,20 @@ function BreathingOrbComponent({
       }
       // Phase 3 (holdOut): stay at contracted state
 
+      // Skip zero-duration phases cleanly (e.g. holdOut: 0 in 4-7-8) so we
+      // never sit on a frame for 0 ms and never race onto the next phase.
+      if (dur <= 0) {
+        const nextIdx = idx + 1;
+        if (nextIdx < 4) {
+          runPhase(nextIdx);
+        } else {
+          if (onCycleComplete) runOnJS(onCycleComplete)();
+          colorProgress.value = 0;
+          runCycle();
+        }
+        return;
+      }
+
       // Countdown timer ticks
       const tickInterval = 1000;
       let remaining = Math.round(dur / 1000);
@@ -122,7 +147,7 @@ function BreathingOrbComponent({
         }
       };
       for (let t = 1; t <= remaining; t++) {
-        setTimeout(tick, t * tickInterval);
+        tickTimersRef.current.push(setTimeout(tick, t * tickInterval));
       }
 
       // Schedule next phase
@@ -144,7 +169,7 @@ function BreathingOrbComponent({
     };
 
     runPhase(0);
-  }, [pattern, onCycleComplete, phaseIndex, phaseLabel, colorProgress, countdown, scale, opacity]);
+  }, [pattern, onCycleComplete, phaseIndex, colorProgress, countdown, scale, opacity]);
 
   useEffect(() => {
     if (isActive) {
@@ -155,12 +180,12 @@ function BreathingOrbComponent({
       scale.value = withTiming(1.0, { duration: 400 });
       opacity.value = withTiming(0.6, { duration: 400 });
       colorProgress.value = withTiming(0, { duration: 400 });
-      phaseLabel.value = PHASE_LABELS[0];
+      setVisibleLabel(PHASE_LABELS[0]);
       countdown.value = 0;
     }
 
     return clearTimers;
-  }, [isActive, runCycle, clearTimers, scale, opacity, colorProgress, phaseLabel, countdown]);
+  }, [isActive, runCycle, clearTimers, scale, opacity, colorProgress, countdown]);
 
   const orbAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: scale.value }],
@@ -221,10 +246,11 @@ function BreathingOrbComponent({
         </Animated.View>
       </View>
 
-      {/* Phase label */}
+      {/* Phase label — driven by visibleLabel so Inhale/Hold/Exhale/Rest all
+          actually appear in turn. */}
       <Animated.View style={[styles.labelContainer, phaseLabelStyle]}>
         <Text variant="body" color={colors.text.secondary} align="center">
-          {isActive ? PHASE_LABELS[0] : 'Tap to begin'}
+          {isActive ? visibleLabel : 'Tap to begin'}
         </Text>
       </Animated.View>
     </View>


### PR DESCRIPTION
## Summary

Three paper-cuts reported on the live Android build of Nitya Sadhana:

1. **Breathing orb looked stuck at "Breathe In…" forever.** Root cause: `BreathingOrb` wrote the phase label only to a Reanimated `SharedValue` but then rendered `PHASE_LABELS[0]` verbatim in JSX. SharedValue writes don't drive React re-renders, so Inhale → Hold → Exhale → Rest never appeared in turn. (The breath _was_ cycling — `onCycleComplete` fired every ~19 s — only the label was frozen.)

2. **"Complete Phase" / "Breathing…" button was clipped by the Android gesture / nav bar.** `sadhana/index.tsx` reserved `insets.top` for the header but never `insets.bottom` for the body, so on edge-to-edge the CTA sat under the gesture bar.

3. **Tapping a text input slid the keyboard over the field with no way to scroll.** `ReflectionPhase` and `GratitudePhase` were plain `<View>` containers with `flex: 1` input wrappers.

## What changed

- **`packages/ui/src/components/BreathingOrb.tsx`**
  - Switched the phase label from a `useSharedValue` to React `useState` + `setVisibleLabel()` so the `<Text>` actually re-renders each beat.
  - Track per-cycle tick timers in a ref and clear them on unmount / deactivation (previously they leaked when the phase advanced mid-tick).
  - Short-circuit zero-duration phases (4-7-8 has `holdOut: 0`) so we never hang on an empty beat or double-schedule the next phase.

- **`apps/mobile/app/sadhana/index.tsx`**
  - Added `paddingBottom: Math.max(insets.bottom, 12)` to the `KeyboardAvoidingView` so every phase's bottom CTA clears the gesture / nav bar.
  - Split `KeyboardAvoidingView` behavior per platform — `padding` on iOS, `height` on Android (Expo already sets `adjustResize`, so `padding` there would double-shift).

- **`apps/mobile/components/sadhana/phases/ReflectionPhase.tsx`** and **`GratitudePhase.tsx`**
  - Wrapped each in a `ScrollView` with `keyboardShouldPersistTaps="handled"` and `keyboardDismissMode="on-drag"`.
  - Replaced `flex: 1` on the input wrapper with `minHeight` so the ScrollView can grow the content above the keyboard.
  - Added `paddingBottom: 32` in `contentContainerStyle` for extra breathing room below the Complete CTA.

## Test plan

- [ ] Launch Nitya Sadhana on Android (gesture nav + 3-button nav).
- [ ] Phase I (Arrival): observe the orb label cycling through "Breathe In…", "Hold…", "Breathe Out…", "Rest…" — no longer stuck at "Breathe In…".
- [ ] After 3 full cycles the button should change from "Breathing…" (disabled) to "Complete Phase" (enabled) and sit fully above the nav bar.
- [ ] Phase IV (Reflection): tap the text field; the keyboard opens, the field and "Complete Phase" button remain reachable; dragging dismisses the keyboard.
- [ ] Phase VI (Gratitude): pick a mood, tap the gratitude field, type; verify input visible and "Complete Sadhana" CTA reachable.
- [ ] iOS smoke test — keyboard still lifts correctly (`behavior="padding"` path unchanged).

https://claude.ai/code/session_01MQRqLKLX4jC9SawMGx4iuS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQRqLKLX4jC9SawMGx4iuS)_