### PR TITLE
chore(expo): clean-build-aab helper for git bash + powershell

### DIFF
--- a/kiaanverse-mobile/scripts/clean-build-aab.ps1
+++ b/kiaanverse-mobile/scripts/clean-build-aab.ps1
@@ -1,0 +1,165 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+    Kiaanverse — clean AAB build via EAS, no cache. PowerShell variant.
+
+.DESCRIPTION
+    Identical behaviour to clean-build-aab.sh. Use this from PowerShell or
+    Windows Terminal if you don't have Git Bash. From Git Bash run the .sh
+    instead — both produce the same AAB.
+
+    Steps:
+      1. Hard-reset main to origin/main.
+      2. Update global CLIs (pnpm, eas-cli, expo).
+      3. Wipe every cache layer (node_modules, .expo, Metro, pnpm/npm, Gradle).
+      4. pnpm install --frozen-lockfile.
+      5. npx expo-doctor.
+      6. eas build --platform android --profile production --clear-cache.
+
+.PARAMETER Local
+    Run the build on this machine (needs JDK 17 + Android SDK).
+    Default: cloud build via EAS.
+
+.PARAMETER SkipSync
+    Don't reset local main to origin/main.
+
+.PARAMETER SkipUpdate
+    Don't `npm install -g` the latest CLIs.
+
+.PARAMETER NoClean
+    Skip the cache wipe.
+
+.EXAMPLE
+    .\kiaanverse-mobile\scripts\clean-build-aab.ps1
+
+.EXAMPLE
+    .\kiaanverse-mobile\scripts\clean-build-aab.ps1 -Local
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Local,
+    [switch]$SkipSync,
+    [switch]$SkipUpdate,
+    [switch]$NoClean
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Section($msg) {
+    Write-Host ""
+    Write-Host ("→ " + $msg) -ForegroundColor Cyan
+}
+
+# ----------------------------------------------------------------- paths --
+$RepoRoot = (& git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $RepoRoot) {
+    Write-Error "not inside a git working tree"
+    exit 1
+}
+$Workspace = Join-Path $RepoRoot 'kiaanverse-mobile'
+$AppDir    = Join-Path $Workspace 'apps\mobile'
+
+if (-not (Test-Path $AppDir)) {
+    Write-Error "$AppDir not found — is this the right repo?"
+    exit 1
+}
+
+# ----------------------------------------------------------------- 1 sync --
+if (-not $SkipSync) {
+    Section "Sync to latest origin/main"
+    Set-Location $RepoRoot
+    git fetch origin --prune --tags
+    git checkout main
+    git reset --hard origin/main
+    git status --short
+    git rev-parse HEAD
+}
+
+# ----------------------------------------------------------------- 2 clis --
+if (-not $SkipUpdate) {
+    Section "Update global CLIs (pnpm, eas-cli, expo)"
+    npm install -g pnpm@latest eas-cli@latest expo@latest
+    pnpm --version
+    eas --version
+}
+
+# Auth check
+$null = & eas whoami 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "not logged in to EAS — running 'eas login' now"
+    eas login
+}
+
+# ----------------------------------------------------------------- 3 clean -
+if (-not $NoClean) {
+    Section "Wipe local caches"
+    Set-Location $Workspace
+
+    foreach ($pattern in @(
+        'node_modules',
+        'apps\*\node_modules',
+        'packages\*\node_modules'
+    )) {
+        Get-ChildItem -Path $pattern -Force -Recurse -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    foreach ($p in @(
+        (Join-Path $AppDir '.expo'),
+        (Join-Path $env:USERPROFILE '.expo'),
+        (Join-Path $AppDir 'android'),
+        (Join-Path $AppDir 'ios')
+    )) {
+        if (Test-Path $p) {
+            Remove-Item -Recurse -Force $p -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Metro / Haste cache from temp
+    $tempRoot = $env:TEMP
+    if ($tempRoot -and (Test-Path $tempRoot)) {
+        Get-ChildItem -Path $tempRoot -Filter 'metro-*'     -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        Get-ChildItem -Path $tempRoot -Filter 'haste-map-*' -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    pnpm store prune
+    npm cache clean --force
+
+    if ($Local) {
+        $gradleHome = Join-Path $env:USERPROFILE '.gradle'
+        foreach ($g in @('caches', 'daemon')) {
+            $p = Join-Path $gradleHome $g
+            if (Test-Path $p) {
+                Remove-Item -Recurse -Force $p -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
+# ----------------------------------------------------------------- 4 install
+Section "Fresh install (pnpm --frozen-lockfile)"
+Set-Location $Workspace
+pnpm install --frozen-lockfile
+
+# ----------------------------------------------------------------- 5 doctor
+Section "Health check (expo-doctor)"
+Set-Location $AppDir
+# expo-doctor warnings shouldn't abort
+& npx expo-doctor
+
+# ----------------------------------------------------------------- 6 build
+Section "EAS build — production AAB, --clear-cache"
+Set-Location $AppDir
+
+$flags = @('--platform', 'android', '--profile', 'production', '--clear-cache', '--non-interactive')
+if ($Local) {
+    $flags += '--local'
+}
+& eas build @flags
+
+Section "Done"
+Write-Host "Cloud build: download URL is in the output above."
+Write-Host "Local build: AAB is at $AppDir\build-*.aab"

--- a/kiaanverse-mobile/scripts/clean-build-aab.sh
+++ b/kiaanverse-mobile/scripts/clean-build-aab.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Kiaanverse — clean AAB build via EAS, no cache.
+#
+# What this does, in order:
+#   1. Sync repo to current origin/main (hard reset — drops local edits).
+#   2. Update global CLIs (pnpm, eas-cli, expo).
+#   3. Wipe every cache layer that could leak stale state into the AAB:
+#        - node_modules (root + workspace packages + apps/mobile)
+#        - .expo / ~/.expo (Expo CLI cache)
+#        - Metro / Haste cache from $TMPDIR
+#        - Generated apps/mobile/android + apps/mobile/ios (from prebuild)
+#        - pnpm content-addressable store (`pnpm store prune`)
+#        - npm cache
+#        - Gradle daemon + caches (only matters for --local builds)
+#   4. Fresh `pnpm install --frozen-lockfile` so the dep tree matches
+#      pnpm-lock.yaml exactly — reproducible with what's on main.
+#   5. `npx expo-doctor` health check.
+#   6. `eas build --platform android --profile production --clear-cache`
+#      The `--clear-cache` flag also invalidates EAS's server-side build
+#      cache so the worker rebuilds from a fresh checkout.
+#
+# Usage (Git Bash on Windows, or any POSIX shell):
+#
+#     bash kiaanverse-mobile/scripts/clean-build-aab.sh
+#
+# Optional flags:
+#   --local        Run the build on this machine (needs JDK 17 + Android SDK).
+#                  Without this, EAS builds in their cloud (no SDK needed).
+#   --skip-sync    Don't reset local main to origin/main. Useful if you have
+#                  uncommitted work-in-progress you want to keep.
+#   --skip-update  Don't `npm install -g` the latest CLIs.
+#   --no-clean     Skip the cache wipe (only do install + build).
+#
+# Prerequisites (one-time): Node 20+, npm, an Expo login (`eas login`).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------- args ----
+LOCAL_BUILD=false
+SKIP_SYNC=false
+SKIP_UPDATE=false
+NO_CLEAN=false
+for arg in "$@"; do
+    case "$arg" in
+        --local)        LOCAL_BUILD=true ;;
+        --skip-sync)    SKIP_SYNC=true ;;
+        --skip-update)  SKIP_UPDATE=true ;;
+        --no-clean)     NO_CLEAN=true ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            exit 0 ;;
+        *)
+            echo "Unknown flag: $arg" >&2
+            exit 2 ;;
+    esac
+done
+
+# Find repo root from anywhere — works whether you cd into the script dir
+# or invoke it via an absolute path.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$REPO_ROOT" ]; then
+    echo "ERROR: not inside a git working tree" >&2
+    exit 1
+fi
+WORKSPACE="$REPO_ROOT/kiaanverse-mobile"
+APP_DIR="$WORKSPACE/apps/mobile"
+
+if [ ! -d "$APP_DIR" ]; then
+    echo "ERROR: $APP_DIR not found — is this the right repo?" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------- helpers --
+section() {
+    printf '\n\033[1;36m→ %s\033[0m\n' "$1"
+}
+
+# ---------------------------------------------------------------- 1. sync --
+if [ "$SKIP_SYNC" = false ]; then
+    section "Sync to latest origin/main"
+    cd "$REPO_ROOT"
+    git fetch origin --prune --tags
+    git checkout main
+    git reset --hard origin/main
+    git status --short
+    git rev-parse HEAD
+fi
+
+# ---------------------------------------------------------------- 2. clis --
+if [ "$SKIP_UPDATE" = false ]; then
+    section "Update global CLIs (pnpm, eas-cli, expo)"
+    npm install -g pnpm@latest eas-cli@latest expo@latest
+    pnpm --version
+    eas --version
+fi
+
+# Sanity: must be logged in to EAS for the build to start.
+if ! eas whoami >/dev/null 2>&1; then
+    echo "WARN: not logged in to EAS — running 'eas login' now"
+    eas login
+fi
+
+# ---------------------------------------------------------------- 3. clean -
+if [ "$NO_CLEAN" = false ]; then
+    section "Wipe local caches"
+    cd "$WORKSPACE"
+
+    # JS deps (workspace-aware)
+    rm -rf node_modules
+    rm -rf apps/*/node_modules
+    rm -rf packages/*/node_modules
+
+    # Expo / Metro
+    rm -rf "$APP_DIR/.expo"
+    rm -rf "$HOME/.expo"
+
+    # Metro temp on POSIX + Windows
+    if [ -n "${TMPDIR:-}" ]; then
+        rm -rf "$TMPDIR/metro-"* "$TMPDIR/haste-map-"* 2>/dev/null || true
+    fi
+    if [ -n "${USERNAME:-}" ] && [ -d "/c/Users/$USERNAME/AppData/Local/Temp" ]; then
+        rm -rf "/c/Users/$USERNAME/AppData/Local/Temp/metro-"* 2>/dev/null || true
+        rm -rf "/c/Users/$USERNAME/AppData/Local/Temp/haste-map-"* 2>/dev/null || true
+    fi
+
+    # Generated native dirs (only present after a prior `expo prebuild` /
+    # `eas build --local`). Always regenerated from app.config.ts on next
+    # build — committing them is unsupported in EAS Managed workflow.
+    rm -rf "$APP_DIR/android" "$APP_DIR/ios"
+
+    # pnpm content-addressable store + npm cache
+    pnpm store prune || true
+    npm cache clean --force || true
+
+    # Gradle (only matters with --local)
+    if [ "$LOCAL_BUILD" = true ]; then
+        rm -rf "$HOME/.gradle/caches" "$HOME/.gradle/daemon" 2>/dev/null || true
+    fi
+
+    # Watchman, if installed (rare on Windows)
+    watchman watch-del-all 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------- 4. install
+section "Fresh install (pnpm --frozen-lockfile)"
+cd "$WORKSPACE"
+pnpm install --frozen-lockfile
+
+# ---------------------------------------------------------------- 5. doctor
+section "Health check (expo-doctor)"
+cd "$APP_DIR"
+# expo-doctor exits non-zero on warnings — don't let that abort the build,
+# we surface the output for the operator to decide.
+npx expo-doctor || true
+
+# ---------------------------------------------------------------- 6. build
+section "EAS build — production AAB, --clear-cache"
+cd "$APP_DIR"
+
+BUILD_FLAGS=(--platform android --profile production --clear-cache --non-interactive)
+if [ "$LOCAL_BUILD" = true ]; then
+    BUILD_FLAGS+=(--local)
+fi
+
+eas build "${BUILD_FLAGS[@]}"
+
+section "Done"
+echo "If this was a cloud build, the AAB download URL is in the output above."
+echo "If --local, the AAB is in: $APP_DIR/build-*.aab"


### PR DESCRIPTION
## Summary

A one-shot helper that produces an AAB from `kiaanverse-mobile` via EAS
with **zero cache reuse**, plus a PowerShell variant for non-Git-Bash
shells. The manual cache-wiping sequence is 8 commands long, easy to
skip a step on, and accounts for caches at four different layers (npm,
pnpm, Metro/Expo, EAS server-side). This script does all of it
deterministically.

## What the script does

1. `git fetch` + hard-reset `main` to `origin/main` (skip with `--skip-sync`)
2. `npm install -g` latest `pnpm` + `eas-cli` + `expo` (skip with `--skip-update`)
3. Wipe every cache layer (skip with `--no-clean`):
   - `node_modules` across the workspace
   - `apps/mobile/.expo` and `~/.expo`
   - Metro / Haste cache from `$TMPDIR` (POSIX) and `%TEMP%` (Windows)
   - Generated `apps/mobile/{android,ios}` from prior `expo prebuild`
   - pnpm content-addressable store
   - npm cache
   - Gradle daemon + caches (only with `--local`)
4. `pnpm install --frozen-lockfile` — reproducible with main's lockfile
5. `npx expo-doctor` health check
6. `eas build --platform android --profile production --clear-cache`
   — `--clear-cache` also invalidates EAS's **server-side** build cache,
   so the worker rebuilds from a fresh checkout

## Files

- `kiaanverse-mobile/scripts/clean-build-aab.sh` — POSIX / Git Bash
- `kiaanverse-mobile/scripts/clean-build-aab.ps1` — PowerShell

Both respect the existing `eas.json` — `production` profile produces an
AAB by default (no `buildType` override → `app-bundle`).

## Usage

From Git Bash on Windows:

```bash
bash kiaanverse-mobile/scripts/clean-build-aab.sh
```

From PowerShell:

```powershell
.\kiaanverse-mobile\scripts\clean-build-aab.ps1
```

Flags supported by both: `--local`, `--skip-sync`, `--skip-update`,
`--no-clean` (PowerShell uses `-Local`, `-SkipSync`, `-SkipUpdate`,
`-NoClean`).

Both scripts confirm `eas whoami` before starting and prompt for
`eas login` if not authenticated. They print a build URL on completion.

## Test plan

- [x] `bash -n clean-build-aab.sh` — syntax clean
- [x] PowerShell parser tokeniser run (no execution) — script structure
  valid (no syntax errors flagged when validated)
- [ ] Reviewer to run `bash kiaanverse-mobile/scripts/clean-build-aab.sh`
  end-to-end on a Windows host with Node 20 + EAS account, confirm AAB
  artefact URL is printed and downloads cleanly
- [ ] Reviewer to verify the AAB has `versionCode > 21` (auto-incremented
  by EAS thanks to `appVersionSource: remote` + `autoIncrement: true`
  in `eas.json`)

https://claude.ai/code/session_015GrM8YFE7mwty4ycJXGuP4

---
_Generated by [Claude Code](https://claude.ai/code/session_015GrM8YFE7mwty4ycJXGuP4)_