### PR TITLE
fix(android): Sakha Chat streaming, layout, and mobile refresh-token flow

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -523,8 +523,22 @@ async def _login_impl(
     except Exception:
         pass
 
-    # Return refresh token in body for mobile clients (cookie is also set above)
-    refresh_body = raw_refresh if settings.REFRESH_TOKEN_ENABLE_BODY_RETURN else None
+    # Return refresh token in body for clients that cannot read httpOnly
+    # cookies. Mobile apps (React Native) cannot access Set-Cookie headers
+    # by design — we identify them via the X-Client header the Kiaanverse
+    # mobile app sets on every request. Browsers keep using the httpOnly
+    # cookie path and never see the body copy.
+    x_client = (request.headers.get("x-client") or "").lower()
+    is_cookieless_client = x_client.startswith("kiaanverse-mobile") or x_client in {
+        "mobile",
+        "android",
+        "ios",
+    }
+    refresh_body = (
+        raw_refresh
+        if settings.REFRESH_TOKEN_ENABLE_BODY_RETURN or is_cookieless_client
+        else None
+    )
 
     logger.info("Login successful: user_id=%s session_id=%s", user_id, session.id)
 
@@ -785,12 +799,27 @@ async def refresh_tokens(
         max_age=expires_in_seconds,
     )
 
+    # Mirror the /login behaviour: mobile clients (identified by the
+    # X-Client header) cannot read httpOnly cookies, so they need the
+    # rotated refresh_token in the response body to keep the SecureStore
+    # copy in sync and survive the next access-token expiry.
+    x_client_refresh = (request.headers.get("x-client") or "").lower()
+    is_cookieless_refresh = (
+        x_client_refresh.startswith("kiaanverse-mobile")
+        or x_client_refresh in {"mobile", "android", "ios"}
+    )
+    return_body_refresh = (
+        new_raw
+        if settings.REFRESH_TOKEN_ENABLE_BODY_RETURN or is_cookieless_refresh
+        else None
+    )
+
     return RefreshOut(
         access_token=access_token,
         token_type="bearer",  # nosec B106
         expires_in=expires_in_seconds,
         session_id=str(session_row.id),
-        refresh_token=new_raw if settings.REFRESH_TOKEN_ENABLE_BODY_RETURN else None,
+        refresh_token=return_body_refresh,
     )
 
 

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
@@ -42,7 +42,6 @@ import {
   View,
   type ListRenderItemInfo,
 } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Haptics from 'expo-haptics';
 
@@ -66,6 +65,17 @@ const CONVERSATION_CACHE_KEY = 'sakha_chat_conversation_v1';
 /** Max number of messages we keep in the persisted snapshot. */
 const MAX_CACHED_MESSAGES = 60;
 
+/**
+ * Height of the custom DivineTabBar's content (safe-area bottom is added on
+ * top inside the tab bar itself). The tab bar is `position: absolute, bottom:
+ * 0` so it overlays tab screens; we reserve this space on the chat root so
+ * the ChatInput and the InsightFab both sit above it instead of being
+ * covered by the Home / Sakha / Shlokas row.
+ *
+ * Must stay in sync with `TAB_BAR_HEIGHT` in components/navigation/DivineTabBar.tsx.
+ */
+const TAB_BAR_CONTENT_HEIGHT = 64;
+
 interface CachedConversation {
   readonly sessionId: string | null;
   readonly messages: SakhaStreamMessage[];
@@ -77,7 +87,6 @@ const OFFLINE_BANNER_TEXT =
   'You appear to be offline. I will listen as soon as the connection returns.';
 
 export default function ChatScreen(): React.JSX.Element {
-  const insets = useSafeAreaInsets();
   const listRef = useRef<FlatList<SakhaStreamMessage>>(null);
   const headerRef = useRef<ChatHeaderHandle | null>(null);
   const { isOnline } = useNetworkStatus();
@@ -293,7 +302,7 @@ export default function ChatScreen(): React.JSX.Element {
           {/* Offline banner — subtle, does not block the UI. */}
           {!isOnline && (
             <View
-              style={[styles.offlineBanner, { bottom: insets.bottom + 72 }]}
+              style={[styles.offlineBanner, { bottom: 12 }]}
               accessibilityLiveRegion="polite"
               accessibilityLabel={OFFLINE_BANNER_TEXT}
             >
@@ -304,18 +313,21 @@ export default function ChatScreen(): React.JSX.Element {
           {/* Error toast — shown after a failed stream. */}
           {error && isOnline && !streaming && (
             <View
-              style={[styles.offlineBanner, { bottom: insets.bottom + 72 }]}
+              style={[styles.offlineBanner, { bottom: 12 }]}
               accessibilityLiveRegion="polite"
             >
               <Text style={styles.offlineText}>{error}</Text>
             </View>
           )}
 
-          {/* Floating insight FAB — seeds a Gita-rooted reflection prompt. */}
+          {/* Floating insight FAB — seeds a Gita-rooted reflection prompt.
+              Positioned relative to the body's bottom edge, which — thanks
+              to the flex layout and the root's reserved tab-bar space —
+              already sits just above the ChatInput composer. */}
           <InsightFab
             onPress={handleInsightPress}
             hidden={streaming}
-            bottomOffset={insets.bottom + 80}
+            bottomOffset={12}
           />
         </View>
 
@@ -339,6 +351,10 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: BG,
+    // Reserve room for the DivineTabBar that's `position: absolute, bottom:
+    // 0`. Without this the ChatInput renders behind the tab bar and users
+    // have nowhere to type.
+    paddingBottom: TAB_BAR_CONTENT_HEIGHT,
   },
   keyboardAvoider: {
     flex: 1,

--- a/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
+++ b/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
@@ -126,6 +126,8 @@ const AUTH_ERROR_TEXT =
   'Your session has expired. Please sign in again to continue our dialogue.';
 const COLD_START_TEXT =
   'I am waking from deep meditation (server cold start). Please ask again in a moment.';
+const NO_CREDENTIALS_TEXT =
+  'To speak with Sakha, please sign in with your email. (Developer Login skips the server session and cannot start a dialogue.)';
 
 export function useSakhaStream(
   options: UseSakhaStreamOptions = {},
@@ -242,15 +244,17 @@ export function useSakhaStream(
       };
 
       const finishStreamingFailure = (
-        reason: 'network' | 'auth' | 'server' | 'cold_start',
+        reason: 'network' | 'auth' | 'server' | 'cold_start' | 'no_credentials',
         activeXhr: XMLHttpRequest,
       ): void => {
         const errorText =
-          reason === 'auth'
-            ? AUTH_ERROR_TEXT
-            : reason === 'cold_start'
-              ? COLD_START_TEXT
-              : CONNECTION_ERROR_TEXT;
+          reason === 'no_credentials'
+            ? NO_CREDENTIALS_TEXT
+            : reason === 'auth'
+              ? AUTH_ERROR_TEXT
+              : reason === 'cold_start'
+                ? COLD_START_TEXT
+                : CONNECTION_ERROR_TEXT;
         const id = assistantIdRef.current;
         if (id) {
           setMessages((prev) =>
@@ -302,14 +306,24 @@ export function useSakhaStream(
             // the "Your session has expired" copy. This mirrors the
             // apiClient's axios interceptor so SSE has the same resilience
             // as regular authenticated POSTs.
+            //
+            // Special case: if we attempted the request without any token to
+            // begin with, a refresh will also fail (there's nothing to
+            // refresh from). In that case we show the clearer "please sign
+            // in with your email" copy — this is the devLogin path, where
+            // the app has `status: authenticated` locally but no backend
+            // session exists.
             if ((status === 401 || status === 403) && !hasRetriedAfterRefresh) {
               hasRetriedAfterRefresh = true;
+              const hadInitialToken = authToken !== null && authToken.length > 0;
               void (async () => {
                 const refreshed = await refreshAccessToken();
                 if (refreshed) {
                   openAndSend(refreshed);
-                } else {
+                } else if (hadInitialToken) {
                   finishStreamingFailure('auth', x);
+                } else {
+                  finishStreamingFailure('no_credentials', x);
                 }
               })();
               return;

--- a/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
+++ b/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
@@ -21,17 +21,37 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as SecureStore from 'expo-secure-store';
-import { API_CONFIG } from '@kiaanverse/api';
+import {
+  API_CONFIG,
+  getCurrentAccessToken,
+  refreshAccessToken,
+} from '@kiaanverse/api';
 
 /**
  * SecureStore key under which the authStore persists the access JWT.
  * Duplicated here (rather than imported) because the chat components belong
  * to the mobile app, which should not depend on the store package for a
  * single constant. If the key ever changes in authStore.ts, update here too.
+ *
+ * Used as a last-resort fallback when the apiClient's TokenManager has not
+ * yet been wired (e.g. during very early app startup). Normal reads go
+ * through `getCurrentAccessToken` so the stream shares the exact same
+ * token source — and refresh cadence — as regular authenticated requests.
  */
 const ACCESS_TOKEN_STORAGE_KEY = 'kiaanverse_access_token';
 
-async function readAccessTokenFromSecureStore(): Promise<string | null> {
+/** Best-effort token read. Order:
+ *  1. apiClient's TokenManager (authoritative; kept fresh by the 401 interceptor).
+ *  2. Direct SecureStore read (fallback for the tiny window before the
+ *     TokenManager is registered on app startup).
+ */
+async function readAuthToken(): Promise<string | null> {
+  try {
+    const fromClient = await getCurrentAccessToken();
+    if (fromClient) return fromClient;
+  } catch {
+    /* fall through */
+  }
   try {
     return await SecureStore.getItemAsync(ACCESS_TOKEN_STORAGE_KEY);
   } catch {
@@ -179,18 +199,17 @@ export function useSakhaStream(
       setStreaming(true);
 
       // 3. Resolve bearer token. Prefer the caller-supplied getter (tests,
-      // custom flows) and otherwise fall back to the access token the
-      // authStore persisted to SecureStore. Without this fallback the SSE
-      // request went out unauthenticated — the backend rejected it with 401
-      // and the UI showed the "connection wavered" error even though the
-      // network and backend were both healthy.
+      // custom flows); otherwise go through the apiClient's TokenManager so
+      // we share the same token source — and refresh cadence — as regular
+      // authenticated requests. A last-resort SecureStore read covers the
+      // narrow window before the TokenManager has been registered on boot.
       let token: string | null = null;
       try {
         if (getAccessToken) {
           const resolved = await getAccessToken();
           token = resolved ?? null;
         } else {
-          token = await readAccessTokenFromSecureStore();
+          token = await readAuthToken();
         }
       } catch {
         token = null;
@@ -205,19 +224,11 @@ export function useSakhaStream(
         );
       }
 
-      // 4. Open the streaming XHR.
-      const url = `${baseUrl ?? API_CONFIG.baseURL}/api/chat/message/stream`;
-      const xhr = new XMLHttpRequest();
-      xhrRef.current = xhr;
-
+      // 4. Open the streaming XHR. Wrapped in a local function so we can
+      // retry once with a refreshed token if the server returns 401/403.
+      let hasRetriedAfterRefresh = false;
       let cursor = 0;
       let fullText = '';
-
-      xhr.open('POST', url, true);
-      xhr.setRequestHeader('Content-Type', 'application/json');
-      xhr.setRequestHeader('Accept', 'text/event-stream');
-      xhr.setRequestHeader('X-Client', 'kiaanverse-mobile');
-      if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
 
       const finishStreamingSuccess = (): void => {
         setMessages((prev) =>
@@ -230,7 +241,10 @@ export function useSakhaStream(
         streamCompleteCallbackRef.current?.();
       };
 
-      const finishStreamingFailure = (reason: 'network' | 'auth' | 'server' | 'cold_start'): void => {
+      const finishStreamingFailure = (
+        reason: 'network' | 'auth' | 'server' | 'cold_start',
+        activeXhr: XMLHttpRequest,
+      ): void => {
         const errorText =
           reason === 'auth'
             ? AUTH_ERROR_TEXT
@@ -254,7 +268,7 @@ export function useSakhaStream(
         if (typeof __DEV__ !== 'undefined' && __DEV__) {
           // eslint-disable-next-line no-console
           console.error(
-            `[SakhaStream] failed (${reason}) status=${xhr.status} response=${xhr.responseText?.slice(0, 200) ?? ''}`,
+            `[SakhaStream] failed (${reason}) status=${activeXhr.status} response=${activeXhr.responseText?.slice(0, 200) ?? ''}`,
           );
         }
         setError(errorText);
@@ -262,88 +276,131 @@ export function useSakhaStream(
         xhrRef.current = null;
       };
 
-      xhr.onreadystatechange = () => {
-        // 3 = LOADING (incremental responseText is available).
-        if (xhr.readyState !== 3 && xhr.readyState !== 4) return;
-        if (xhr.readyState === 4 && xhr.status >= 400) {
-          // Translate the HTTP status into the most useful recovery hint:
-          //   401 → sign in again; 502/503/504 → cold-start retry; else → generic.
-          const status = xhr.status;
-          if (status === 401 || status === 403) {
-            finishStreamingFailure('auth');
-          } else if (status === 502 || status === 503 || status === 504) {
-            finishStreamingFailure('cold_start');
-          } else {
-            finishStreamingFailure('server');
+      const openAndSend = (authToken: string | null): void => {
+        const url = `${baseUrl ?? API_CONFIG.baseURL}/api/chat/message/stream`;
+        const x = new XMLHttpRequest();
+        xhrRef.current = x;
+        // Reset the SSE parse state every time we (re)open so the retry
+        // path never double-emits tokens that the failed attempt already
+        // surfaced to the UI.
+        cursor = 0;
+        fullText = '';
+
+        x.open('POST', url, true);
+        x.setRequestHeader('Content-Type', 'application/json');
+        x.setRequestHeader('Accept', 'text/event-stream');
+        x.setRequestHeader('X-Client', 'kiaanverse-mobile');
+        if (authToken) x.setRequestHeader('Authorization', `Bearer ${authToken}`);
+
+        x.onreadystatechange = () => {
+          // 3 = LOADING (incremental responseText is available).
+          if (x.readyState !== 3 && x.readyState !== 4) return;
+          if (x.readyState === 4 && x.status >= 400) {
+            const status = x.status;
+
+            // On 401/403, try exactly one silent refresh before surfacing
+            // the "Your session has expired" copy. This mirrors the
+            // apiClient's axios interceptor so SSE has the same resilience
+            // as regular authenticated POSTs.
+            if ((status === 401 || status === 403) && !hasRetriedAfterRefresh) {
+              hasRetriedAfterRefresh = true;
+              void (async () => {
+                const refreshed = await refreshAccessToken();
+                if (refreshed) {
+                  openAndSend(refreshed);
+                } else {
+                  finishStreamingFailure('auth', x);
+                }
+              })();
+              return;
+            }
+
+            if (status === 401 || status === 403) {
+              finishStreamingFailure('auth', x);
+            } else if (status === 502 || status === 503 || status === 504) {
+              finishStreamingFailure('cold_start', x);
+            } else {
+              finishStreamingFailure('server', x);
+            }
+            return;
           }
-          return;
-        }
 
-        const raw = xhr.responseText;
-        const { frames, nextCursor } = parseSSEFrames(raw, cursor);
-        cursor = nextCursor;
+          const raw = x.responseText;
+          const { frames, nextCursor } = parseSSEFrames(raw, cursor);
+          cursor = nextCursor;
 
-        let sawDone = false;
+          let sawDone = false;
 
-        for (const frame of frames) {
-          try {
-            const event = JSON.parse(frame) as {
-              word?: string;
-              done?: boolean;
-              session_id?: string;
-              sessionId?: string;
-              verseRefs?: unknown;
-            };
-            if (event.session_id && !sessionId) setSessionId(event.session_id);
-            if (event.sessionId && !sessionId) setSessionId(event.sessionId);
-            if (event.done) {
-              sawDone = true;
-              break;
+          for (const frame of frames) {
+            try {
+              const event = JSON.parse(frame) as {
+                word?: string;
+                done?: boolean;
+                session_id?: string;
+                sessionId?: string;
+                verseRefs?: unknown;
+                error?: string;
+                message?: string;
+              };
+              if (event.session_id && !sessionId) setSessionId(event.session_id);
+              if (event.sessionId && !sessionId) setSessionId(event.sessionId);
+              // Quota / service-unavailable frames the backend emits
+              // occasionally carry an `error` field and a human message.
+              if (event.error && typeof event.message === 'string') {
+                appendAssistantText(event.message);
+                fullText += event.message;
+              }
+              if (event.done) {
+                sawDone = true;
+                break;
+              }
+              if (event.word) {
+                fullText += event.word;
+                appendAssistantText(event.word);
+              }
+            } catch {
+              // Legacy plain-text format.
+              if (frame === '[DONE]') {
+                sawDone = true;
+                break;
+              }
+              const space =
+                fullText.length > 0 && !frame.startsWith(' ') ? ' ' : '';
+              fullText += space + frame;
+              appendAssistantText(space + frame);
             }
-            if (event.word) {
-              fullText += event.word;
-              appendAssistantText(event.word);
-            }
-          } catch {
-            // Legacy plain-text format.
-            if (frame === '[DONE]') {
-              sawDone = true;
-              break;
-            }
-            const space =
-              fullText.length > 0 && !frame.startsWith(' ') ? ' ' : '';
-            fullText += space + frame;
-            appendAssistantText(space + frame);
           }
-        }
 
-        if (sawDone || xhr.readyState === 4) {
-          finishStreamingSuccess();
+          if (sawDone || x.readyState === 4) {
+            finishStreamingSuccess();
+          }
+        };
+
+        x.onerror = () => finishStreamingFailure('network', x);
+        x.ontimeout = () => finishStreamingFailure('cold_start', x);
+        x.onabort = () => {
+          // Aborts set isStreaming false silently — no error toast.
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantId ? { ...m, isStreaming: false } : m,
+            ),
+          );
+          setStreaming(false);
+        };
+
+        try {
+          x.send(
+            JSON.stringify({
+              message: trimmed,
+              session_id: sessionId ?? undefined,
+            }),
+          );
+        } catch {
+          finishStreamingFailure('network', x);
         }
       };
 
-      xhr.onerror = () => finishStreamingFailure('network');
-      xhr.ontimeout = () => finishStreamingFailure('cold_start');
-      xhr.onabort = () => {
-        // Aborts set isStreaming false silently — no error toast.
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId ? { ...m, isStreaming: false } : m,
-          ),
-        );
-        setStreaming(false);
-      };
-
-      try {
-        xhr.send(
-          JSON.stringify({
-            message: trimmed,
-            session_id: sessionId ?? undefined,
-          }),
-        );
-      } catch {
-        finishStreamingFailure('network');
-      }
+      openAndSend(token);
     },
     [appendAssistantText, baseUrl, getAccessToken, sessionId, streaming],
   );

--- a/kiaanverse-mobile/packages/api/src/auth/authService.ts
+++ b/kiaanverse-mobile/packages/api/src/auth/authService.ts
@@ -205,7 +205,13 @@ async function login(email: string, password: string): Promise<LoginResult> {
       { email, password },
     );
 
-    const refreshToken = extractRefreshTokenFromResponse(response);
+    // React Native's HTTP stack does not expose httpOnly Set-Cookie headers
+    // to JavaScript, so the cookie-based refresh token path never works on
+    // mobile. Prefer the body field (which the backend returns for clients
+    // that send `X-Client: kiaanverse-mobile`); fall back to Set-Cookie
+    // extraction for web / tests / future platforms that surface it.
+    const refreshToken =
+      response.data.refresh_token ?? extractRefreshTokenFromResponse(response);
 
     return {
       loginResponse: response.data,

--- a/kiaanverse-mobile/packages/api/src/client.ts
+++ b/kiaanverse-mobile/packages/api/src/client.ts
@@ -66,6 +66,55 @@ export function setTokenManager(manager: TokenManager): void {
   tokenManager = manager;
 }
 
+/**
+ * Read the current access token via the registered TokenManager.
+ *
+ * Exposed for transports that bypass the axios interceptor (e.g. SSE over
+ * XHR) and therefore cannot piggy-back on the apiClient's built-in
+ * Authorization header injection. Callers get the exact same token that a
+ * normal apiClient POST would attach, which guarantees the streaming
+ * endpoint sees the same identity as non-streaming chat.
+ *
+ * Returns null when the app is not authenticated, when the token manager
+ * has not been configured yet, or when SecureStore throws.
+ */
+export async function getCurrentAccessToken(): Promise<string | null> {
+  try {
+    const token = await tokenManager.getAccessToken();
+    return token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attempt to refresh the access token via the registered TokenManager.
+ * Returns the new access token on success, or null if no refresh token
+ * is available / the refresh call fails. Safe to call when already
+ * unauthenticated — it just returns null.
+ *
+ * Uses a raw axios.post (not `apiClient`) so it bypasses the response
+ * interceptor and can never loop on a refresh that itself returns 401.
+ */
+export async function refreshAccessToken(): Promise<string | null> {
+  try {
+    const refreshToken = await tokenManager.getRefreshToken();
+    if (!refreshToken) return null;
+    const response = await axios.post<RefreshResponse>(
+      `${API_CONFIG.baseURL}/api/auth/refresh`,
+      { refresh_token: refreshToken },
+      { withCredentials: true, timeout: API_CONFIG.timeout },
+    );
+    const newAccess = response.data?.access_token;
+    const newRefresh = response.data?.refresh_token ?? refreshToken;
+    if (!newAccess) return null;
+    await tokenManager.setTokens(newAccess, newRefresh);
+    return newAccess;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Cookie Extraction Helper
 // ---------------------------------------------------------------------------

--- a/kiaanverse-mobile/packages/api/src/client.ts
+++ b/kiaanverse-mobile/packages/api/src/client.ts
@@ -103,7 +103,17 @@ export async function refreshAccessToken(): Promise<string | null> {
     const response = await axios.post<RefreshResponse>(
       `${API_CONFIG.baseURL}/api/auth/refresh`,
       { refresh_token: refreshToken },
-      { withCredentials: true, timeout: API_CONFIG.timeout },
+      {
+        withCredentials: true,
+        timeout: API_CONFIG.timeout,
+        // Signal to the backend that we are a cookieless mobile client so
+        // it returns the rotated refresh_token in the body (we cannot read
+        // the httpOnly Set-Cookie from React Native).
+        headers: {
+          'X-Client': 'kiaanverse-mobile',
+          'Content-Type': 'application/json',
+        },
+      },
     );
     const newAccess = response.data?.access_token;
     const newRefresh = response.data?.refresh_token ?? refreshToken;
@@ -339,7 +349,16 @@ function createApiClient(): AxiosInstance {
           const refreshResponse = await axios.post<RefreshResponse>(
             `${API_CONFIG.baseURL}/api/auth/refresh`,
             storedRefreshToken ? { refresh_token: storedRefreshToken } : {},
-            { withCredentials: true },
+            {
+              withCredentials: true,
+              // Same X-Client signal as the standalone refreshAccessToken
+              // helper — tells the backend to return the rotated
+              // refresh_token in the body so SecureStore stays in sync.
+              headers: {
+                'X-Client': 'kiaanverse-mobile',
+                'Content-Type': 'application/json',
+              },
+            },
           );
 
           const newAccessToken = refreshResponse.data.access_token;

--- a/kiaanverse-mobile/packages/api/src/index.ts
+++ b/kiaanverse-mobile/packages/api/src/index.ts
@@ -3,7 +3,12 @@
  */
 
 // Client
-export { apiClient, setTokenManager } from './client';
+export {
+  apiClient,
+  setTokenManager,
+  getCurrentAccessToken,
+  refreshAccessToken,
+} from './client';
 export { api } from './endpoints';
 export { API_CONFIG } from './config';
 

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -106,6 +106,62 @@ class TestLogin:
         # Check that refresh token cookie was set
         assert "refresh_token" in response.cookies
 
+        # Browsers receive `refresh_token: None` in the body — the cookie
+        # is the source of truth for them.
+        assert data.get("refresh_token") is None
+
+    async def test_login_mobile_client_gets_refresh_token_in_body(
+        self, test_client: AsyncClient, test_user
+    ):
+        """Mobile clients (X-Client: kiaanverse-mobile) cannot read httpOnly
+        cookies from React Native, so the backend must return the rotated
+        refresh_token in the response body for them to store in SecureStore."""
+        response = await test_client.post(
+            "/api/auth/login",
+            json={"email": TEST_USER_EMAIL, "password": TEST_USER_PASSWORD},
+            headers={"X-Client": "kiaanverse-mobile"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("refresh_token"), (
+            "Mobile login must return refresh_token in the body; "
+            "without it, mobile cannot refresh expired access tokens."
+        )
+        # Cookie is still set (belt-and-suspenders) but the body copy is
+        # what mobile actually consumes.
+        assert "refresh_token" in response.cookies
+
+    async def test_refresh_mobile_client_gets_refresh_token_in_body(
+        self, test_client: AsyncClient, test_user
+    ):
+        """Mobile's refresh call must also receive the rotated refresh_token
+        in the body so SecureStore stays in sync across rotations."""
+        # 1. Mobile login — captures the initial refresh_token body copy.
+        login_response = await test_client.post(
+            "/api/auth/login",
+            json={"email": TEST_USER_EMAIL, "password": TEST_USER_PASSWORD},
+            headers={"X-Client": "kiaanverse-mobile"},
+        )
+        assert login_response.status_code == 200
+        initial_refresh = login_response.json().get("refresh_token")
+        assert initial_refresh is not None
+
+        # 2. Mobile refresh — sends the refresh token in the body (not cookie).
+        refresh_response = await test_client.post(
+            "/api/auth/refresh",
+            json={"refresh_token": initial_refresh},
+            headers={"X-Client": "kiaanverse-mobile"},
+        )
+        assert refresh_response.status_code == 200
+        refresh_data = refresh_response.json()
+        assert "access_token" in refresh_data
+        assert refresh_data.get("refresh_token"), (
+            "Mobile refresh must return rotated refresh_token in the body."
+        )
+        # Rotation — new token must differ from the old one.
+        assert refresh_data["refresh_token"] != initial_refresh
+
     async def test_login_wrong_password(self, test_client: AsyncClient, test_user):
         """Test login with wrong password."""
         response = await test_client.post(


### PR DESCRIPTION
## Summary

Makes the Sakha / Kiaan chat on Android actually generate responses — same behaviour as `kiaanverse.com` web.

Three stacked fixes:

1. **UI (layout):** Composer was hidden behind the DivineTabBar, FAB was floating over the starter chips. Reserved tab-bar space on the chat root and reseated the FAB above the composer.
2. **Mobile auth (401 resilience):** `useSakhaStream` now reads the JWT via the apiClient's TokenManager and does one silent refresh-and-retry on 401 — same resilience the rest of the app has for regular POSTs.
3. **Root cause (backend + mobile auth contract):** React Native cannot read `Set-Cookie` headers from JS, so mobile was silently storing no refresh token. 30 min later (access-token TTL) every request 401'd, refresh failed (nothing to send), and users saw "please sign in". Fixed by returning `refresh_token` in the login/refresh response body when the request carries `X-Client: kiaanverse-mobile` (browser contract untouched — they still get `null` in the body and keep using the httpOnly cookie).

New Sakha UI pieces to match the web reference:
- `HeroMandala` — large animated Shatkona yantra for the empty state.
- `InsightFab` — floating lightbulb FAB that seeds a curated Gita prompt.
- `useSakhaStream` rewired to stream `/api/chat/message/stream` SSE frames word-by-word.
- Persists the last 60 messages to AsyncStorage so the tab survives cold kills.
- NetInfo-gated sending with a compassionate offline banner.

## Test plan

- [x] Backend syntax + pytest integration tests for the mobile refresh-token-in-body path (2 new).
- [x] `pnpm typecheck` clean on all changed mobile files.
- [x] `pnpm test` green: 15 api + 100 store + 83 app = **198 tests passing**.
- [x] `pnpm eslint` clean on all changed mobile files.
- [ ] Android device smoke test after deploy: log in with real email, send a starter prompt, words stream in.

## After merge

1. Render redeploys the backend automatically from `main`.
2. `mobile-ota-update.yml` publishes the JS bundle via `eas update --branch production`.
3. On device: **fully close the app** (swipe from recents) and reopen — `expo-updates` pulls the new bundle on cold start.
4. Sign out → sign back in with email + password (not Developer Login) to pick up the new refresh token.
5. Test Sakha chat.

https://claude.ai/code/session_01RvVk2UyymwfVRZPAtt1ZCq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvVk2UyymwfVRZPAtt1ZCq)_