### PR TITLE
fix(csrf): skip native mobile + Bearer-auth — unblocks Android tools

### DIFF
--- a/backend/middleware/csrf.py
+++ b/backend/middleware/csrf.py
@@ -141,6 +141,27 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
         # For state-changing methods, validate CSRF token (unless exempt)
         if method in CSRF_PROTECTED_METHODS and not is_exempt:
+            # Native mobile app (React Native) authenticates with a Bearer
+            # token from SecureStore — it cannot be CSRF'd because a malicious
+            # site cannot read SecureStore or forge an Authorization header
+            # cross-origin. The native HTTP stack on iOS/Android, however,
+            # auto-attaches any cookies the backend has set on prior GETs
+            # (including csrf_token), which would otherwise trigger this
+            # middleware and 403 every chat/tool POST. Identify the mobile
+            # app via the X-Client header it sets on every request and skip.
+            client_header = request.headers.get("X-Client", "").lower()
+            if client_header in {"kiaanverse-mobile", "mindvibe-mobile"}:
+                return await call_next(request)
+
+            # Bearer-auth requests carry their credential in the Authorization
+            # header rather than a cookie. Cross-origin attackers cannot set
+            # arbitrary Authorization headers (CORS forbids it without an
+            # explicit Access-Control-Allow-Headers grant), so CSRF does not
+            # apply. This also covers server-to-server / SDK clients.
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header.lower().startswith("bearer "):
+                return await call_next(request)
+
             # Only skip CSRF if there are absolutely no auth cookies present
             # (i.e., this is a purely stateless API call with no browser session)
             has_auth_cookies = (

--- a/tests/unit/test_csrf_middleware.py
+++ b/tests/unit/test_csrf_middleware.py
@@ -1,0 +1,154 @@
+"""Unit tests for the CSRF middleware bypass paths used by the React Native
+Android app.
+
+Background
+----------
+The Android app authenticates with ``Authorization: Bearer <token>`` and tags
+every request with ``X-Client: kiaanverse-mobile``.  The native HTTP stack on
+Android/iOS auto-attaches any cookies the backend has set on prior GETs
+(including ``csrf_token``), which previously caused every chat / tool POST to
+be rejected with ``403 CSRF token validation failed`` because the app does
+not (and should not) read those cookies.
+
+These tests lock in the middleware's new behaviour:
+
+* skip CSRF when the request authenticates via Bearer or comes from a known
+  native client identifier, AND
+* continue to enforce CSRF for classic browser cookie-auth flows.
+
+Note on the autouse fixture
+---------------------------
+``tests/conftest.py`` has a session-scoped autouse fixture that monkey-patches
+``CSRFMiddleware.dispatch`` to a passthrough so the rest of the suite is not
+gated by CSRF.  We capture the *original* dispatch reference at module-import
+time (which runs before any fixture executes) and rebuild a small Starlette
+app whose CSRFMiddleware uses that captured dispatch.  This lets us exercise
+the real logic without disturbing other tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.middleware.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+)
+
+# Capture before conftest's autouse fixture runs.  Module-level statements
+# execute during collection, well before fixture setup.
+_ORIGINAL_DISPATCH = CSRFMiddleware.dispatch
+
+
+@pytest.fixture
+def csrf_app():
+    """Build a minimal Starlette app with only CSRF middleware mounted.
+
+    Subclasses ``CSRFMiddleware`` to bind the *original* dispatch — bypassing
+    the session-scoped passthrough patch installed by ``tests/conftest.py``.
+    """
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    class _RealCSRFMiddleware(CSRFMiddleware):
+        # Re-bind the captured original dispatch on this subclass so the
+        # conftest patch on the parent class does not affect us.
+        dispatch = _ORIGINAL_DISPATCH  # type: ignore[assignment]
+
+    async def echo(request):
+        return JSONResponse({"ok": True})
+
+    app = Starlette(routes=[Route("/echo", echo, methods=["GET", "POST"])])
+    # cookie_secure=False so TestClient can set/read the cookie over http.
+    app.add_middleware(_RealCSRFMiddleware, cookie_secure=False, cookie_samesite="lax")
+    return TestClient(app)
+
+
+def test_post_with_cookie_but_no_header_is_rejected(csrf_app):
+    """Classic browser cookie-auth without X-CSRF-Token must still 403."""
+    csrf_app.get("/echo")
+    assert csrf_app.cookies.get(CSRF_COOKIE_NAME), "GET should seed csrf_token"
+
+    res = csrf_app.post("/echo")
+    assert res.status_code == 403
+    assert res.json()["error"] == "csrf_token_invalid"
+
+
+def test_post_with_matching_header_succeeds(csrf_app):
+    """Classic browser flow with matching cookie + header must pass."""
+    csrf_app.get("/echo")
+    token = csrf_app.cookies.get(CSRF_COOKIE_NAME)
+    assert token
+
+    res = csrf_app.post("/echo", headers={CSRF_HEADER_NAME: token})
+    assert res.status_code == 200, res.text
+    assert res.json() == {"ok": True}
+
+
+def test_post_with_x_client_native_mobile_skips_csrf(csrf_app):
+    """React Native ``X-Client: kiaanverse-mobile`` bypasses CSRF.
+
+    The native HTTP stack auto-attaches cookies the backend set on prior
+    GETs, so the request looks "browser-like" to the middleware.  Since the
+    Android app cannot read those cookies and authenticates via Bearer, CSRF
+    is irrelevant — and the middleware must let the request through even
+    though no X-CSRF-Token header is present.
+    """
+    csrf_app.get("/echo")  # seed csrf_token cookie
+    assert csrf_app.cookies.get(CSRF_COOKIE_NAME)
+
+    res = csrf_app.post("/echo", headers={"X-Client": "kiaanverse-mobile"})
+    assert res.status_code == 200, res.text
+
+
+def test_post_with_x_client_uppercase_native_mobile_skips_csrf(csrf_app):
+    """Header value matching is case-insensitive."""
+    csrf_app.get("/echo")
+    res = csrf_app.post("/echo", headers={"X-Client": "Kiaanverse-Mobile"})
+    assert res.status_code == 200, res.text
+
+
+def test_post_with_bearer_auth_skips_csrf(csrf_app):
+    """Bearer-auth requests bypass CSRF (header auth, not cookie auth)."""
+    csrf_app.get("/echo")
+    assert csrf_app.cookies.get(CSRF_COOKIE_NAME)
+
+    res = csrf_app.post(
+        "/echo",
+        headers={"Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.fake.token"},
+    )
+    assert res.status_code == 200, res.text
+
+
+def test_post_with_unknown_x_client_still_enforces_csrf(csrf_app):
+    """Only known native client identifiers bypass CSRF.  Random strings must
+    NOT — otherwise an attacker could trivially defeat the protection by
+    setting the header from a malicious site."""
+    csrf_app.get("/echo")
+
+    res = csrf_app.post("/echo", headers={"X-Client": "evil-attacker"})
+    assert res.status_code == 403
+    assert res.json()["error"] == "csrf_token_invalid"
+
+
+def test_post_with_basic_auth_still_enforces_csrf(csrf_app):
+    """Only Bearer-auth bypasses CSRF.  Basic auth is uncommon but browsers
+    re-send it like a cookie, so it must remain protected."""
+    csrf_app.get("/echo")
+
+    res = csrf_app.post(
+        "/echo",
+        headers={"Authorization": "Basic dXNlcjpwYXNz"},
+    )
+    assert res.status_code == 403
+
+
+def test_post_without_any_cookies_passes(csrf_app):
+    """Stateless API clients with no cookies at all bypass CSRF — the
+    pre-existing behaviour for SDK / server-to-server callers."""
+    # Fresh client, no GET first → no csrf_token cookie set.
+    res = csrf_app.post("/echo")
+    assert res.status_code == 200, res.text


### PR DESCRIPTION
The Android RN app showed "Sakha could not respond. CSRF token validation failed." on Sakha Chat, Viyoga, Ardha, Karma Reset, Relationship Compass, and Emotional Reset because the native HTTP stack auto-attaches cookies the backend set on prior GETs (including csrf_token), but the app cannot read them and authenticates via Bearer instead. Every state-changing POST therefore arrived with a CSRF cookie and no matching X-CSRF-Token header and was rejected with 403.

CSRF only protects browser cookie-auth (cross-origin attackers rely on the browser auto-sending cookies). Bearer tokens stored in SecureStore cannot be forged by a malicious site, so CSRF does not apply. The middleware now bypasses validation when:

  1. X-Client identifies a known native client (kiaanverse-mobile, mindvibe-mobile), or
  2. Authorization is a Bearer token.

All classic browser flows (cookie auth without Bearer) keep the existing strict cookie+header validation. Adds test_csrf_middleware.py with seven cases covering both bypass paths and the negative cases (random X-Client strings, Basic auth) so the protection is not silently weakened.

This is purely a backend change; the Android app needs no rebuild — it already sends X-Client: kiaanverse-mobile and Authorization: Bearer. Once deployed, the same /api/viyoga/chat, /api/ardha/reframe, /api/relationship-compass/guide, /api/karma-reset/* endpoints that drive desktop and mobile-web will start answering Android requests, putting response generation in sync with kiaanverse.com mobile.

https://claude.ai/code/session_01UkcV2fxgLigcBoSgQqdJq6

<!-- Describe the change and why it matters -->
## Summary

<!-- One-sentence summary of the change -->

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing
Describe how this change was tested locally (commands run).

## Reviewers
Tag any maintainers or teams that should review.
