### PR TITLE
Update home shloka to Bhagavad Gita 4.7 (Dharma verse)

### DIFF
--- a/app/(mobile)/m/kiaan-vibe/verse/[chapterVerse]/page.tsx
+++ b/app/(mobile)/m/kiaan-vibe/verse/[chapterVerse]/page.tsx
@@ -199,7 +199,7 @@ export default function VerseReaderPage() {
             className="text-[10px] tracking-[0.1em] uppercase font-[family-name:var(--font-ui)]"
             style={{ color: '#D4A017' }}
           >
-            BG {chapterNum}.{verseNum} \u00B7 {chapter.transliteration}
+            BG {chapterNum}.{verseNum} {'·'} {chapter.transliteration}
           </span>
           <div className="flex gap-2">
             <motion.button

--- a/app/(mobile)/m/page.tsx
+++ b/app/(mobile)/m/page.tsx
@@ -67,11 +67,11 @@ interface DailyWisdom {
 }
 
 const FALLBACK_WISDOM: DailyWisdom = {
-  sanskrit: 'कर्मण्येवाधिकारस्ते मा फलेषु कदाचन',
-  transliteration: 'karmaṇy evādhikāras te mā phaleṣu kadācana',
-  translation: 'You have the right to perform your actions, but you are not entitled to the fruits of the actions.',
-  chapter: 2,
-  verse: 47,
+  sanskrit: 'यदा यदा हि धर्मस्य ग्लानिर्भवति भारत। अभ्युत्थानमधर्मस्य तदात्मानं सृजाम्यहम्॥',
+  transliteration: 'yadā yadā hi dharmasya glānir bhavati bhārata abhyutthānam adharmasya tadātmānaṁ sṛjāmy aham',
+  translation: 'When injustice rises, so does the force that corrects it. Be part of that force.',
+  chapter: 4,
+  verse: 7,
 }
 
 export default function SacredMobileHomePage() {
@@ -396,12 +396,13 @@ export default function SacredMobileHomePage() {
             whileTap={{ scale: 0.98 }}
             onClick={() => handleNavigate('/m/wisdom')}
             className="w-full text-left"
+            aria-label="Open Today's Wisdom"
           >
             <VerseRevelation
               sanskrit={dailyWisdom.sanskrit}
               transliteration={dailyWisdom.transliteration}
               meaning={dailyWisdom.translation}
-              reference={`${dailyWisdom.chapter}.${dailyWisdom.verse}`}
+              reference={`Chapter ${dailyWisdom.chapter}, Verse ${dailyWisdom.verse}`}
             />
           </motion.button>
         </motion.section>

--- a/app/(mobile)/m/wisdom/page.tsx
+++ b/app/(mobile)/m/wisdom/page.tsx
@@ -46,14 +46,14 @@ const WISDOM_THEMES = [
   { id: 'detachment', label: 'Letting Go', emoji: '🍃', gradient: 'from-green-500/15 to-emerald-500/15', border: 'border-green-500/20' },
 ]
 
-// Fallback verse when API is unavailable
+// Fallback verse when API is unavailable — matches the Sakha home shloka
 const FALLBACK_VERSE: DailyVerse = {
-  chapter: 2,
-  verse: 47,
-  sanskrit: 'कर्मण्येवाधिकारस्ते मा फलेषु कदाचन।',
-  translation: 'You have the right to perform your actions, but you are not entitled to the fruits of the actions.',
-  commentary: 'This verse teaches us to focus on the effort, not the outcome. When we release attachment to results, we find freedom in every action.',
-  theme: 'action',
+  chapter: 4,
+  verse: 7,
+  sanskrit: 'यदा यदा हि धर्मस्य ग्लानिर्भवति भारत। अभ्युत्थानमधर्मस्य तदात्मानं सृजाम्यहम्॥',
+  translation: 'When injustice rises, so does the force that corrects it. Be part of that force.',
+  commentary: 'Whenever there is a decline of Dharma, O Arjuna, and an uprising of Adharma, then I incarnate myself. Let this courage live in you today.',
+  theme: 'courage',
 }
 
 export default function MobileWisdomPage() {

--- a/components/sacred/VerseRevelation.tsx
+++ b/components/sacred/VerseRevelation.tsx
@@ -73,7 +73,7 @@ export function VerseRevelation({
 
       {reference && (
         <p className="sacred-label text-right mt-2">
-          Chapter {reference}
+          {/^chapter\b/i.test(reference.trim()) ? reference : `Chapter ${reference}`}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary

Updates the fallback/default Bhagavad Gita verse displayed on the mobile home and wisdom pages from BG 2.47 (Karma Yoga) to BG 4.7 (Dharma/Courage theme). This verse is now consistent across both the home page and wisdom page, and aligns with the app's "Sakha home shloka" designation.

## Changes

- **Fallback verse update**: Changed from BG 2.47 (कर्मण्येवाधिकारस्ते...) to BG 4.7 (यदा यदा हि धर्मस्य...) in both `app/(mobile)/m/page.tsx` and `app/(mobile)/m/wisdom/page.tsx`
- **Theme alignment**: Updated theme from 'action' to 'courage' to match the new verse's meaning
- **Reference formatting**: Improved verse reference display from abbreviated format (e.g., "2.47") to full format (e.g., "Chapter 4, Verse 7")
- **Component robustness**: Enhanced `VerseRevelation` component to handle both abbreviated and full reference formats
- **Accessibility**: Added `aria-label` to wisdom section button for better screen reader support
- **Code cleanup**: Replaced Unicode escape sequence with literal Unicode character (·) for improved readability

## Testing

- Verify home page displays BG 4.7 verse with correct Sanskrit, transliteration, and translation
- Verify wisdom page shows the same verse as fallback when API is unavailable
- Confirm verse reference displays as "Chapter 4, Verse 7" format
- Test that `VerseRevelation` component correctly handles both reference formats

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

https://claude.ai/code/session_01E1DxM4zpc8HMbPQ9P4MPAC