### PR TITLE
fix(deploy) + feat(shlokas): OTA pipeline + Sacred Hub tab

### DIFF
--- a/.github/workflows/mobile-ota-update.yml
+++ b/.github/workflows/mobile-ota-update.yml
@@ -96,8 +96,12 @@ jobs:
             MSG=$(git log -1 --pretty=%s)
           fi
           echo "Publishing EAS update: $MSG"
+          # The `production` channel must be mapped to the `production` branch
+          # before this runs. One-time setup:
+          #   eas channel:edit production --branch production
+          # Newer eas-cli versions reject --channel and --branch together, so we
+          # publish to the branch only and rely on the pre-configured mapping.
           eas update \
             --branch production \
-            --channel production \
             --message "$MSG" \
             --non-interactive

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,12 +1,18 @@
 /**
  * Tabs Layout — 5-tab bottom navigation for Kiaanverse.
  *
- *   Home · Sakha · Journeys · Journal · Profile
+ *   Home · Sakha · Shlokas · Journal · Profile
  *
- * Shlokas used to live in slot 3 and Journeys was buried as a sub-tab of
- * Journal; the layout promotes Journeys to a top-level destination and
- * keeps Shlokas reachable via deep-links (from the Vibe Player's Daily
- * Verse banner, notifications, etc.) while removing it from the tab bar.
+ * Shlokas owns slot 3 as a Sacred Hub — every sacred instrument the user
+ * has (Gita scriptures, healing + wisdom tools, Wisdom Rooms, Sacred
+ * Reflections, KIAAN Vibe Player) is one tap away from this tab's root
+ * screen. The full shloka browser lives at `/shlokas/gita`, with existing
+ * deep-link routes `/shlokas/[chapter]/[verse]` untouched.
+ *
+ * Journeys is still a first-class route (reachable from Home's "Browse
+ * Sacred Catalog" CTA and from notifications), but it is `href: null`'d
+ * here so the bottom bar stays at five doorways and the Shlokas Hub is
+ * the home for exploration.
  *
  * - Uses the custom DivineTabBar (gold-accented, dark navy background).
  * - `freezeOnBlur` preserves tab state (scroll positions, chat history,
@@ -14,9 +20,6 @@
  * - Deep-link routes (`/journey/...`, `/verse/...`, `/journal/new`, etc.)
  *   live outside the (tabs) group and are pushed with the Expo Router
  *   stack, not rendered in the tab bar.
- * - `shlokas` is registered with `href: null` so its route is still valid
- *   (every existing `router.push('/(tabs)/shlokas/...')` call in the app
- *   keeps working) but it doesn't render in the bottom bar.
  */
 
 import React from 'react';
@@ -38,13 +41,13 @@ export default function TabsLayout(): React.JSX.Element {
     >
       <Tabs.Screen name="index" options={{ title: t('home') }} />
       <Tabs.Screen name="chat" options={{ title: t('chat') }} />
-      <Tabs.Screen name="journeys" options={{ title: t('journeys') }} />
+      <Tabs.Screen name="shlokas" options={{ title: t('shlokas') }} />
       <Tabs.Screen name="journal" options={{ title: t('journal') }} />
       <Tabs.Screen name="profile" options={{ title: t('profile') }} />
-      {/* Hidden from the bottom bar but still routable — see header note. */}
+      {/* Routable but hidden from the bar — reached from Home's CTA. */}
       <Tabs.Screen
-        name="shlokas"
-        options={{ title: t('shlokas'), href: null }}
+        name="journeys"
+        options={{ title: t('journeys'), href: null }}
       />
     </Tabs>
   );

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/_layout.tsx
@@ -2,9 +2,15 @@
  * Shlokas Tab — Nested Stack
  *
  * Routes:
- *   /shlokas                       — 18 chapters + daily verse + search
+ *   /shlokas                       — Sacred Hub (scriptures + tools + community)
+ *   /shlokas/gita                  — 18 chapters + daily verse + search
  *   /shlokas/[chapter]             — Chapter detail (verse list)
  *   /shlokas/[chapter]/[verse]     — Full shloka detail
+ *
+ * The `gita` screen is the former `index.tsx` — renamed so the tab root
+ * can host the Sacred Hub while every existing deep-link to a chapter or
+ * verse (from Daily Verse banners, notifications, share URLs) keeps
+ * resolving against `[chapter]/[verse]` without modification.
  *
  * Every nested screen is wrapped in DivineScreenWrapper at the screen level
  * so the particle field / aurora persists on route change.
@@ -17,6 +23,7 @@ export default function ShlokasLayout(): React.JSX.Element {
   return (
     <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
       <Stack.Screen name="index" />
+      <Stack.Screen name="gita" />
       <Stack.Screen name="[chapter]/index" />
       <Stack.Screen name="[chapter]/[verse]" />
     </Stack>

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/gita.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/gita.tsx
@@ -1,0 +1,782 @@
+/**
+ * Shlokas — Bhagavad Gita Browser
+ *
+ * 1:1 port of kiaanverse.com/m/gita for native. Composition:
+ *
+ *   ┌──────────────────────────────────────────────────────────┐
+ *   │ Header:  "भगवद गीता" (gold, Devanagari)                  │
+ *   │          "Bhagavad Gita" (muted, Outfit)     [🔍 Search] │
+ *   ├──────────────────────────────────────────────────────────┤
+ *   │ Daily Verse — ShlokaCard with VerseRevelation            │
+ *   │ "18 Chapters" section header + GoldenDivider             │
+ *   │ 18 SacredCard rows (chapter circle + Sanskrit + English) │
+ *   └──────────────────────────────────────────────────────────┘
+ *
+ * Background: DivineScreenWrapper (particle field + aurora).
+ * Search overlay: full-screen lotus-bloom modal with debounced queries.
+ * Offline-first: chapter catalog + daily verse cached for 24h.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  FlatList,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type ListRenderItem,
+} from 'react-native';
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeInDown,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ChevronRight, Search, X } from 'lucide-react-native';
+
+import {
+  DivineScreenWrapper,
+  GoldenDivider,
+  OmLoader,
+  SacredCard,
+  ShlokaCard,
+} from '@kiaanverse/ui';
+import {
+  useGitaChapters,
+  useGitaSearchFull,
+  useGitaVerseDetail,
+  type GitaChapter,
+  type GitaSearchResult,
+} from '@kiaanverse/api';
+import { useGitaStore } from '@kiaanverse/store';
+
+// ---------------------------------------------------------------------------
+// Design tokens (sourced from the web parity tokens used across the UI kit)
+// ---------------------------------------------------------------------------
+
+const GOLD = '#D4A017';
+const GOLD_SOFT = 'rgba(212, 160, 23, 0.35)';
+const GOLD_GLOW = 'rgba(212, 160, 23, 0.55)';
+const TEXT_PRIMARY = '#F5F0E8';
+const TEXT_SECONDARY = '#C8BFA8';
+const TEXT_MUTED = '#7A7060';
+const TEXT_TERTIARY = '#5F5545';
+const SURFACE_OVERLAY = 'rgba(5, 7, 20, 0.88)';
+const ICON_BG = 'rgba(212, 160, 23, 0.10)';
+
+/** Sanskrit (Devanagari) names for each Gita chapter — the backend only
+ *  returns transliterated names, so the screen supplies the canonical
+ *  Devanagari so we never fall back to system text. */
+const CHAPTER_SANSKRIT_NAMES: Record<number, string> = {
+  1: 'अर्जुन विषाद योग',
+  2: 'सांख्य योग',
+  3: 'कर्म योग',
+  4: 'ज्ञान कर्म संन्यास योग',
+  5: 'कर्म संन्यास योग',
+  6: 'आत्म संयम योग',
+  7: 'ज्ञान विज्ञान योग',
+  8: 'अक्षर ब्रह्म योग',
+  9: 'राज विद्या राज गुह्य योग',
+  10: 'विभूति योग',
+  11: 'विश्वरूप दर्शन योग',
+  12: 'भक्ति योग',
+  13: 'क्षेत्र क्षेत्रज्ञ विभाग योग',
+  14: 'गुणत्रय विभाग योग',
+  15: 'पुरुषोत्तम योग',
+  16: 'दैवासुर संपद विभाग योग',
+  17: 'श्रद्धात्रय विभाग योग',
+  18: 'मोक्ष संन्यास योग',
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
+const SEARCH_MIN_CHARS = 3;
+
+/** lotus-bloom easing — matches VerseRevelation + every sacred entrance. */
+const lotusBloom = Easing.bezier(0.22, 1, 0.36, 1);
+
+// ---------------------------------------------------------------------------
+// Daily Verse card
+// ---------------------------------------------------------------------------
+
+/**
+ * Daily Verse — featured ShlokaCard at the top of the screen.
+ *
+ * Reads the same vodChapter/vodVerse from gitaStore that the Home tab uses,
+ * so the "verse of the day" is consistent across the app. On first mount we
+ * trigger `refreshVerseOfTheDay()` inside a useEffect (never during render).
+ */
+function DailyVerse(): React.JSX.Element {
+  const refreshVerseOfTheDay = useGitaStore((s) => s.refreshVerseOfTheDay);
+  useEffect(() => {
+    refreshVerseOfTheDay();
+  }, [refreshVerseOfTheDay]);
+
+  const vodChapter = useGitaStore((s) => s.vodChapter);
+  const vodVerse = useGitaStore((s) => s.vodVerse);
+
+  // Iconic fallback (BG 2.47) before first refresh resolves.
+  const chapter = vodChapter ?? 2;
+  const verse = vodVerse ?? 47;
+
+  const { data, isLoading, error } = useGitaVerseDetail(chapter, verse);
+  const router = useRouter();
+
+  if (isLoading || !data?.verse) {
+    return (
+      <Animated.View entering={FadeIn.duration(400)} style={styles.dailyLoading}>
+        {error ? (
+          <OmLoader size={56} label="The daily verse will return soon…" />
+        ) : (
+          <OmLoader size={56} />
+        )}
+      </Animated.View>
+    );
+  }
+
+  const v = data.verse;
+  const reference = `Bhagavad Gita ${v.chapter}.${v.verse}`;
+
+  return (
+    <Animated.View entering={FadeInDown.duration(500).springify()}>
+      <Pressable
+        onPress={() => router.push(`/(tabs)/shlokas/${v.chapter}/${v.verse}`)}
+        accessibilityRole="button"
+        accessibilityLabel={`Daily verse: ${reference}`}
+      >
+        <View style={styles.dailyWrap}>
+          <Text style={styles.dailyLabel}>✦ Verse of the Day</Text>
+          <ShlokaCard
+            sanskrit={v.sanskrit}
+            meaning={v.english}
+            reference={reference}
+            style={styles.dailyCard}
+          />
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chapter row
+// ---------------------------------------------------------------------------
+
+interface ChapterRowProps {
+  readonly chapter: GitaChapter;
+  readonly index: number;
+  readonly onPress: (chapterId: number) => void;
+}
+
+function ChapterRow({ chapter, index, onPress }: ChapterRowProps): React.JSX.Element {
+  const handlePress = useCallback(() => onPress(chapter.id), [chapter.id, onPress]);
+  const sanskrit = CHAPTER_SANSKRIT_NAMES[chapter.id] ?? '';
+
+  return (
+    <Animated.View
+      entering={FadeInDown.delay(index * 35).duration(340).springify()}
+    >
+      <SacredCard
+        onPress={handlePress}
+        accessibilityLabel={`Chapter ${chapter.id}: ${chapter.title}, ${chapter.versesCount} verses`}
+        contentStyle={styles.chapterBody}
+      >
+        <View style={styles.chapterRow}>
+          {/* Chapter number circle */}
+          <View style={styles.chapterCircle}>
+            <Text style={styles.chapterNumber}>{chapter.id}</Text>
+          </View>
+
+          {/* Chapter names */}
+          <View style={styles.chapterInfo}>
+            <Text
+              style={styles.chapterSanskrit}
+              numberOfLines={1}
+              allowFontScaling
+              accessibilityLanguage="sa"
+            >
+              {sanskrit}
+            </Text>
+            <Text style={styles.chapterEnglish} numberOfLines={1}>
+              {chapter.title}
+            </Text>
+          </View>
+
+          {/* Verse count badge + chevron */}
+          <View style={styles.chapterTrailing}>
+            <View style={styles.versesBadge}>
+              <Text style={styles.versesBadgeText}>{chapter.versesCount}</Text>
+            </View>
+            <ChevronRight size={16} color={TEXT_MUTED} />
+          </View>
+        </View>
+      </SacredCard>
+    </Animated.View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Search overlay
+// ---------------------------------------------------------------------------
+
+interface SearchOverlayProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+  readonly onSelectVerse: (chapter: number, verse: number) => void;
+}
+
+function SearchOverlay({
+  visible,
+  onClose,
+  onSelectVerse,
+}: SearchOverlayProps): React.JSX.Element {
+  const insets = useSafeAreaInsets();
+  const [input, setInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Slide-up animation — 350ms lotusBloom, parity with SacredBottomSheet.
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withTiming(visible ? 1 : 0, {
+      duration: 350,
+      easing: lotusBloom,
+    });
+  }, [visible, progress]);
+
+  const overlayStyle = useAnimatedStyle(() => ({
+    opacity: progress.value,
+    transform: [
+      {
+        translateY: (1 - progress.value) * 40,
+      },
+    ],
+  }));
+
+  const handleChange = useCallback((text: string) => {
+    setInput(text);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setKeyword(text.trim());
+    }, SEARCH_DEBOUNCE_MS);
+  }, []);
+
+  // Cleanup debounce on unmount / close, and reset input on close.
+  useEffect(() => {
+    if (!visible) {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      setInput('');
+      setKeyword('');
+    }
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [visible]);
+
+  const isSearching = keyword.length >= SEARCH_MIN_CHARS;
+  const { data, isLoading, isError } = useGitaSearchFull(keyword);
+  const results: GitaSearchResult[] = data?.results ?? [];
+
+  const renderResult = useCallback<ListRenderItem<GitaSearchResult>>(
+    ({ item }) => {
+      const v = item.verse;
+      return (
+        <Pressable
+          onPress={() => {
+            onSelectVerse(v.chapter, v.verse);
+            onClose();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`Open verse ${v.chapter}.${v.verse}`}
+          style={styles.resultItem}
+        >
+          <ShlokaCard
+            sanskrit={v.sanskrit}
+            meaning={v.english}
+            reference={`Bhagavad Gita ${v.chapter}.${v.verse}`}
+            revealDelay={0}
+          />
+        </Pressable>
+      );
+    },
+    [onClose, onSelectVerse],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="none"
+      transparent
+      statusBarTranslucent
+      onRequestClose={onClose}
+    >
+      <Animated.View style={[styles.overlayRoot, overlayStyle]}>
+        <View style={[styles.overlayHeader, { paddingTop: insets.top + 10 }]}>
+          <View style={styles.overlayInputWrap}>
+            <Search size={18} color={TEXT_SECONDARY} />
+            <TextInput
+              value={input}
+              onChangeText={handleChange}
+              placeholder="Search verses, themes, words…"
+              placeholderTextColor={TEXT_MUTED}
+              autoFocus
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+              style={styles.overlayInput}
+              accessibilityLabel="Search the Bhagavad Gita"
+            />
+          </View>
+          <Pressable
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close search"
+            hitSlop={12}
+            style={styles.overlayClose}
+          >
+            <X size={22} color={TEXT_PRIMARY} />
+          </Pressable>
+        </View>
+
+        <View style={styles.overlayBody}>
+          {!isSearching ? (
+            <View style={styles.emptyState}>
+              <OmLoader size={48} />
+              <Text style={styles.emptyTitle}>Searching the sacred texts…</Text>
+              <Text style={styles.emptyHint}>
+                Type at least {SEARCH_MIN_CHARS} characters to find verses by theme,
+                Sanskrit keyword, or English translation.
+              </Text>
+            </View>
+          ) : isLoading ? (
+            <View style={styles.emptyState}>
+              <OmLoader size={56} label="Reflecting on 700 verses…" />
+            </View>
+          ) : isError ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.errorTitle}>Unable to search right now</Text>
+              <Text style={styles.emptyHint}>
+                Please check your connection and try again. Your previously viewed
+                verses remain available offline.
+              </Text>
+            </View>
+          ) : results.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyTitle}>No verses found</Text>
+              <Text style={styles.emptyHint}>
+                Try another keyword — e.g. &ldquo;dharma&rdquo;, &ldquo;karma&rdquo;,
+                or &ldquo;surrender&rdquo;.
+              </Text>
+            </View>
+          ) : (
+            <FlatList
+              data={results}
+              renderItem={renderResult}
+              keyExtractor={(item) => item.verse.verse_id}
+              contentContainerStyle={styles.resultsContent}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              ItemSeparatorComponent={() => <View style={styles.resultSeparator} />}
+              showsVerticalScrollIndicator={false}
+            />
+          )}
+        </View>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+export default function ShlokasScreen(): React.JSX.Element {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  const { data: chapters, isLoading, error, refetch } = useGitaChapters();
+
+  const openChapter = useCallback(
+    (chapterId: number) => {
+      router.push(`/(tabs)/shlokas/${chapterId}`);
+    },
+    [router],
+  );
+
+  const openVerse = useCallback(
+    (chapter: number, verse: number) => {
+      router.push(`/(tabs)/shlokas/${chapter}/${verse}`);
+    },
+    [router],
+  );
+
+  const listHeader = useMemo(
+    () => (
+      <View style={styles.listHeader}>
+        <DailyVerse />
+
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>18 Chapters</Text>
+          <Text style={styles.sectionSub}>700 verses · the whole Gita</Text>
+        </View>
+        <GoldenDivider withGlyph style={styles.sectionDivider} />
+      </View>
+    ),
+    [],
+  );
+
+  const renderChapter = useCallback<ListRenderItem<GitaChapter>>(
+    ({ item, index }) => (
+      <ChapterRow chapter={item} index={index} onPress={openChapter} />
+    ),
+    [openChapter],
+  );
+
+  const listEmpty = (
+    <View style={styles.emptyState}>
+      {isLoading ? (
+        <OmLoader size={64} label="Opening the sacred text…" />
+      ) : error ? (
+        <>
+          <Text style={styles.errorTitle}>Chapters are temporarily unavailable</Text>
+          <Text style={styles.emptyHint}>
+            Pull down to try again — your bookmarks remain safe offline.
+          </Text>
+          <Pressable onPress={() => void refetch()} style={styles.retryButton}>
+            <Text style={styles.retryText}>Retry</Text>
+          </Pressable>
+        </>
+      ) : null}
+    </View>
+  );
+
+  return (
+    <DivineScreenWrapper>
+      {/* Header (not inside the scroll so the search action stays reachable) */}
+      <View style={styles.header}>
+        <View style={styles.headerTitles}>
+          <Text
+            style={styles.headerSanskrit}
+            allowFontScaling
+            accessibilityLanguage="sa"
+          >
+            भगवद गीता
+          </Text>
+          <Text style={styles.headerEnglish}>Bhagavad Gita</Text>
+        </View>
+        <Pressable
+          onPress={() => setSearchOpen(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Search verses"
+          hitSlop={10}
+          style={styles.searchIconButton}
+        >
+          <Search size={22} color={GOLD} />
+        </Pressable>
+      </View>
+
+      <FlatList<GitaChapter>
+        data={chapters ?? []}
+        renderItem={renderChapter}
+        keyExtractor={(c) => String(c.id)}
+        contentContainerStyle={[
+          styles.listContent,
+          { paddingBottom: insets.bottom + 96 },
+        ]}
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={listEmpty}
+        ItemSeparatorComponent={ChapterSeparator}
+        showsVerticalScrollIndicator={false}
+      />
+
+      <SearchOverlay
+        visible={searchOpen}
+        onClose={() => setSearchOpen(false)}
+        onSelectVerse={openVerse}
+      />
+    </DivineScreenWrapper>
+  );
+}
+
+function ChapterSeparator(): React.JSX.Element {
+  return <View style={styles.chapterSeparator} />;
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  // Header --------------------------------------------------------------------
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 16,
+  },
+  headerTitles: {
+    flex: 1,
+    gap: 2,
+  },
+  headerSanskrit: {
+    fontFamily: 'NotoSansDevanagari-Bold',
+    fontSize: 22,
+    lineHeight: 30,
+    color: GOLD,
+    letterSpacing: 0.3,
+  },
+  headerEnglish: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    lineHeight: 18,
+    color: TEXT_MUTED,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  searchIconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: ICON_BG,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+  },
+
+  // List --------------------------------------------------------------------
+  listContent: {
+    paddingHorizontal: 16,
+    paddingTop: 4,
+  },
+  listHeader: {
+    gap: 18,
+  },
+
+  // Daily verse --------------------------------------------------------------
+  dailyWrap: {
+    gap: 8,
+    marginBottom: 10,
+  },
+  dailyLabel: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 11,
+    color: GOLD,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  dailyCard: {
+    borderColor: GOLD_GLOW,
+    borderWidth: 1,
+    shadowColor: GOLD,
+    shadowOpacity: 0.2,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 0 },
+    elevation: 8,
+  },
+  dailyLoading: {
+    paddingVertical: 24,
+    alignItems: 'center',
+  },
+
+  // Section header ----------------------------------------------------------
+  sectionHeader: {
+    marginTop: 6,
+    gap: 2,
+  },
+  sectionTitle: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    fontSize: 20,
+    lineHeight: 26,
+    color: TEXT_PRIMARY,
+    letterSpacing: 0.4,
+  },
+  sectionSub: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 12,
+    color: TEXT_MUTED,
+    letterSpacing: 0.6,
+  },
+  sectionDivider: {
+    marginTop: 6,
+    marginBottom: 2,
+  },
+
+  // Chapter row --------------------------------------------------------------
+  chapterBody: {
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+  },
+  chapterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  chapterCircle: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(212, 160, 23, 0.08)',
+  },
+  chapterNumber: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    fontSize: 18,
+    color: GOLD,
+    lineHeight: 22,
+  },
+  chapterInfo: {
+    flex: 1,
+    gap: 2,
+  },
+  chapterSanskrit: {
+    fontFamily: 'NotoSansDevanagari-Medium',
+    fontSize: 15,
+    lineHeight: 22,
+    color: GOLD,
+  },
+  chapterEnglish: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    lineHeight: 18,
+    color: TEXT_MUTED,
+    letterSpacing: 0.3,
+  },
+  chapterTrailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  versesBadge: {
+    minWidth: 30,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+    backgroundColor: ICON_BG,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: GOLD_SOFT,
+    alignItems: 'center',
+  },
+  versesBadgeText: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 11,
+    color: GOLD,
+    letterSpacing: 0.4,
+  },
+  chapterSeparator: {
+    height: 10,
+  },
+
+  // Empty / error / retry ----------------------------------------------------
+  emptyState: {
+    paddingVertical: 48,
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    fontSize: 18,
+    color: TEXT_PRIMARY,
+    textAlign: 'center',
+  },
+  emptyHint: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    color: TEXT_SECONDARY,
+    textAlign: 'center',
+    lineHeight: 20,
+    maxWidth: 320,
+  },
+  errorTitle: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    fontSize: 18,
+    color: '#E57373',
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: 8,
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+    backgroundColor: ICON_BG,
+  },
+  retryText: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    color: GOLD,
+    letterSpacing: 0.6,
+  },
+
+  // Search overlay ----------------------------------------------------------
+  overlayRoot: {
+    flex: 1,
+    backgroundColor: SURFACE_OVERLAY,
+  },
+  overlayHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: GOLD_SOFT,
+  },
+  overlayInputWrap: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 14,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: 'rgba(22, 26, 66, 0.85)',
+    borderWidth: 1,
+    borderColor: GOLD_SOFT,
+  },
+  overlayInput: {
+    flex: 1,
+    color: TEXT_PRIMARY,
+    fontFamily: 'Outfit-Regular',
+    fontSize: 14,
+    padding: 0,
+  },
+  overlayClose: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 20,
+  },
+  overlayBody: {
+    flex: 1,
+  },
+  resultsContent: {
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    paddingBottom: 48,
+  },
+  resultItem: {
+    // ShlokaCard handles its own radius + border.
+  },
+  resultSeparator: {
+    height: 12,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/shlokas/index.tsx
@@ -1,782 +1,313 @@
 /**
- * Shlokas — Bhagavad Gita Browser
+ * Shlokas Tab — Sacred Hub
  *
- * 1:1 port of kiaanverse.com/m/gita for native. Composition:
+ * The middle tab of the 5-doorway bottom bar. Replaces the old bare Gita
+ * verse browser with a composed hub that surfaces every sacred instrument
+ * the user has at their disposal:
  *
- *   ┌──────────────────────────────────────────────────────────┐
- *   │ Header:  "भगवद गीता" (gold, Devanagari)                  │
- *   │          "Bhagavad Gita" (muted, Outfit)     [🔍 Search] │
- *   ├──────────────────────────────────────────────────────────┤
- *   │ Daily Verse — ShlokaCard with VerseRevelation            │
- *   │ "18 Chapters" section header + GoldenDivider             │
- *   │ 18 SacredCard rows (chapter circle + Sanskrit + English) │
- *   └──────────────────────────────────────────────────────────┘
+ *   SACRED SCRIPTURES  — Bhagavad Gita (18-chapter browser)
+ *   HEALING TOOLS      — Emotional Reset, Karma Reset
+ *   WISDOM TOOLS       — Ardha, Viyoga, Relationship Compass
+ *   SACRED COMMUNITY   — Wisdom Room, Sacred Reflections
+ *   SACRED SOUND       — KIAAN Vibe Player (full-width, elevated)
  *
- * Background: DivineScreenWrapper (particle field + aurora).
- * Search overlay: full-screen lotus-bloom modal with debounced queries.
- * Offline-first: chapter catalog + daily verse cached for 24h.
+ * Every card is a `ToolCard` (96 px) with a semantic left-accent stripe,
+ * tinted icon bubble, Devanagari label, and one-line description. The
+ * Gita browser card routes into `/shlokas/gita` (the renamed former
+ * `index.tsx`); the deep-link routes `/shlokas/[chapter]/[verse]` are
+ * untouched so existing push notifications and Daily-Verse banners still
+ * resolve.
+ *
+ * Entrance choreography matches the Tools Dashboard pattern:
+ *   - Each section (header + cards) is staggered by 100 ms.
+ *   - Cards within a section stagger by an additional 60 ms per card.
+ *   - Lotus-bloom easing at NATURAL duration.
+ *
+ * This screen is the source of truth for the "Shlokas" doorway — when the
+ * user taps the middle tab, this is what they see. The old `/tools` route
+ * (and `/tools/index.tsx`) is kept as an alternate surface for deep links
+ * and intentionally mirrors a subset of these sections.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  FlatList,
-  Modal,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-  type ListRenderItem,
-} from 'react-native';
-import Animated, {
-  Easing,
-  FadeIn,
-  FadeInDown,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import React, { useCallback, useMemo } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
 import { useRouter } from 'expo-router';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ChevronRight, Search, X } from 'lucide-react-native';
+import { Screen, useDivineEntrance } from '@kiaanverse/ui';
+import { useVibePlayerStore } from '@kiaanverse/store';
 
 import {
-  DivineScreenWrapper,
-  GoldenDivider,
-  OmLoader,
-  SacredCard,
-  ShlokaCard,
-} from '@kiaanverse/ui';
+  SectionHeader,
+  ToolCard,
+  VibePlayerCard,
+} from '../../../components/tools';
 import {
-  useGitaChapters,
-  useGitaSearchFull,
-  useGitaVerseDetail,
-  type GitaChapter,
-  type GitaSearchResult,
-} from '@kiaanverse/api';
-import { useGitaStore } from '@kiaanverse/store';
+  ANGER_RED,
+  DELUSION_PURPLE,
+  DESIRE_AMBER,
+  DIVINE_GOLD,
+  GREED_GREEN,
+  PEACOCK_TEAL,
+} from '../../../components/tools/toolColors';
 
-// ---------------------------------------------------------------------------
-// Design tokens (sourced from the web parity tokens used across the UI kit)
-// ---------------------------------------------------------------------------
+const SACRED_WHITE = '#F5F0E8';
+const TEXT_MUTED = 'rgba(200,191,168,0.65)';
 
-const GOLD = '#D4A017';
-const GOLD_SOFT = 'rgba(212, 160, 23, 0.35)';
-const GOLD_GLOW = 'rgba(212, 160, 23, 0.55)';
-const TEXT_PRIMARY = '#F5F0E8';
-const TEXT_SECONDARY = '#C8BFA8';
-const TEXT_MUTED = '#7A7060';
-const TEXT_TERTIARY = '#5F5545';
-const SURFACE_OVERLAY = 'rgba(5, 7, 20, 0.88)';
-const ICON_BG = 'rgba(212, 160, 23, 0.10)';
+const SECTION_STAGGER_MS = 100;
+const CARD_STAGGER_MS = 60;
 
-/** Sanskrit (Devanagari) names for each Gita chapter — the backend only
- *  returns transliterated names, so the screen supplies the canonical
- *  Devanagari so we never fall back to system text. */
-const CHAPTER_SANSKRIT_NAMES: Record<number, string> = {
-  1: 'अर्जुन विषाद योग',
-  2: 'सांख्य योग',
-  3: 'कर्म योग',
-  4: 'ज्ञान कर्म संन्यास योग',
-  5: 'कर्म संन्यास योग',
-  6: 'आत्म संयम योग',
-  7: 'ज्ञान विज्ञान योग',
-  8: 'अक्षर ब्रह्म योग',
-  9: 'राज विद्या राज गुह्य योग',
-  10: 'विभूति योग',
-  11: 'विश्वरूप दर्शन योग',
-  12: 'भक्ति योग',
-  13: 'क्षेत्र क्षेत्रज्ञ विभाग योग',
-  14: 'गुणत्रय विभाग योग',
-  15: 'पुरुषोत्तम योग',
-  16: 'दैवासुर संपद विभाग योग',
-  17: 'श्रद्धात्रय विभाग योग',
-  18: 'मोक्ष संन्यास योग',
-};
+interface ToolDescriptor {
+  readonly id: string;
+  readonly name: string;
+  readonly sanskrit: string;
+  readonly description: string;
+  readonly color: string;
+  readonly icon: string;
+  readonly route: string;
+}
 
-const SEARCH_DEBOUNCE_MS = 300;
-const SEARCH_MIN_CHARS = 3;
+const SCRIPTURE_TOOLS: readonly ToolDescriptor[] = [
+  {
+    id: 'bhagavad-gita',
+    name: 'Bhagavad Gita',
+    sanskrit: 'भगवद्गीता',
+    description: '18 chapters · 700 shlokas',
+    color: DIVINE_GOLD,
+    icon: '📜',
+    route: '/(tabs)/shlokas/gita',
+  },
+];
 
-/** lotus-bloom easing — matches VerseRevelation + every sacred entrance. */
-const lotusBloom = Easing.bezier(0.22, 1, 0.36, 1);
+const HEALING_TOOLS: readonly ToolDescriptor[] = [
+  {
+    id: 'emotional-reset',
+    name: 'Emotional Reset',
+    sanskrit: 'भावनात्मक पुनर्स्थापना',
+    description: 'Release and transform emotions',
+    color: ANGER_RED,
+    icon: '🔥',
+    route: '/tools/emotional-reset',
+  },
+  {
+    id: 'karma-reset',
+    name: 'Karma Reset',
+    sanskrit: 'कर्म पुनर्निर्धारण',
+    description: 'Heal karmic patterns',
+    color: DELUSION_PURPLE,
+    icon: '☸',
+    route: '/tools/karma-reset',
+  },
+];
 
-// ---------------------------------------------------------------------------
-// Daily Verse card
-// ---------------------------------------------------------------------------
+const WISDOM_TOOLS: readonly ToolDescriptor[] = [
+  {
+    id: 'ardha',
+    name: 'Ardha',
+    sanskrit: 'अर्थ',
+    description: 'Reframe your perspective',
+    color: DESIRE_AMBER,
+    icon: '💡',
+    route: '/tools/ardha',
+  },
+  {
+    id: 'viyoga',
+    name: 'Viyoga',
+    sanskrit: 'वियोग',
+    description: 'The art of letting go',
+    color: PEACOCK_TEAL,
+    icon: '🌊',
+    route: '/tools/viyoga',
+  },
+  {
+    id: 'relationship-compass',
+    name: 'Relationship Compass',
+    sanskrit: 'संबंध सूत्र',
+    description: 'Dharma-guided clarity',
+    color: GREED_GREEN,
+    icon: '🧭',
+    route: '/tools/relationship-compass',
+  },
+];
 
-/**
- * Daily Verse — featured ShlokaCard at the top of the screen.
- *
- * Reads the same vodChapter/vodVerse from gitaStore that the Home tab uses,
- * so the "verse of the day" is consistent across the app. On first mount we
- * trigger `refreshVerseOfTheDay()` inside a useEffect (never during render).
- */
-function DailyVerse(): React.JSX.Element {
-  const refreshVerseOfTheDay = useGitaStore((s) => s.refreshVerseOfTheDay);
-  useEffect(() => {
-    refreshVerseOfTheDay();
-  }, [refreshVerseOfTheDay]);
+const COMMUNITY_TOOLS: readonly ToolDescriptor[] = [
+  {
+    id: 'wisdom-rooms',
+    name: 'Wisdom Room',
+    sanskrit: 'ज्ञान कक्ष',
+    description: 'Sacred circles of seekers',
+    color: GREED_GREEN,
+    icon: '🏛',
+    route: '/wisdom-rooms',
+  },
+  {
+    id: 'sacred-reflections',
+    name: 'Sacred Reflections',
+    sanskrit: 'पवित्र चिन्तन',
+    description: 'Encrypted journal & insights',
+    color: DIVINE_GOLD,
+    icon: '🪷',
+    route: '/journal',
+  },
+];
 
-  const vodChapter = useGitaStore((s) => s.vodChapter);
-  const vodVerse = useGitaStore((s) => s.vodVerse);
-
-  // Iconic fallback (BG 2.47) before first refresh resolves.
-  const chapter = vodChapter ?? 2;
-  const verse = vodVerse ?? 47;
-
-  const { data, isLoading, error } = useGitaVerseDetail(chapter, verse);
+export default function ShlokasHubScreen(): React.JSX.Element {
   const router = useRouter();
 
-  if (isLoading || !data?.verse) {
-    return (
-      <Animated.View entering={FadeIn.duration(400)} style={styles.dailyLoading}>
-        {error ? (
-          <OmLoader size={56} label="The daily verse will return soon…" />
-        ) : (
-          <OmLoader size={56} />
-        )}
-      </Animated.View>
-    );
-  }
+  const currentTrack = useVibePlayerStore((s) => s.currentTrack);
+  const isPlaying = useVibePlayerStore((s) => s.isPlaying);
+  const togglePlay = useVibePlayerStore((s) => s.togglePlay);
 
-  const v = data.verse;
-  const reference = `Bhagavad Gita ${v.chapter}.${v.verse}`;
-
-  return (
-    <Animated.View entering={FadeInDown.duration(500).springify()}>
-      <Pressable
-        onPress={() => router.push(`/(tabs)/shlokas/${v.chapter}/${v.verse}`)}
-        accessibilityRole="button"
-        accessibilityLabel={`Daily verse: ${reference}`}
-      >
-        <View style={styles.dailyWrap}>
-          <Text style={styles.dailyLabel}>✦ Verse of the Day</Text>
-          <ShlokaCard
-            sanskrit={v.sanskrit}
-            meaning={v.english}
-            reference={reference}
-            style={styles.dailyCard}
-          />
-        </View>
-      </Pressable>
-    </Animated.View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Chapter row
-// ---------------------------------------------------------------------------
-
-interface ChapterRowProps {
-  readonly chapter: GitaChapter;
-  readonly index: number;
-  readonly onPress: (chapterId: number) => void;
-}
-
-function ChapterRow({ chapter, index, onPress }: ChapterRowProps): React.JSX.Element {
-  const handlePress = useCallback(() => onPress(chapter.id), [chapter.id, onPress]);
-  const sanskrit = CHAPTER_SANSKRIT_NAMES[chapter.id] ?? '';
-
-  return (
-    <Animated.View
-      entering={FadeInDown.delay(index * 35).duration(340).springify()}
-    >
-      <SacredCard
-        onPress={handlePress}
-        accessibilityLabel={`Chapter ${chapter.id}: ${chapter.title}, ${chapter.versesCount} verses`}
-        contentStyle={styles.chapterBody}
-      >
-        <View style={styles.chapterRow}>
-          {/* Chapter number circle */}
-          <View style={styles.chapterCircle}>
-            <Text style={styles.chapterNumber}>{chapter.id}</Text>
-          </View>
-
-          {/* Chapter names */}
-          <View style={styles.chapterInfo}>
-            <Text
-              style={styles.chapterSanskrit}
-              numberOfLines={1}
-              allowFontScaling
-              accessibilityLanguage="sa"
-            >
-              {sanskrit}
-            </Text>
-            <Text style={styles.chapterEnglish} numberOfLines={1}>
-              {chapter.title}
-            </Text>
-          </View>
-
-          {/* Verse count badge + chevron */}
-          <View style={styles.chapterTrailing}>
-            <View style={styles.versesBadge}>
-              <Text style={styles.versesBadgeText}>{chapter.versesCount}</Text>
-            </View>
-            <ChevronRight size={16} color={TEXT_MUTED} />
-          </View>
-        </View>
-      </SacredCard>
-    </Animated.View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Search overlay
-// ---------------------------------------------------------------------------
-
-interface SearchOverlayProps {
-  readonly visible: boolean;
-  readonly onClose: () => void;
-  readonly onSelectVerse: (chapter: number, verse: number) => void;
-}
-
-function SearchOverlay({
-  visible,
-  onClose,
-  onSelectVerse,
-}: SearchOverlayProps): React.JSX.Element {
-  const insets = useSafeAreaInsets();
-  const [input, setInput] = useState('');
-  const [keyword, setKeyword] = useState('');
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Slide-up animation — 350ms lotusBloom, parity with SacredBottomSheet.
-  const progress = useSharedValue(0);
-
-  useEffect(() => {
-    progress.value = withTiming(visible ? 1 : 0, {
-      duration: 350,
-      easing: lotusBloom,
-    });
-  }, [visible, progress]);
-
-  const overlayStyle = useAnimatedStyle(() => ({
-    opacity: progress.value,
-    transform: [
-      {
-        translateY: (1 - progress.value) * 40,
-      },
-    ],
-  }));
-
-  const handleChange = useCallback((text: string) => {
-    setInput(text);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      setKeyword(text.trim());
-    }, SEARCH_DEBOUNCE_MS);
-  }, []);
-
-  // Cleanup debounce on unmount / close, and reset input on close.
-  useEffect(() => {
-    if (!visible) {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = null;
-      }
-      setInput('');
-      setKeyword('');
-    }
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [visible]);
-
-  const isSearching = keyword.length >= SEARCH_MIN_CHARS;
-  const { data, isLoading, isError } = useGitaSearchFull(keyword);
-  const results: GitaSearchResult[] = data?.results ?? [];
-
-  const renderResult = useCallback<ListRenderItem<GitaSearchResult>>(
-    ({ item }) => {
-      const v = item.verse;
-      return (
-        <Pressable
-          onPress={() => {
-            onSelectVerse(v.chapter, v.verse);
-            onClose();
-          }}
-          accessibilityRole="button"
-          accessibilityLabel={`Open verse ${v.chapter}.${v.verse}`}
-          style={styles.resultItem}
-        >
-          <ShlokaCard
-            sanskrit={v.sanskrit}
-            meaning={v.english}
-            reference={`Bhagavad Gita ${v.chapter}.${v.verse}`}
-            revealDelay={0}
-          />
-        </Pressable>
-      );
-    },
-    [onClose, onSelectVerse],
-  );
-
-  return (
-    <Modal
-      visible={visible}
-      animationType="none"
-      transparent
-      statusBarTranslucent
-      onRequestClose={onClose}
-    >
-      <Animated.View style={[styles.overlayRoot, overlayStyle]}>
-        <View style={[styles.overlayHeader, { paddingTop: insets.top + 10 }]}>
-          <View style={styles.overlayInputWrap}>
-            <Search size={18} color={TEXT_SECONDARY} />
-            <TextInput
-              value={input}
-              onChangeText={handleChange}
-              placeholder="Search verses, themes, words…"
-              placeholderTextColor={TEXT_MUTED}
-              autoFocus
-              autoCorrect={false}
-              autoCapitalize="none"
-              returnKeyType="search"
-              style={styles.overlayInput}
-              accessibilityLabel="Search the Bhagavad Gita"
-            />
-          </View>
-          <Pressable
-            onPress={onClose}
-            accessibilityRole="button"
-            accessibilityLabel="Close search"
-            hitSlop={12}
-            style={styles.overlayClose}
-          >
-            <X size={22} color={TEXT_PRIMARY} />
-          </Pressable>
-        </View>
-
-        <View style={styles.overlayBody}>
-          {!isSearching ? (
-            <View style={styles.emptyState}>
-              <OmLoader size={48} />
-              <Text style={styles.emptyTitle}>Searching the sacred texts…</Text>
-              <Text style={styles.emptyHint}>
-                Type at least {SEARCH_MIN_CHARS} characters to find verses by theme,
-                Sanskrit keyword, or English translation.
-              </Text>
-            </View>
-          ) : isLoading ? (
-            <View style={styles.emptyState}>
-              <OmLoader size={56} label="Reflecting on 700 verses…" />
-            </View>
-          ) : isError ? (
-            <View style={styles.emptyState}>
-              <Text style={styles.errorTitle}>Unable to search right now</Text>
-              <Text style={styles.emptyHint}>
-                Please check your connection and try again. Your previously viewed
-                verses remain available offline.
-              </Text>
-            </View>
-          ) : results.length === 0 ? (
-            <View style={styles.emptyState}>
-              <Text style={styles.emptyTitle}>No verses found</Text>
-              <Text style={styles.emptyHint}>
-                Try another keyword — e.g. &ldquo;dharma&rdquo;, &ldquo;karma&rdquo;,
-                or &ldquo;surrender&rdquo;.
-              </Text>
-            </View>
-          ) : (
-            <FlatList
-              data={results}
-              renderItem={renderResult}
-              keyExtractor={(item) => item.verse.verse_id}
-              contentContainerStyle={styles.resultsContent}
-              keyboardShouldPersistTaps="handled"
-              keyboardDismissMode="on-drag"
-              ItemSeparatorComponent={() => <View style={styles.resultSeparator} />}
-              showsVerticalScrollIndicator={false}
-            />
-          )}
-        </View>
-      </Animated.View>
-    </Modal>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main screen
-// ---------------------------------------------------------------------------
-
-export default function ShlokasScreen(): React.JSX.Element {
-  const router = useRouter();
-  const insets = useSafeAreaInsets();
-  const [searchOpen, setSearchOpen] = useState(false);
-
-  const { data: chapters, isLoading, error, refetch } = useGitaChapters();
-
-  const openChapter = useCallback(
-    (chapterId: number) => {
-      router.push(`/(tabs)/shlokas/${chapterId}`);
+  const handleToolPress = useCallback(
+    (route: string) => {
+      router.push(route as never);
     },
     [router],
   );
 
-  const openVerse = useCallback(
-    (chapter: number, verse: number) => {
-      router.push(`/(tabs)/shlokas/${chapter}/${verse}`);
-    },
-    [router],
-  );
+  const handleOpenVibePlayer = useCallback(() => {
+    router.push('/vibe-player' as never);
+  }, [router]);
 
-  const listHeader = useMemo(
-    () => (
-      <View style={styles.listHeader}>
-        <DailyVerse />
-
-        <View style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>18 Chapters</Text>
-          <Text style={styles.sectionSub}>700 verses · the whole Gita</Text>
-        </View>
-        <GoldenDivider withGlyph style={styles.sectionDivider} />
-      </View>
-    ),
+  const sections = useMemo(
+    () =>
+      [
+        { title: 'Sacred Scriptures', tools: SCRIPTURE_TOOLS },
+        { title: 'Healing Tools', tools: HEALING_TOOLS },
+        { title: 'Wisdom Tools', tools: WISDOM_TOOLS },
+        { title: 'Sacred Community', tools: COMMUNITY_TOOLS },
+      ] as const,
     [],
   );
 
-  const renderChapter = useCallback<ListRenderItem<GitaChapter>>(
-    ({ item, index }) => (
-      <ChapterRow chapter={item} index={index} onPress={openChapter} />
-    ),
-    [openChapter],
-  );
-
-  const listEmpty = (
-    <View style={styles.emptyState}>
-      {isLoading ? (
-        <OmLoader size={64} label="Opening the sacred text…" />
-      ) : error ? (
-        <>
-          <Text style={styles.errorTitle}>Chapters are temporarily unavailable</Text>
-          <Text style={styles.emptyHint}>
-            Pull down to try again — your bookmarks remain safe offline.
-          </Text>
-          <Pressable onPress={() => void refetch()} style={styles.retryButton}>
-            <Text style={styles.retryText}>Retry</Text>
-          </Pressable>
-        </>
-      ) : null}
-    </View>
-  );
+  // Sacred Sound (Vibe Player) is the final section and gets the last
+  // entrance slot so the delay chain is 0 / 100 / 200 / 300 / 400 ms.
+  const vibePlayerDelay = SECTION_STAGGER_MS * sections.length;
 
   return (
-    <DivineScreenWrapper>
-      {/* Header (not inside the scroll so the search action stays reachable) */}
-      <View style={styles.header}>
-        <View style={styles.headerTitles}>
-          <Text
-            style={styles.headerSanskrit}
-            allowFontScaling
-            accessibilityLanguage="sa"
-          >
-            भगवद गीता
-          </Text>
-          <Text style={styles.headerEnglish}>Bhagavad Gita</Text>
-        </View>
-        <Pressable
-          onPress={() => setSearchOpen(true)}
-          accessibilityRole="button"
-          accessibilityLabel="Search verses"
-          hitSlop={10}
-          style={styles.searchIconButton}
-        >
-          <Search size={22} color={GOLD} />
-        </Pressable>
-      </View>
-
-      <FlatList<GitaChapter>
-        data={chapters ?? []}
-        renderItem={renderChapter}
-        keyExtractor={(c) => String(c.id)}
-        contentContainerStyle={[
-          styles.listContent,
-          { paddingBottom: insets.bottom + 96 },
-        ]}
-        ListHeaderComponent={listHeader}
-        ListEmptyComponent={listEmpty}
-        ItemSeparatorComponent={ChapterSeparator}
+    <Screen scroll={false} gradient edges={['top', 'left', 'right']}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
-      />
+      >
+        <View style={styles.header}>
+          <Text style={styles.title} accessibilityRole="header">
+            Shlokas
+          </Text>
+          <Text style={styles.subtitle}>
+            Sacred scriptures & instruments for transformation
+          </Text>
+        </View>
 
-      <SearchOverlay
-        visible={searchOpen}
-        onClose={() => setSearchOpen(false)}
-        onSelectVerse={openVerse}
-      />
-    </DivineScreenWrapper>
+        {sections.map((section, sectionIndex) => (
+          <ToolSection
+            key={section.title}
+            title={section.title}
+            tools={section.tools}
+            sectionDelay={sectionIndex * SECTION_STAGGER_MS}
+            onToolPress={handleToolPress}
+          />
+        ))}
+
+        {/* SACRED SOUND — full-width KIAAN Vibe card. */}
+        <AnimatedEntrance delay={vibePlayerDelay}>
+          <SectionHeader title="Sacred Sound" />
+        </AnimatedEntrance>
+        <AnimatedEntrance delay={vibePlayerDelay + CARD_STAGGER_MS}>
+          <View style={styles.vibeWrap}>
+            <VibePlayerCard
+              trackName={currentTrack?.title ?? null}
+              isPlaying={isPlaying}
+              onOpenPlayer={handleOpenVibePlayer}
+              onTogglePlay={togglePlay}
+            />
+          </View>
+        </AnimatedEntrance>
+      </ScrollView>
+    </Screen>
   );
 }
 
-function ChapterSeparator(): React.JSX.Element {
-  return <View style={styles.chapterSeparator} />;
+interface ToolSectionProps {
+  readonly title: string;
+  readonly tools: readonly ToolDescriptor[];
+  readonly sectionDelay: number;
+  readonly onToolPress: (route: string) => void;
 }
 
-// ---------------------------------------------------------------------------
-// Styles
-// ---------------------------------------------------------------------------
+function ToolSection({
+  title,
+  tools,
+  sectionDelay,
+  onToolPress,
+}: ToolSectionProps): React.JSX.Element {
+  return (
+    <View style={styles.section}>
+      <AnimatedEntrance delay={sectionDelay}>
+        <SectionHeader title={title} />
+      </AnimatedEntrance>
+      <View style={styles.cardStack}>
+        {tools.map((tool, cardIndex) => (
+          <AnimatedEntrance
+            key={tool.id}
+            delay={sectionDelay + (cardIndex + 1) * CARD_STAGGER_MS}
+          >
+            <ToolCard
+              name={tool.name}
+              sanskrit={tool.sanskrit}
+              description={tool.description}
+              color={tool.color}
+              icon={tool.icon}
+              onPress={() => onToolPress(tool.route)}
+            />
+          </AnimatedEntrance>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function AnimatedEntrance({
+  delay,
+  children,
+}: {
+  readonly delay: number;
+  readonly children: React.ReactNode;
+}): React.JSX.Element {
+  const { animatedStyle } = useDivineEntrance({ delay });
+  return <Animated.View style={animatedStyle}>{children}</Animated.View>;
+}
 
 const styles = StyleSheet.create({
-  // Header --------------------------------------------------------------------
-  header: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 16,
-  },
-  headerTitles: {
-    flex: 1,
-    gap: 2,
-  },
-  headerSanskrit: {
-    fontFamily: 'NotoSansDevanagari-Bold',
-    fontSize: 22,
-    lineHeight: 30,
-    color: GOLD,
-    letterSpacing: 0.3,
-  },
-  headerEnglish: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 13,
-    lineHeight: 18,
-    color: TEXT_MUTED,
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-  },
-  searchIconButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: ICON_BG,
-    borderWidth: 1,
-    borderColor: GOLD_SOFT,
-  },
-
-  // List --------------------------------------------------------------------
-  listContent: {
-    paddingHorizontal: 16,
-    paddingTop: 4,
-  },
-  listHeader: {
-    gap: 18,
-  },
-
-  // Daily verse --------------------------------------------------------------
-  dailyWrap: {
-    gap: 8,
-    marginBottom: 10,
-  },
-  dailyLabel: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 11,
-    color: GOLD,
-    letterSpacing: 2,
-    textTransform: 'uppercase',
-  },
-  dailyCard: {
-    borderColor: GOLD_GLOW,
-    borderWidth: 1,
-    shadowColor: GOLD,
-    shadowOpacity: 0.2,
-    shadowRadius: 18,
-    shadowOffset: { width: 0, height: 0 },
-    elevation: 8,
-  },
-  dailyLoading: {
-    paddingVertical: 24,
-    alignItems: 'center',
-  },
-
-  // Section header ----------------------------------------------------------
-  sectionHeader: {
-    marginTop: 6,
-    gap: 2,
-  },
-  sectionTitle: {
-    fontFamily: 'CormorantGaramond-SemiBold',
-    fontSize: 20,
-    lineHeight: 26,
-    color: TEXT_PRIMARY,
-    letterSpacing: 0.4,
-  },
-  sectionSub: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 12,
-    color: TEXT_MUTED,
-    letterSpacing: 0.6,
-  },
-  sectionDivider: {
-    marginTop: 6,
-    marginBottom: 2,
-  },
-
-  // Chapter row --------------------------------------------------------------
-  chapterBody: {
-    paddingVertical: 14,
-    paddingHorizontal: 14,
-  },
-  chapterRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-  },
-  chapterCircle: {
-    width: 42,
-    height: 42,
-    borderRadius: 21,
-    borderWidth: 1,
-    borderColor: GOLD_SOFT,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'rgba(212, 160, 23, 0.08)',
-  },
-  chapterNumber: {
-    fontFamily: 'CormorantGaramond-SemiBold',
-    fontSize: 18,
-    color: GOLD,
-    lineHeight: 22,
-  },
-  chapterInfo: {
-    flex: 1,
-    gap: 2,
-  },
-  chapterSanskrit: {
-    fontFamily: 'NotoSansDevanagari-Medium',
-    fontSize: 15,
-    lineHeight: 22,
-    color: GOLD,
-  },
-  chapterEnglish: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 13,
-    lineHeight: 18,
-    color: TEXT_MUTED,
-    letterSpacing: 0.3,
-  },
-  chapterTrailing: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  versesBadge: {
-    minWidth: 30,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 10,
-    backgroundColor: ICON_BG,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: GOLD_SOFT,
-    alignItems: 'center',
-  },
-  versesBadgeText: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 11,
-    color: GOLD,
-    letterSpacing: 0.4,
-  },
-  chapterSeparator: {
-    height: 10,
-  },
-
-  // Empty / error / retry ----------------------------------------------------
-  emptyState: {
-    paddingVertical: 48,
-    alignItems: 'center',
-    gap: 12,
-    paddingHorizontal: 24,
-  },
-  emptyTitle: {
-    fontFamily: 'CormorantGaramond-SemiBold',
-    fontSize: 18,
-    color: TEXT_PRIMARY,
-    textAlign: 'center',
-  },
-  emptyHint: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 13,
-    color: TEXT_SECONDARY,
-    textAlign: 'center',
-    lineHeight: 20,
-    maxWidth: 320,
-  },
-  errorTitle: {
-    fontFamily: 'CormorantGaramond-SemiBold',
-    fontSize: 18,
-    color: '#E57373',
-    textAlign: 'center',
-  },
-  retryButton: {
-    marginTop: 8,
-    paddingHorizontal: 18,
-    paddingVertical: 10,
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: GOLD_SOFT,
-    backgroundColor: ICON_BG,
-  },
-  retryText: {
-    fontFamily: 'Outfit-Regular',
-    fontSize: 13,
-    color: GOLD,
-    letterSpacing: 0.6,
-  },
-
-  // Search overlay ----------------------------------------------------------
-  overlayRoot: {
-    flex: 1,
-    backgroundColor: SURFACE_OVERLAY,
-  },
-  overlayHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    paddingHorizontal: 16,
-    paddingBottom: 12,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: GOLD_SOFT,
-  },
-  overlayInputWrap: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingHorizontal: 14,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: 'rgba(22, 26, 66, 0.85)',
-    borderWidth: 1,
-    borderColor: GOLD_SOFT,
-  },
-  overlayInput: {
-    flex: 1,
-    color: TEXT_PRIMARY,
-    fontFamily: 'Outfit-Regular',
-    fontSize: 14,
-    padding: 0,
-  },
-  overlayClose: {
-    width: 40,
-    height: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 20,
-  },
-  overlayBody: {
-    flex: 1,
-  },
-  resultsContent: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
+  scrollContent: {
+    paddingTop: 12,
     paddingBottom: 48,
+    paddingHorizontal: 0,
   },
-  resultItem: {
-    // ShlokaCard handles its own radius + border.
+  header: {
+    paddingHorizontal: 20,
+    marginBottom: 12,
+    gap: 6,
   },
-  resultSeparator: {
-    height: 12,
+  title: {
+    fontFamily: 'CormorantGaramond-LightItalic',
+    fontSize: 28,
+    color: SACRED_WHITE,
+    letterSpacing: 0.4,
+  },
+  subtitle: {
+    fontFamily: 'CrimsonText-Italic',
+    fontSize: 14,
+    color: TEXT_MUTED,
+  },
+  section: {
+    marginBottom: 12,
+  },
+  cardStack: {
+    paddingHorizontal: 16,
+    gap: 10,
+  },
+  vibeWrap: {
+    paddingHorizontal: 16,
+    marginBottom: 24,
   },
 });

--- a/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
@@ -2,15 +2,15 @@
  * DivineTabBar — Kiaanverse bottom tab bar (5 sacred doorways).
  *
  * Tab order:
- *   Home · Sakha · Journeys · Journal · Profile
+ *   Home · Sakha · Shlokas · Journal · Profile
  *
- * Shlokas used to occupy slot 3; it now lives inside the Vibe Player (via
- * the Daily Verse banner) and is still reachable through the legacy
- * `/(tabs)/shlokas/*` routes. Journeys was promoted from a sub-tab of
- * Journal to its own top-level slot so the षड्रिपु flow is one tap away.
- * The icon list is recycled from the existing set — ChakraColumn (was
- * Journal) now signals the journey progression, and Manuscript (was
- * Shlokas) signals the written journal.
+ * Slot 3 is now the Shlokas Sacred Hub (scriptures + every sacred tool
+ * + Wisdom Rooms + Sacred Reflections + KIAAN Vibe Player). Its glyph is
+ * the ManuscriptIcon — the scroll carries the "sacred utterance" meaning
+ * that anchors the hub. The Journal tab takes the ChakraColumnIcon (the
+ * seven stacked chakras read as an inward ascent through one's own
+ * reflections). Journeys is still a full route; it's reached from Home's
+ * "Browse Sacred Catalog" CTA rather than occupying tab-bar real estate.
  *
  * Visual specification:
  * - Dark navy background: rgba(5,7,20,0.97).
@@ -82,13 +82,13 @@ interface SacredTab {
 const TABS: ReadonlyArray<SacredTab> = [
   { name: 'index', label: 'Home', Icon: GopuramIcon },
   { name: 'chat', label: 'Sakha', Icon: LotusDialogIcon },
-  // ChakraColumn's seven stacked chakras read as progression / ascent —
-  // the visual cue for the षड्रिपु journey sequence.
-  { name: 'journeys', label: 'Journeys', Icon: ChakraColumnIcon },
-  // ManuscriptIcon carries the written / reflection meaning. It was
-  // originally used for Shlokas; now that Shlokas has moved inside the
-  // Vibe Player, the manuscript glyph fits the diary better.
-  { name: 'journal', label: 'Journal', Icon: ManuscriptIcon },
+  // Manuscript glyph = scroll of shlokas; the Shlokas Hub opens to every
+  // sacred scripture and instrument so the written-word metaphor fits.
+  { name: 'shlokas', label: 'Shlokas', Icon: ManuscriptIcon },
+  // ChakraColumn's seven stacked chakras read as an inward ascent — a
+  // fitting cue for the reflection-and-journal practice of Sacred
+  // Reflections (the Journal tab's content).
+  { name: 'journal', label: 'Journal', Icon: ChakraColumnIcon },
   { name: 'profile', label: 'Profile', Icon: MeditatorIcon },
 ] as const;
 


### PR DESCRIPTION
## Summary

Two related changes bundled because shipping the Sacred Hub safely depends on the OTA pipeline being in place first.

### 1. Fix the stale-build pipeline

Merging PRs to `main` was doing **nothing** for the installed Expo app. The only mobile workflow (`mobile-production-release.yml`) is tag-triggered (`v*.*.*`), and no `eas update` step existed anywhere. The JS bundle baked into the APK on users' phones never got replaced — that's the "I merged 4 PRs and the app still shows the old build" symptom.

- **`.github/workflows/mobile-ota-update.yml`** — new workflow. On every push to `main` that touches `kiaanverse-mobile/**`, runs `eas update --branch production`. JS-only PRs reach installed APKs on next cold start via `expo-updates` (`runtimeVersion: appVersion`). Skip with `[skip ota]` in the commit message. Native changes still require a `v*.*.*` tag for a full rebuild.
- **`public/sw.js`** — bump `CACHE_VERSION` from `v19.0` → `v20.0` so PWA users drop the stale `CACHE_DYNAMIC` entries that survived the last 4 merges (the activate handler only evicts caches outside the current set).

### 2. Promote Shlokas tab into a Sacred Hub

Slot 3 of the bottom bar becomes the single doorway to every sacred instrument — matching the provided design reference. One tap from **Shlokas** reaches:

| Section | Tools |
|---|---|
| Sacred Scriptures | Bhagavad Gita (18 chapters + daily verse) |
| Healing Tools | Emotional Reset, Karma Reset |
| Wisdom Tools | Ardha, Viyoga, Relationship Compass |
| Sacred Community | Wisdom Room, Sacred Reflections |
| Sacred Sound | KIAAN Vibe Player (full-width elevated card) |

- **`(tabs)/shlokas/index.tsx`** — new Sacred Hub screen composed from existing `ToolCard` / `SectionHeader` / `VibePlayerCard` primitives with identical lotus-bloom entrance choreography to `/tools`.
- **`(tabs)/shlokas/gita.tsx`** — the former `index.tsx` (Bhagavad Gita browser) renamed so the tab root can host the hub. Existing deep-link routes `/shlokas/[chapter]/[verse]` stay intact — Daily-Verse banners and push-notifications still resolve without edits.
- **`(tabs)/shlokas/_layout.tsx`** — registers the new `gita` stack screen alongside `index` and `[chapter]/[verse]`.
- **`(tabs)/_layout.tsx`** — un-hides `shlokas` (slot 3), hides `journeys` (still routable; reached from Home's "Browse Sacred Catalog" CTA). Bar stays at five doorways.
- **`components/navigation/DivineTabBar.tsx`** — TABS array now maps slot 3 → shlokas/ManuscriptIcon (scroll of shlokas) and slot 4 → journal/ChakraColumnIcon (inward ascent), matching the screenshot.

Zero native config changes — ships as a pure OTA once merged, picked up by the new workflow.

### 3. Workflow compatibility fix (second commit)

Newer `eas-cli` versions reject `--channel` and `--branch` together. The workflow now publishes to the branch only and relies on the one-time `eas channel:edit production --branch production` mapping.

## Test plan

- [ ] CI passes on the PR (typecheck, lint, existing mobile-pr-check)
- [ ] After merge, `Mobile OTA Update` workflow runs green and prints "Update published" with branch `production`
- [ ] On device: swipe app out of recents → reopen (silent download) → close fully → reopen → Shlokas tab now shows the hub with all 9 tiles
- [ ] Tapping each hub tile navigates to the correct screen (verified routes: `/tools/*`, `/shlokas/gita`, `/wisdom-rooms`, `/journal`, `/vibe-player`)
- [ ] Deep-link `/shlokas/12/14` (Daily Verse) still resolves to the chapter/verse detail screens (untouched)
- [ ] Journeys still reachable from Home's "Browse Sacred Catalog" CTA (now `href: null` in tab bar)
- [ ] Web PWA: `CACHE_VERSION` bump evicts old `CACHE_DYNAMIC` on SW activate (check DevTools → Application → Cache Storage shows only `mindvibe-v20.0-*` entries)

## Follow-ups (non-blocking)

- One-time `eas channel:edit production --branch production` if the channel mapping isn't already set (workflow will log a helpful error if it isn't).
- Confirm `EXPO_TOKEN` repo secret exists (workflow fails early with a clear message if missing).
- Potential rename: "Shlokas" traditionally means Gita verses; users may expect verses, not a hub. The Gita browser is one tap inside under "Sacred Scriptures → Bhagavad Gita", but if the team prefers a clearer label (e.g. "Sacred" / "Mandir" / "Altar"), it's a one-line change.


---
_Generated by [Claude Code](https://claude.ai/code/session_011wPuHZFtmKKn51SwyQpSv2)_