### PR TITLE
feat(mobile): canonical 6-card daily journey step renderer

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/journey/step/[day].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/journey/step/[day].tsx
@@ -119,15 +119,18 @@ function detectEnemyKey(title: string, description: string): string | null {
 /**
  * Parse step content into structured sections.
  *
- * The step.content field contains the teaching text. Verse and reflection
- * data come from dedicated WisdomJourneyStep fields. Additional structured
- * data (practice instructions, micro-commitment, safety) may be embedded
- * in the content as markdown-style headers — we parse them out here.
+ * Modern backend deployments expose every section as a typed field on
+ * `WisdomJourneyStep` (verse fields, reflectionPrompts, practice block,
+ * microCommitment, safetyNote, modernExample). This parser:
+ *
+ *   1. Prefers the structured fields when present.
+ *   2. Falls back to markdown-style headers embedded in `content` so legacy
+ *      seed data and offline cache rows still render the 6 cards.
  */
 function parseStepSections(step: WisdomJourneyStep) {
   const content = step.content ?? '';
 
-  // Split content into sections by markdown-style headers
+  // Split content into sections by markdown-style headers (legacy fallback).
   const sections: Record<string, string> = {};
   let currentKey = 'teaching';
   const lines = content.split('\n');
@@ -136,7 +139,6 @@ function parseStepSections(step: WisdomJourneyStep) {
   for (const line of lines) {
     const headerMatch = line.match(/^##?\s*(.+)/);
     if (headerMatch) {
-      // Save buffer to current section
       if (buffer.length > 0) {
         sections[currentKey] = buffer.join('\n').trim();
         buffer.length = 0;
@@ -150,34 +152,57 @@ function parseStepSections(step: WisdomJourneyStep) {
     sections[currentKey] = buffer.join('\n').trim();
   }
 
-  // Extract reflection prompts from the step.reflection field or content
-  const reflectionText =
-    step.reflection ??
-    sections['reflection'] ??
-    sections['guided reflection'] ??
-    '';
-  const reflectionPrompts = reflectionText
-    .split('\n')
-    .map((l) => l.replace(/^\d+\.\s*/, '').trim())
-    .filter(Boolean);
+  // Reflection prompts — prefer the structured array, then the joined
+  // legacy `reflection` string, then the markdown header fallback.
+  let reflectionPrompts: string[] | undefined;
+  if (step.reflectionPrompts && step.reflectionPrompts.length > 0) {
+    reflectionPrompts = step.reflectionPrompts;
+  } else {
+    const reflectionText =
+      step.reflection ??
+      sections['reflection'] ??
+      sections['guided reflection'] ??
+      '';
+    const parsed = reflectionText
+      .split('\n')
+      .map((l) => l.replace(/^\d+\.\s*/, '').trim())
+      .filter(Boolean);
+    if (parsed.length > 0) reflectionPrompts = parsed;
+  }
 
-  // Extract practice instructions
-  const practiceText =
-    sections['practice'] ?? sections["today's practice"] ?? '';
-  const practiceInstructions = practiceText
-    .split('\n')
-    .map((l) => l.replace(/^\d+\.\s*/, '').trim())
-    .filter(Boolean);
+  // Practice instructions — prefer structured block, then header fallback.
+  let practiceInstructions: string[] | undefined;
+  let practiceName: string | undefined;
+  let practiceDuration: string | undefined;
+  if (step.practice && step.practice.instructions.length > 0) {
+    practiceInstructions = step.practice.instructions;
+    practiceName = step.practice.name;
+    if (typeof step.practice.durationMinutes === 'number') {
+      practiceDuration = `${step.practice.durationMinutes} min`;
+    }
+  } else {
+    const practiceText =
+      sections['practice'] ?? sections["today's practice"] ?? '';
+    const parsed = practiceText
+      .split('\n')
+      .map((l) => l.replace(/^\d+\.\s*/, '').trim())
+      .filter(Boolean);
+    if (parsed.length > 0) practiceInstructions = parsed;
+  }
 
   return {
     teaching: sections['teaching'] ?? content,
-    reflectionPrompts:
-      reflectionPrompts.length > 0 ? reflectionPrompts : undefined,
-    practiceInstructions:
-      practiceInstructions.length > 0 ? practiceInstructions : undefined,
+    reflectionPrompts,
+    practiceInstructions,
+    practiceName,
+    practiceDuration,
     microCommitment:
-      sections['micro-commitment'] ?? sections['commitment'] ?? undefined,
+      step.microCommitment ??
+      sections['micro-commitment'] ??
+      sections['commitment'] ??
+      undefined,
     safetyNotes:
+      step.safetyNote ??
       sections['safety'] ??
       sections['safety notes'] ??
       sections['note'] ??
@@ -198,6 +223,8 @@ function CompletionArea({
   onReflectionChange,
   onComplete,
   accentColor,
+  showReflection,
+  onToggleReflection,
 }: {
   readonly step: WisdomJourneyStep;
   readonly isCompleted: boolean;
@@ -207,6 +234,8 @@ function CompletionArea({
   readonly onReflectionChange: (text: string) => void;
   readonly onComplete: () => void;
   readonly accentColor: string;
+  readonly showReflection: boolean;
+  readonly onToggleReflection: () => void;
 }): React.JSX.Element {
   if (isCompleted) {
     return (
@@ -250,38 +279,66 @@ function CompletionArea({
       entering={FadeInUp.delay(200).duration(400)}
       style={styles.completionArea}
     >
-      {/* Optional reflection textarea */}
-      <Text
-        variant="label"
-        color={colors.text.secondary}
-        style={styles.reflectionLabel}
-      >
-        Your Reflection (optional)
-      </Text>
-      <TextInput
+      {/* "Add Reflection (Optional)" toggle — mirrors the web design.
+          Tapping reveals the textarea; tapping again collapses it. */}
+      <Pressable
+        onPress={onToggleReflection}
         style={[
-          styles.reflectionInput,
+          styles.reflectionToggle,
           {
-            borderColor:
-              reflectionText.length > 0 ? accentColor : colors.alpha.whiteLight,
+            borderColor: showReflection
+              ? `${accentColor}66`
+              : colors.alpha.whiteLight,
+            backgroundColor: showReflection
+              ? `${accentColor}14`
+              : colors.alpha.whiteLight,
           },
         ]}
-        value={reflectionText}
-        onChangeText={onReflectionChange}
-        placeholder="What arose for you during this practice? Share your thoughts..."
-        placeholderTextColor={colors.text.muted}
-        multiline
-        maxLength={MAX_REFLECTION_LENGTH}
-        textAlignVertical="top"
-        accessibilityLabel="Reflection textarea"
-      />
-      <Text
-        variant="caption"
-        color={colors.text.muted}
-        style={styles.charCount}
+        accessibilityRole="button"
+        accessibilityLabel={
+          showReflection ? 'Hide reflection input' : 'Add a reflection'
+        }
+        testID="add-reflection-toggle"
       >
-        {reflectionText.length}/{MAX_REFLECTION_LENGTH}
-      </Text>
+        <Text
+          variant="label"
+          color={showReflection ? accentColor : colors.text.secondary}
+          align="center"
+        >
+          {showReflection ? 'Hide Reflection' : 'Add Reflection (Optional)'}
+        </Text>
+      </Pressable>
+
+      {showReflection ? (
+        <>
+          <TextInput
+            style={[
+              styles.reflectionInput,
+              {
+                borderColor:
+                  reflectionText.length > 0
+                    ? accentColor
+                    : colors.alpha.whiteLight,
+              },
+            ]}
+            value={reflectionText}
+            onChangeText={onReflectionChange}
+            placeholder="What stirs in you after this practice?"
+            placeholderTextColor={colors.text.muted}
+            multiline
+            maxLength={MAX_REFLECTION_LENGTH}
+            textAlignVertical="top"
+            accessibilityLabel="Reflection textarea"
+          />
+          <Text
+            variant="caption"
+            color={colors.text.muted}
+            style={styles.charCount}
+          >
+            {reflectionText.length}/{MAX_REFLECTION_LENGTH}
+          </Text>
+        </>
+      ) : null}
 
       {/* Complete button */}
       <GoldenButton
@@ -329,6 +386,7 @@ export default function StepPlayerScreen(): React.JSX.Element {
   const { updateJourneyProgress } = useJourneyStore();
 
   const [reflectionText, setReflectionText] = useState('');
+  const [showReflection, setShowReflection] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
   const [celebration, setCelebration] = useState<{
     xp: number;
@@ -540,12 +598,19 @@ export default function StepPlayerScreen(): React.JSX.Element {
 
           <SacredDivider />
 
-          {/* ---------- Step Content Sections ---------- */}
+          {/* ---------- Step Content Sections (canonical 6 cards) ---------- */}
           {parsedSections ? (
             <StepContent
               teaching={parsedSections.teaching}
               verseRef={currentStep.verseRef}
+              sanskrit={currentStep.verseSanskrit}
+              transliteration={currentStep.verseTransliteration}
+              englishTranslation={currentStep.verseTranslation}
+              hindiTranslation={currentStep.verseHindi}
+              modernExample={currentStep.modernExample}
               reflectionPrompts={parsedSections.reflectionPrompts}
+              practiceName={parsedSections.practiceName}
+              practiceDuration={parsedSections.practiceDuration}
               practiceInstructions={parsedSections.practiceInstructions}
               microCommitment={parsedSections.microCommitment}
               safetyNotes={parsedSections.safetyNotes}
@@ -576,6 +641,11 @@ export default function StepPlayerScreen(): React.JSX.Element {
             onReflectionChange={setReflectionText}
             onComplete={handleComplete}
             accentColor={accentColor}
+            showReflection={showReflection}
+            onToggleReflection={() => {
+              Haptics.selectionAsync();
+              setShowReflection((s) => !s);
+            }}
           />
         </ScrollView>
       </KeyboardAvoidingView>
@@ -682,8 +752,13 @@ const styles = StyleSheet.create({
     gap: spacing.md,
     paddingVertical: spacing.xl,
   },
-  reflectionLabel: {
-    marginBottom: spacing.xxs,
+  reflectionToggle: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   reflectionInput: {
     backgroundColor: colors.alpha.whiteLight,

--- a/kiaanverse-mobile/apps/mobile/components/journey/StepContent.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/journey/StepContent.tsx
@@ -1,10 +1,16 @@
 /**
- * StepContent — Full step content renderer for the daily journey experience.
+ * StepContent — Canonical 6-card daily journey renderer.
  *
- * Renders all sections of a journey step: teaching, verse, reflection prompts,
- * practice instructions, micro-commitment, and safety notes. Each section is
- * wrapped in a themed GlowCard with an icon-accented left border.
+ * Renders the six fixed cards every journey step must surface, in this exact
+ * order:
+ *   1. Verse        — Sanskrit + transliteration + English translation.
+ *   2. Teaching     — The day's lesson body.
+ *   3. Today's World — Modern real-life example + Gita implementation.
+ *   4. Reflection   — Numbered guided-reflection prompts.
+ *   5. Practice     — Daily practice with duration + numbered steps.
+ *   6. Micro-Commitment — One-line vow for the day.
  *
+ * An optional safety note is rendered after the six cards when applicable.
  * Designed to be embedded inside the step player ScrollView.
  */
 
@@ -20,6 +26,7 @@ import {
   radii,
 } from '@kiaanverse/ui';
 import { VerseCard } from './VerseCard';
+import type { JourneyModernExample } from '@kiaanverse/api';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,6 +45,8 @@ export interface StepContentSection {
   readonly englishTranslation?: string | undefined;
   /** Hindi translation (toggleable in VerseCard). */
   readonly hindiTranslation?: string | undefined;
+  /** "In Today's World" — modern example + Gita implementation. */
+  readonly modernExample?: JourneyModernExample | undefined;
   /** Array of guided reflection prompts. */
   readonly reflectionPrompts?: string[] | undefined;
   /** Practice name / title. */
@@ -76,7 +85,7 @@ function TeachingSection({
             {'\u{1F4D6}'}
           </Text>
           <Text variant="label" color={colors.divine.aura}>
-            Today&apos;s Teaching
+            Teaching
           </Text>
         </View>
         <Text
@@ -87,6 +96,110 @@ function TeachingSection({
           {text}
         </Text>
       </GlowCard>
+    </Animated.View>
+  );
+}
+
+/**
+ * "In Today's World" — Modern real-life example connected to a Gita verse.
+ *
+ * Renders three layers, mirroring the web mobile experience:
+ *   • Scenario      — the everyday situation the user recognises.
+ *   • Manifestation — how the inner enemy shows up in that scenario.
+ *   • Antidote      — the Gita-rooted practical response (with optional
+ *                     verse-ref chip when supplied).
+ */
+function TodaysWorldSection({
+  example,
+  accentColor,
+  delay,
+}: {
+  readonly example: JourneyModernExample;
+  readonly accentColor: string;
+  readonly delay: number;
+}): React.JSX.Element {
+  const verseLabel = example.gitaVerseRef
+    ? `BG ${example.gitaVerseRef.chapter}.${example.gitaVerseRef.verse}`
+    : null;
+
+  return (
+    <Animated.View entering={FadeInDown.delay(delay).duration(400)}>
+      <View
+        style={[
+          styles.todaysWorldCard,
+          {
+            borderColor: `${accentColor}33`,
+            borderLeftColor: accentColor,
+          },
+        ]}
+      >
+        <View style={styles.sectionHeader}>
+          <Text variant="h3" color={accentColor}>
+            {'✦'}
+          </Text>
+          <Text variant="label" color={accentColor}>
+            In Today&apos;s World
+          </Text>
+        </View>
+
+        {/* Scenario — the recognisable everyday situation. */}
+        <Text
+          variant="body"
+          color={colors.text.primary}
+          style={styles.todaysWorldScenario}
+        >
+          {example.scenario}
+        </Text>
+
+        {/* How the enemy manifests. */}
+        <Text
+          variant="bodySmall"
+          color={colors.text.secondary}
+          style={styles.todaysWorldManifestation}
+        >
+          {example.howEnemyManifests}
+        </Text>
+
+        {/* Hairline divider mirroring the web treatment. */}
+        <View
+          style={[
+            styles.todaysWorldDivider,
+            { backgroundColor: `${accentColor}33` },
+          ]}
+        />
+
+        {/* Gita implementation — verse chip + wisdom + practical antidote. */}
+        {verseLabel ? (
+          <View
+            style={[
+              styles.verseChip,
+              { backgroundColor: `${accentColor}1A`, borderColor: `${accentColor}55` },
+            ]}
+          >
+            <Text variant="caption" color={accentColor}>
+              {verseLabel}
+            </Text>
+          </View>
+        ) : null}
+
+        {example.gitaWisdom ? (
+          <Text
+            variant="bodySmall"
+            color={colors.text.secondary}
+            style={styles.todaysWorldWisdom}
+          >
+            {example.gitaWisdom}
+          </Text>
+        ) : null}
+
+        <Text
+          variant="body"
+          color={colors.text.primary}
+          style={styles.todaysWorldAntidote}
+        >
+          {example.practicalAntidote}
+        </Text>
+      </View>
     </Animated.View>
   );
 }
@@ -109,7 +222,7 @@ function ReflectionSection({
             {'\u{1F4AD}'}
           </Text>
           <Text variant="label" color={colors.divine.peacock}>
-            Guided Reflection
+            Reflection
           </Text>
         </View>
         {prompts.map((prompt, index) => (
@@ -161,7 +274,7 @@ function PracticeSection({
           </Text>
           <View style={styles.practiceHeaderText}>
             <Text variant="label" color={colors.semantic.success}>
-              {name ?? "Today's Practice"}
+              Practice
             </Text>
             {duration ? (
               <View style={styles.durationBadge}>
@@ -172,6 +285,11 @@ function PracticeSection({
             ) : null}
           </View>
         </View>
+        {name ? (
+          <Text variant="h3" color={colors.text.primary}>
+            {name}
+          </Text>
+        ) : null}
         {instructions.map((instruction, index) => (
           <View key={index} style={styles.numberedItem}>
             <View
@@ -199,7 +317,10 @@ function PracticeSection({
 }
 
 /**
- * Micro-commitment — single inspiring quote centered in a GlowCard.
+ * Micro-commitment — single inspiring quote in a cyan-bordered card.
+ *
+ * Mirrors the web treatment: an uppercase "MICRO COMMITMENT" eyebrow with
+ * the day's vow rendered as an italic, quoted line beneath.
  */
 function MicroCommitmentSection({
   text,
@@ -210,19 +331,23 @@ function MicroCommitmentSection({
 }): React.JSX.Element {
   return (
     <Animated.View entering={FadeInDown.delay(delay).duration(400)}>
-      <GlowCard variant="default" style={styles.commitmentCard}>
-        <Text variant="h3" color={colors.divine.aura} align="center">
-          {'\u{1F3AF}'}
-        </Text>
+      <View style={styles.commitmentCard}>
+        <View style={[styles.sectionHeader, styles.commitmentBorder]}>
+          <Text variant="h3" color={colors.divine.aura}>
+            {'\u{1F3AF}'}
+          </Text>
+          <Text variant="label" color={colors.divine.aura}>
+            Micro Commitment
+          </Text>
+        </View>
         <Text
           variant="body"
-          color={colors.text.secondary}
-          align="center"
+          color={colors.text.primary}
           style={styles.commitmentText}
         >
-          {text}
+          {`“${text}”`}
         </Text>
-      </GlowCard>
+      </View>
     </Animated.View>
   );
 }
@@ -242,7 +367,7 @@ function SafetySection({
       <View style={styles.safetyCard}>
         <View style={[styles.sectionHeader, styles.safetyBorder]}>
           <Text variant="h3" color={colors.semantic.warning}>
-            {'\u26A0\uFE0F'}
+            {'⚠️'}
           </Text>
           <Text variant="label" color={colors.semantic.warning}>
             Please Note
@@ -271,6 +396,7 @@ export function StepContent({
   transliteration,
   englishTranslation,
   hindiTranslation,
+  modernExample,
   reflectionPrompts,
   practiceName,
   practiceDuration,
@@ -280,14 +406,13 @@ export function StepContent({
   accentColor = colors.primary[500],
 }: StepContentSection): React.JSX.Element {
   let delayCounter = 0;
+  const next = () => (delayCounter += 100);
 
   return (
     <View style={styles.container}>
-      {/* Verse Section — the Sacred Heart */}
+      {/* CARD 1 — Verse (English + Sanskrit + Transliteration) */}
       {verseRef ? (
-        <Animated.View
-          entering={FadeInDown.delay((delayCounter += 100)).duration(500)}
-        >
+        <Animated.View entering={FadeInDown.delay(next()).duration(500)}>
           <VerseCard
             verseRef={verseRef}
             sanskrit={sanskrit}
@@ -299,41 +424,40 @@ export function StepContent({
         </Animated.View>
       ) : null}
 
-      {/* Teaching Section */}
-      {teaching ? (
-        <TeachingSection text={teaching} delay={(delayCounter += 100)} />
-      ) : null}
+      {/* CARD 2 — Teaching */}
+      {teaching ? <TeachingSection text={teaching} delay={next()} /> : null}
 
-      {/* Reflection Prompts */}
-      {reflectionPrompts && reflectionPrompts.length > 0 ? (
-        <ReflectionSection
-          prompts={reflectionPrompts}
-          delay={(delayCounter += 100)}
+      {/* CARD 3 — In Today's World (modern example + Gita implementation) */}
+      {modernExample ? (
+        <TodaysWorldSection
+          example={modernExample}
+          accentColor={accentColor}
+          delay={next()}
         />
       ) : null}
 
-      {/* Practice Instructions */}
+      {/* CARD 4 — Reflection */}
+      {reflectionPrompts && reflectionPrompts.length > 0 ? (
+        <ReflectionSection prompts={reflectionPrompts} delay={next()} />
+      ) : null}
+
+      {/* CARD 5 — Practice */}
       {practiceInstructions && practiceInstructions.length > 0 ? (
         <PracticeSection
           name={practiceName}
           duration={practiceDuration}
           instructions={practiceInstructions}
-          delay={(delayCounter += 100)}
+          delay={next()}
         />
       ) : null}
 
-      {/* Micro-Commitment */}
+      {/* CARD 6 — Micro Commitment */}
       {microCommitment ? (
-        <MicroCommitmentSection
-          text={microCommitment}
-          delay={(delayCounter += 100)}
-        />
+        <MicroCommitmentSection text={microCommitment} delay={next()} />
       ) : null}
 
-      {/* Safety Notes */}
-      {safetyNotes ? (
-        <SafetySection text={safetyNotes} delay={(delayCounter += 100)} />
-      ) : null}
+      {/* Optional safety note (after the six required cards). */}
+      {safetyNotes ? <SafetySection text={safetyNotes} delay={next()} /> : null}
 
       <SacredDivider />
     </View>
@@ -367,6 +491,9 @@ const styles = StyleSheet.create({
   },
   practiceBorder: {
     borderLeftColor: colors.semantic.success,
+  },
+  commitmentBorder: {
+    borderLeftColor: colors.divine.aura,
   },
   safetyBorder: {
     borderLeftColor: colors.semantic.warning,
@@ -403,10 +530,49 @@ const styles = StyleSheet.create({
     flex: 1,
     lineHeight: 22,
   },
-  commitmentCard: {
+
+  // Today's World
+  todaysWorldCard: {
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderLeftWidth: 3,
     padding: spacing.lg,
     gap: spacing.sm,
-    alignItems: 'center',
+    backgroundColor: colors.alpha.whiteLight,
+  },
+  todaysWorldScenario: {
+    fontStyle: 'italic',
+    lineHeight: 24,
+  },
+  todaysWorldManifestation: {
+    lineHeight: 22,
+  },
+  todaysWorldDivider: {
+    height: 1,
+    marginVertical: spacing.xs,
+  },
+  todaysWorldWisdom: {
+    fontStyle: 'italic',
+    lineHeight: 22,
+  },
+  todaysWorldAntidote: {
+    lineHeight: 24,
+  },
+  verseChip: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: radii.full,
+    borderWidth: 1,
+  },
+
+  commitmentCard: {
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    borderColor: `${colors.divine.aura}33`,
+    backgroundColor: `${colors.divine.aura}0A`,
+    padding: spacing.lg,
+    gap: spacing.sm,
   },
   commitmentText: {
     fontStyle: 'italic',

--- a/kiaanverse-mobile/packages/api/src/hooks.ts
+++ b/kiaanverse-mobile/packages/api/src/hooks.ts
@@ -59,6 +59,7 @@ import type {
   WeeklyInsight,
   WisdomJourneyDetail,
   WisdomJourneyStep,
+  JourneyPracticeBlock,
   WisdomRoom,
   WisdomRoomMessage,
 } from './types';
@@ -665,6 +666,32 @@ export function useJourneyDashboard(): UseQueryResult<DashboardData> {
  * Backend step response (GET /journeys/{id}/steps/{day_index}).
  * Mirrors StepResponse in backend/routes/journey_engine.py.
  */
+interface RawVerse {
+  chapter: number;
+  verse: number;
+  sanskrit?: string | null;
+  hindi?: string | null;
+  english?: string;
+  transliteration?: string | null;
+  theme?: string | null;
+}
+
+interface RawModernExample {
+  category: string;
+  scenario: string;
+  how_enemy_manifests: string;
+  gita_verse_ref: { chapter: number; verse: number };
+  gita_wisdom: string;
+  practical_antidote: string;
+  reflection_question: string;
+}
+
+interface RawPractice {
+  name?: string;
+  duration_minutes?: number;
+  instructions?: unknown;
+}
+
 interface RawStep {
   step_id: string;
   journey_id: string;
@@ -673,12 +700,39 @@ interface RawStep {
   teaching: string;
   guided_reflection?: string[];
   verse_refs?: Array<{ chapter: number; verse: number }>;
+  verses?: RawVerse[];
+  practice?: RawPractice | null;
+  micro_commitment?: string | null;
+  safety_note?: string | null;
   is_completed: boolean;
+  /** Flattened sacred fields from the backend. */
+  verse_ref?: { chapter: number; verse: number } | null;
+  verse_sanskrit?: string | null;
+  verse_transliteration?: string | null;
+  verse_translation?: string | null;
+  reflection_prompt?: string | null;
+  modern_example?: RawModernExample | null;
 }
 
 function _mapStep(s: RawStep): WisdomJourneyStep {
-  const firstVerse = s.verse_refs?.[0];
-  const reflectionText = (s.guided_reflection ?? []).join('\n\n');
+  // Prefer the flattened sacred fields populated by the backend's
+  // _step_to_response helper, falling back to the legacy verses[] payload
+  // so older deployments remain renderable.
+  const flatRef = s.verse_ref ?? null;
+  const firstLegacyVerse = s.verses?.[0];
+  const refSource = flatRef ?? firstLegacyVerse ?? s.verse_refs?.[0] ?? null;
+
+  const reflectionPrompts = Array.isArray(s.guided_reflection)
+    ? s.guided_reflection.filter((p): p is string => typeof p === 'string' && p.trim().length > 0)
+    : [];
+  const reflectionText = reflectionPrompts.join('\n\n');
+
+  const sanskrit = s.verse_sanskrit ?? firstLegacyVerse?.sanskrit ?? undefined;
+  const transliteration =
+    s.verse_transliteration ?? firstLegacyVerse?.transliteration ?? undefined;
+  const translation = s.verse_translation ?? firstLegacyVerse?.english ?? undefined;
+  const hindi = firstLegacyVerse?.hindi ?? undefined;
+
   const step: WisdomJourneyStep = {
     id: s.step_id,
     dayIndex: s.day_index,
@@ -691,8 +745,57 @@ function _mapStep(s: RawStep): WisdomJourneyStep {
     xpReward: 10,
     karmaReward: 5,
   };
-  if (firstVerse) step.verseRef = `${firstVerse.chapter}.${firstVerse.verse}`;
+  if (refSource) step.verseRef = `${refSource.chapter}.${refSource.verse}`;
+  if (sanskrit) step.verseSanskrit = sanskrit;
+  if (transliteration) step.verseTransliteration = transliteration;
+  if (translation) step.verseTranslation = translation;
+  if (hindi) step.verseHindi = hindi;
   if (reflectionText) step.reflection = reflectionText;
+  if (reflectionPrompts.length > 0) step.reflectionPrompts = reflectionPrompts;
+
+  if (s.modern_example) {
+    const me = s.modern_example;
+    step.modernExample = {
+      category: me.category,
+      scenario: me.scenario,
+      howEnemyManifests: me.how_enemy_manifests,
+      gitaVerseRef: me.gita_verse_ref,
+      gitaWisdom: me.gita_wisdom,
+      practicalAntidote: me.practical_antidote,
+      reflectionQuestion: me.reflection_question,
+    };
+  }
+
+  if (s.practice && typeof s.practice === 'object') {
+    const rawInstructions = Array.isArray(s.practice.instructions)
+      ? s.practice.instructions
+      : [];
+    const instructions = rawInstructions
+      .map((i) => (typeof i === 'string' ? i.trim() : ''))
+      .filter((i): i is string => i.length > 0);
+    if (
+      instructions.length > 0 ||
+      typeof s.practice.name === 'string' ||
+      typeof s.practice.duration_minutes === 'number'
+    ) {
+      const block: JourneyPracticeBlock = { instructions };
+      if (typeof s.practice.name === 'string' && s.practice.name.trim().length > 0) {
+        block.name = s.practice.name.trim();
+      }
+      if (typeof s.practice.duration_minutes === 'number') {
+        block.durationMinutes = s.practice.duration_minutes;
+      }
+      step.practice = block;
+    }
+  }
+
+  if (typeof s.micro_commitment === 'string' && s.micro_commitment.trim().length > 0) {
+    step.microCommitment = s.micro_commitment.trim();
+  }
+  if (typeof s.safety_note === 'string' && s.safety_note.trim().length > 0) {
+    step.safetyNote = s.safety_note.trim();
+  }
+
   return step;
 }
 

--- a/kiaanverse-mobile/packages/api/src/index.ts
+++ b/kiaanverse-mobile/packages/api/src/index.ts
@@ -128,6 +128,8 @@ export type {
   JourneyCategory,
   WisdomJourneyStep,
   WisdomJourneyDetail,
+  JourneyModernExample,
+  JourneyPracticeBlock,
   StepCompletionResult,
   UserJourneyProgress,
   Journey,

--- a/kiaanverse-mobile/packages/api/src/types.ts
+++ b/kiaanverse-mobile/packages/api/src/types.ts
@@ -357,15 +357,60 @@ export type JourneyDifficulty = 'beginner' | 'intermediate' | 'advanced';
 /** Category for wisdom journey paths */
 export type JourneyCategory = 'beginner_paths' | 'deep_dives' | '21_day_challenges';
 
+/**
+ * Modern real-life example for the "In Today's World" card. Mirrors the
+ * backend ModernExampleOut payload — every step exposes a deterministically
+ * picked example (per enemy + day) so the UI can always render the
+ * 6-card sequence (Verse → Teaching → Today's World → Reflection →
+ * Practice → Micro-Commitment).
+ */
+export interface JourneyModernExample {
+  category: string;
+  scenario: string;
+  howEnemyManifests: string;
+  gitaVerseRef: { chapter: number; verse: number };
+  gitaWisdom: string;
+  practicalAntidote: string;
+  reflectionQuestion: string;
+}
+
+/** Structured practice block for the daily step. */
+export interface JourneyPracticeBlock {
+  name?: string;
+  durationMinutes?: number;
+  instructions: string[];
+}
+
 /** A step within a wisdom journey with type-specific content */
 export interface WisdomJourneyStep {
   id: string;
   dayIndex: number;
   title: string;
   type: JourneyStepType;
+  /** Raw teaching/lesson body — kept for backwards compatibility. */
   content: string;
+  /** Chapter.Verse reference, e.g. "2.47". */
   verseRef?: string;
+  /** Sanskrit (Devanagari) verse text. */
+  verseSanskrit?: string;
+  /** Romanised IAST/ITRANS transliteration. */
+  verseTransliteration?: string;
+  /** English translation of the verse. */
+  verseTranslation?: string;
+  /** Hindi translation of the verse (toggle in VerseCard). */
+  verseHindi?: string;
+  /** Joined guided reflection prompts (legacy). */
   reflection?: string;
+  /** Structured guided-reflection prompts. */
+  reflectionPrompts?: string[];
+  /** Modern real-life "In Today's World" example. */
+  modernExample?: JourneyModernExample;
+  /** Structured daily practice (name, duration, numbered instructions). */
+  practice?: JourneyPracticeBlock;
+  /** Single-sentence micro-commitment — the day's vow. */
+  microCommitment?: string;
+  /** Optional safety / trigger note. */
+  safetyNote?: string;
   isCompleted: boolean;
   /** XP earned for completing this step */
   xpReward: number;


### PR DESCRIPTION
Every Bhagavad Gita journey day now surfaces the six fixed cards the spec
mandates, in this exact order:

  1. Verse           — BG ref + Sanskrit + transliteration + English (+ Hindi)
  2. Teaching        — the day's lesson body
  3. In Today's World — modern real-life scenario + Gita implementation
  4. Reflection      — numbered guided-reflection prompts
  5. Practice        — daily practice with name, duration and steps
  6. Micro Commitment — the day's vow, italicised and quoted

The existing step screen rendered only Teaching/Reflection/Practice/Micro-
Commitment from a markdown-parsed teaching blob, dropping the verse details
and the modern example entirely. Backend already returns all six pieces via
StepResponse (verse_sanskrit/transliteration/translation, modern_example,
practice, micro_commitment, safety_note) — we just weren't carrying them
through the API layer.

Changes:

* packages/api/src/types.ts — extend WisdomJourneyStep with structured
  fields (verseSanskrit / verseTransliteration / verseTranslation /
  verseHindi, reflectionPrompts, modernExample, practice block,
  microCommitment, safetyNote) and add JourneyModernExample and
  JourneyPracticeBlock types mirroring the backend payload.

* packages/api/src/hooks.ts — extend RawStep + _mapStep to read the
  flattened sacred fields and the modern_example / practice / micro
  blocks from the backend, falling back to legacy verses[] when the
  flattened block isn't populated.

* components/journey/StepContent.tsx — add TodaysWorldSection (scenario
  + manifestation + verse-ref chip + Gita wisdom + practical antidote)
  and wire the six cards in canonical order. Practice section now
  renders the practice name and the duration chip.

* app/journey/step/[day].tsx — prefer the structured step fields, keep
  markdown fallback so legacy seed data still works, pass everything
  down to StepContent. Replace the always-visible reflection textarea
  with the "Add Reflection (Optional)" toggle (matching the web design)
  that reveals the textarea on tap and sits directly above the
  "Complete Today's Step" button.

All 153 mobile tests pass. tsc clean across @kiaanverse/api and
kiaanverse-mobile-app.

https://claude.ai/code/session_01Cc1zZ3DgADz1UbbxqT9ruL