### PR TITLE
fix(mobile): #327 startup crash — useArrivalStatus race with React co…

### DIFF
--- a/kiaanverse-mobile/apps/mobile/hooks/useArrivalStatus.ts
+++ b/kiaanverse-mobile/apps/mobile/hooks/useArrivalStatus.ts
@@ -13,7 +13,7 @@
  * level, not account-level — a returning user on a new device still
  * deserves the darshan.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const STORAGE_KEY = '@kiaanverse/has-seen-arrival';
@@ -22,6 +22,18 @@ const STORAGE_KEY = '@kiaanverse/has-seen-arrival';
 // Module-level state + subscription set. A single AsyncStorage read is
 // triggered lazily on first hook mount; every subsequent mount sees the
 // cached value immediately.
+//
+// Why useSyncExternalStore (not useState + forceRender):
+//   The previous implementation called listeners synchronously from inside
+//   the AsyncStorage `.then` microtask. When that microtask resolved while
+//   React was still committing the initial mount (which is the normal cold-
+//   start sequence — RootLayout commits, then microtasks flush), the
+//   forceRender setState raced React's commit phase and threw the scheduler
+//   invariant "Should not already be working" (React error #327), which
+//   expo-updates' error-recovery thread then escalated to a fatal crash on
+//   first launch. useSyncExternalStore is the React 18 API explicitly built
+//   to subscribe a component to external mutable state without that race —
+//   it batches notifications correctly against the commit phase.
 // ---------------------------------------------------------------------------
 
 let cachedValue: boolean | null = null;
@@ -68,6 +80,20 @@ async function writeFlag(seen: boolean): Promise<void> {
   }
 }
 
+function subscribe(listener: () => void): () => void {
+  subscribers.add(listener);
+  // Kick off the lazy read on first subscription. Safe to call repeatedly —
+  // ensureLoaded() deduplicates on loadPromise.
+  void ensureLoaded();
+  return () => {
+    subscribers.delete(listener);
+  };
+}
+
+function getSnapshot(): boolean | null {
+  return cachedValue;
+}
+
 // ---------------------------------------------------------------------------
 // Public hook
 // ---------------------------------------------------------------------------
@@ -84,18 +110,9 @@ export interface ArrivalStatus {
 }
 
 export function useArrivalStatus(): ArrivalStatus {
-  const [, forceRender] = useState(0);
-
-  useEffect(() => {
-    const listener = (): void => {
-      forceRender((n) => n + 1);
-    };
-    subscribers.add(listener);
-    void ensureLoaded();
-    return () => {
-      subscribers.delete(listener);
-    };
-  }, []);
+  // Same snapshot fn for client + server: this app has no SSR, and a stable
+  // identity-equal snapshot keeps useSyncExternalStore from re-subscribing.
+  const value = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const markArrivalSeen = useCallback((): Promise<void> => {
     return writeFlag(true);
@@ -105,8 +122,8 @@ export function useArrivalStatus(): ArrivalStatus {
   }, []);
 
   return {
-    isLoaded: cachedValue !== null,
-    hasSeenArrival: cachedValue === true,
+    isLoaded: value !== null,
+    hasSeenArrival: value === true,
     markArrivalSeen,
     resetArrivalStatus,
   };


### PR DESCRIPTION
…mmit

Fixes the immediate-on-install crash in com.kiaanverse.app where every launch produced FATAL EXCEPTION: expo-updates-error-recovery wrapping React error #327 ("Should not already be working") on Hermes.

Root cause: useArrivalStatus.ts subscribed components via a hand-rolled Set<listener> + a useState forceRender. When the AsyncStorage `.then` microtask resolved during the initial mount (cold start sequence: RootLayout commits → microtasks flush), notify() called every listener synchronously, which called forceRender setState while React was still committing — exactly the scheduler invariant #327. The hook is mounted twice in _layout.tsx (AuthGate + AppContent), so both forceRenders fired inside the same microtask and re-entered the in-flight commit.

Fix: migrate to useSyncExternalStore. That's the React 18 API built specifically to subscribe a component to mutable external state without this race — React internally batches the notification against the commit phase. Module-level state, subscribe(), getSnapshot() are pulled out of the hook so the API surface is unchanged for callers.

The consequence — every subsequent launch attempt cycles the same way because expo-updates' error-recovery thread cannot roll back to a prior good bundle on a fresh install — is the symptom users reported as "the app crashes immediately." With this fix in place the cold-start path reaches the first paint without re-entering React.

<!-- Describe the change and why it matters -->
## Summary

<!-- One-sentence summary of the change -->

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing
Describe how this change was tested locally (commands run).

## Reviewers
Tag any maintainers or teams that should review.
