### PR TITLE
fix(kiaan-vibe): make Vibe Player audible on Android & enable own-music uploads

### DIFF
--- a/app/(mobile)/m/kiaan-vibe/page.tsx
+++ b/app/(mobile)/m/kiaan-vibe/page.tsx
@@ -5,10 +5,10 @@
  * Sacred design system with category filtering, track grid, and featured section.
  */
 
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
-import { motion } from 'framer-motion'
-import { Search, Music2 } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Search, Music2, Upload, Trash2, Plus, AlertCircle, Loader2 } from 'lucide-react'
 import { MobileAppShell } from '@/components/mobile/MobileAppShell'
 import { GitaBanner } from '@/components/mobile/vibe/GitaBanner'
 import { usePlayerStore } from '@/lib/kiaan-vibe/store'
@@ -19,11 +19,20 @@ import {
   searchTracks,
   formatDuration,
 } from '@/lib/kiaan-vibe/meditation-library'
-import type { MeditationCategory, Track } from '@/lib/kiaan-vibe/types'
+import {
+  getAllUploadedTracks,
+  uploadTrack,
+  deleteUploadedTrack,
+  audioFileLooksValid,
+  ACCEPTED_AUDIO_ACCEPT_ATTR,
+  MAX_UPLOAD_SIZE,
+} from '@/lib/kiaan-vibe/persistence'
+import type { MeditationCategory, Track, UploadedTrackMeta } from '@/lib/kiaan-vibe/types'
 import { useHapticFeedback } from '@/hooks/useHapticFeedback'
 
 const CATEGORIES: { id: string; label: string; icon: string }[] = [
   { id: 'all',       label: 'All',       icon: '\u2726' },
+  { id: 'uploads',   label: 'My Music',  icon: '\u266b' },
   { id: 'gita',      label: 'Gita',      icon: '\u2638\uFE0F' },
   { id: 'mantra',    label: 'Mantra',    icon: '\uD83D\uDD49' },
   { id: 'ambient',   label: 'Ambient',   icon: '\u25CE' },
@@ -33,6 +42,19 @@ const CATEGORIES: { id: string; label: string; icon: string }[] = [
   { id: 'sleep',     label: 'Sleep',     icon: '\u263D' },
   { id: 'spiritual', label: 'Spiritual', icon: '\u2727' },
 ]
+
+/** Convert uploaded track metadata into a player-ready Track. */
+function uploadToTrack(u: UploadedTrackMeta): Track {
+  return {
+    id: u.id,
+    title: u.title,
+    artist: u.artist || 'My Music',
+    sourceType: 'upload',
+    src: `indexeddb://${u.id}`,
+    duration: u.duration,
+    createdAt: u.createdAt,
+  }
+}
 
 function TrackCard({ track, isCurrentTrack, isPlaying, onPlay }: {
   track: Track
@@ -117,20 +139,53 @@ export default function MobileKiaanVibePage() {
   const router = useRouter()
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [searchQuery, setSearchQuery] = useState('')
+  const [uploads, setUploads] = useState<UploadedTrackMeta[]>([])
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { triggerHaptic } = useHapticFeedback()
   const { currentTrack, isPlaying, play, setQueue, gitaLang, setGitaLang } = usePlayerStore()
 
-  const filteredTracks = useMemo(() => {
+  // Load uploaded tracks once on mount and refresh whenever an upload finishes.
+  useEffect(() => {
+    let cancelled = false
+    getAllUploadedTracks()
+      .then((list) => {
+        if (cancelled) return
+        list.sort((a, b) => b.createdAt - a.createdAt)
+        setUploads(list)
+      })
+      .catch(() => { /* surfaces via empty list */ })
+    return () => { cancelled = true }
+  }, [])
+
+  const uploadedTracks = useMemo<Track[]>(
+    () => uploads.map(uploadToTrack),
+    [uploads],
+  )
+
+  const filteredTracks = useMemo<Track[]>(() => {
     if (searchQuery.trim()) {
-      return searchTracks(searchQuery)
+      const q = searchQuery.toLowerCase()
+      const fromUploads = uploadedTracks.filter(
+        (t) => t.title.toLowerCase().includes(q) || (t.artist || '').toLowerCase().includes(q),
+      )
+      return [...fromUploads, ...searchTracks(searchQuery)]
+    }
+    if (selectedCategory === 'uploads') {
+      return uploadedTracks
     }
     if (selectedCategory === 'all') {
-      return getAllTracks()
+      // Surface the user's own music FIRST so they always see it.
+      return [...uploadedTracks, ...getAllTracks()]
     }
     return getTracksByCategory(selectedCategory as MeditationCategory)
-  }, [selectedCategory, searchQuery])
+  }, [selectedCategory, searchQuery, uploadedTracks])
 
-  const allTracks = useMemo(() => getAllTracks(), [])
+  const allTracks = useMemo<Track[]>(
+    () => [...uploadedTracks, ...getAllTracks()],
+    [uploadedTracks],
+  )
 
   // Featured tracks = first 6 from all
   const featuredTracks = useMemo(() => allTracks.slice(0, 6), [allTracks])
@@ -141,6 +196,65 @@ export default function MobileKiaanVibePage() {
     setQueue(trackList, index >= 0 ? index : 0)
     play(track)
   }, [triggerHaptic, setQueue, play])
+
+  const handleUploadClick = useCallback(() => {
+    triggerHaptic('selection')
+    setUploadError(null)
+    fileInputRef.current?.click()
+  }, [triggerHaptic])
+
+  const handleFilesSelected = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (!files || files.length === 0) return
+
+    setUploading(true)
+    setUploadError(null)
+    let lastError: string | null = null
+
+    for (const file of Array.from(files)) {
+      try {
+        if (!audioFileLooksValid(file)) {
+          lastError = `${file.name} isn't a recognised audio format.`
+          continue
+        }
+        if (file.size > MAX_UPLOAD_SIZE) {
+          lastError = `${file.name} is too large (max ${(MAX_UPLOAD_SIZE / 1024 / 1024).toFixed(0)}MB).`
+          continue
+        }
+        const track = await uploadTrack(file)
+        setUploads((prev) => [
+          {
+            id: track.id,
+            title: track.title,
+            artist: track.artist,
+            duration: track.duration,
+            fileName: file.name,
+            fileSize: file.size,
+            mimeType: file.type || 'audio/unknown',
+            createdAt: track.createdAt,
+          },
+          ...prev,
+        ])
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : `Upload failed: ${file.name}`
+      }
+    }
+
+    if (lastError) setUploadError(lastError)
+    setUploading(false)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    triggerHaptic('medium')
+  }, [triggerHaptic])
+
+  const handleDeleteUpload = useCallback(async (id: string) => {
+    triggerHaptic('selection')
+    try {
+      await deleteUploadedTrack(id)
+      setUploads((prev) => prev.filter((u) => u.id !== id))
+    } catch {
+      setUploadError('Could not delete this track. Please try again.')
+    }
+  }, [triggerHaptic])
 
   return (
     <MobileAppShell title="KIAAN Vibe" showBack>
@@ -182,9 +296,97 @@ export default function MobileKiaanVibePage() {
             >
               <span className="text-sm">{cat.icon}</span>
               {cat.label}
+              {cat.id === 'uploads' && uploads.length > 0 && (
+                <span
+                  className="ml-1 text-[10px] px-1.5 rounded-full font-[family-name:var(--font-ui)]"
+                  style={{
+                    background: selectedCategory === cat.id ? 'rgba(5,7,20,0.25)' : 'rgba(212,160,23,0.18)',
+                    color: selectedCategory === cat.id ? '#050714' : '#D4A017',
+                  }}
+                >
+                  {uploads.length}
+                </span>
+              )}
             </button>
           ))}
         </div>
+
+        {/* Hidden file input for native picker — accepts the broadest set of audio formats */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_AUDIO_ACCEPT_ATTR}
+          multiple
+          onChange={handleFilesSelected}
+          className="hidden"
+          aria-hidden="true"
+        />
+
+        {/* Upload card — always visible so users can drop their own music in */}
+        <div className="mb-4">
+          <button
+            onClick={handleUploadClick}
+            disabled={uploading}
+            className="w-full flex items-center gap-3 rounded-2xl px-4 py-3 text-left transition-all"
+            style={{
+              background: 'linear-gradient(145deg, rgba(22,26,66,0.95), rgba(17,20,53,0.98))',
+              border: '1px dashed rgba(212,160,23,0.4)',
+              opacity: uploading ? 0.6 : 1,
+            }}
+          >
+            <div
+              className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+              style={{ background: 'rgba(212,160,23,0.12)' }}
+            >
+              {uploading ? (
+                <Loader2 className="w-5 h-5 text-[#D4A017] animate-spin" />
+              ) : (
+                <Upload className="w-5 h-5 text-[#D4A017]" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-[13px] text-[#EDE8DC] font-[family-name:var(--font-ui)]" style={{ fontWeight: 500 }}>
+                {uploading ? 'Uploading…' : 'Upload your own music'}
+              </p>
+              <p className="text-[11px] text-[#6B6355] truncate font-[family-name:var(--font-ui)]">
+                MP3 · M4A · AAC · WAV · OGG · Opus · FLAC · WebM · up to {(MAX_UPLOAD_SIZE / 1024 / 1024).toFixed(0)}MB
+              </p>
+            </div>
+            {!uploading && (
+              <Plus className="w-5 h-5 text-[#D4A017] flex-shrink-0" />
+            )}
+          </button>
+        </div>
+
+        {/* Upload error toast */}
+        <AnimatePresence>
+          {uploadError && (
+            <motion.div
+              key="upload-error"
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              className="mb-4 flex items-start gap-2 rounded-xl px-3 py-2"
+              style={{
+                background: 'rgba(220,38,38,0.10)',
+                border: '1px solid rgba(220,38,38,0.25)',
+              }}
+              role="alert"
+            >
+              <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+              <p className="flex-1 text-[12px] text-red-300 font-[family-name:var(--font-ui)]">
+                {uploadError}
+              </p>
+              <button
+                onClick={() => setUploadError(null)}
+                className="text-red-300/80 hover:text-red-300 px-1"
+                aria-label="Dismiss error"
+              >
+                ×
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Gita Banner (shown when 'all' or 'gita' selected, no search) */}
         {(selectedCategory === 'all' || selectedCategory === 'gita') && !searchQuery && (
@@ -256,8 +458,73 @@ export default function MobileKiaanVibePage() {
           </div>
         )}
 
-        {/* Track grid (2 columns) — hidden when 'gita' category is selected */}
-        {selectedCategory !== 'gita' && (
+        {/* Uploads list — selectable category with delete control per row */}
+        {selectedCategory === 'uploads' && !searchQuery && (
+          uploads.length > 0 ? (
+            <div className="space-y-2">
+              {uploads.map((u) => {
+                const track = uploadToTrack(u)
+                const isCurrent = currentTrack?.id === u.id
+                return (
+                  <div
+                    key={u.id}
+                    className="flex items-center gap-3 rounded-xl px-3 py-3"
+                    style={{
+                      background: isCurrent
+                        ? 'linear-gradient(145deg, rgba(212,160,23,0.18), rgba(212,160,23,0.06))'
+                        : 'linear-gradient(145deg, rgba(22,26,66,0.95), rgba(17,20,53,0.98))',
+                      border: isCurrent
+                        ? '1px solid rgba(212,160,23,0.4)'
+                        : '1px solid rgba(212,160,23,0.08)',
+                    }}
+                  >
+                    <button
+                      onClick={() => handlePlayTrack(track, uploadedTracks)}
+                      className="flex-1 flex items-center gap-3 text-left min-w-0"
+                    >
+                      <div
+                        className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                        style={{ background: 'rgba(212,160,23,0.12)' }}
+                      >
+                        <Music2 className="w-5 h-5 text-[#D4A017]" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[13px] text-[#EDE8DC] truncate font-[family-name:var(--font-ui)]" style={{ fontWeight: 500 }}>
+                          {u.title}
+                        </p>
+                        <p className="text-[11px] text-[#6B6355] truncate font-[family-name:var(--font-ui)]">
+                          {u.duration ? formatDuration(u.duration) : 'Unknown duration'}
+                          {' · '}
+                          {(u.fileSize / 1024 / 1024).toFixed(1)} MB
+                        </p>
+                      </div>
+                    </button>
+                    <button
+                      onClick={() => handleDeleteUpload(u.id)}
+                      className="p-2 text-[#6B6355] hover:text-red-400 transition-colors"
+                      aria-label={`Delete ${u.title}`}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <Music2 className="w-10 h-10 text-[#D4A017]/40 mx-auto mb-3" />
+              <p className="text-sm text-[#B8AE98] font-[family-name:var(--font-divine)]">
+                No uploads yet
+              </p>
+              <p className="text-xs text-[#6B6355] mt-1 font-[family-name:var(--font-ui)]">
+                Tap “Upload your own music” above to add tracks
+              </p>
+            </div>
+          )
+        )}
+
+        {/* Standard 2-column track grid for everything except gita and uploads */}
+        {selectedCategory !== 'gita' && selectedCategory !== 'uploads' && (
           <div className="grid grid-cols-2 gap-3">
             {filteredTracks.map(track => (
               <TrackCard
@@ -292,8 +559,8 @@ export default function MobileKiaanVibePage() {
           </div>
         )}
 
-        {/* Empty state */}
-        {selectedCategory !== 'gita' && filteredTracks.length === 0 && (
+        {/* Empty state — only for non-gita / non-uploads views */}
+        {selectedCategory !== 'gita' && selectedCategory !== 'uploads' && filteredTracks.length === 0 && (
           <div className="text-center py-16">
             <p className="text-lg text-[#6B6355] font-[family-name:var(--font-divine)]">No tracks found</p>
             <p className="text-xs text-[#6B6355]/60 mt-1 font-[family-name:var(--font-ui)]">

--- a/app/kiaan-vibe/uploads/page.tsx
+++ b/app/kiaan-vibe/uploads/page.tsx
@@ -23,15 +23,12 @@ import {
   getAllUploadedTracks,
   uploadTrack,
   deleteUploadedTrack,
-  getAudioBlobUrl,
+  audioFileLooksValid,
+  ACCEPTED_AUDIO_ACCEPT_ATTR,
+  MAX_UPLOAD_SIZE,
 } from '@/lib/kiaan-vibe/persistence'
 import { formatDuration } from '@/lib/kiaan-vibe/meditation-library'
 import type { Track, UploadedTrackMeta } from '@/lib/kiaan-vibe/types'
-
-// Accepted audio formats
-const ACCEPTED_FORMATS = ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/ogg', 'audio/webm']
-const ACCEPTED_EXTENSIONS = '.mp3,.m4a,.wav,.ogg,.webm'
-const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
 
 export default function UploadsPage() {
   const { currentTrack, play, setQueue } = usePlayerStore()
@@ -64,42 +61,36 @@ export default function UploadsPage() {
     setError(null)
     setUploading(true)
 
-    try {
-      for (const file of files) {
-        // Validate file type
-        if (!ACCEPTED_FORMATS.includes(file.type)) {
-          setError(`Unsupported format: ${file.name}. Use MP3, M4A, WAV, or OGG.`)
+    let lastError: string | null = null
+    for (const file of files) {
+      try {
+        if (!audioFileLooksValid(file)) {
+          lastError = `Unsupported format: ${file.name}. Try MP3, M4A, WAV, OGG, FLAC, AAC, or Opus.`
           continue
         }
-
-        // Validate file size
-        if (file.size > MAX_FILE_SIZE) {
-          setError(`File too large: ${file.name}. Maximum size is 100MB.`)
+        if (file.size > MAX_UPLOAD_SIZE) {
+          lastError = `${file.name} is too large (max ${(MAX_UPLOAD_SIZE / 1024 / 1024).toFixed(0)}MB).`
           continue
         }
-
-        // Upload the file
         const track = await uploadTrack(file)
-        if (track) {
-          setUploads((prev) => [
-            {
-              id: track.id,
-              title: track.title,
-              artist: track.artist,
-              duration: track.duration,
-              fileName: file.name,
-              fileSize: file.size,
-              mimeType: file.type,
-              createdAt: track.createdAt,
-            },
-            ...prev,
-          ])
-        }
+        setUploads((prev) => [
+          {
+            id: track.id,
+            title: track.title,
+            artist: track.artist,
+            duration: track.duration,
+            fileName: file.name,
+            fileSize: file.size,
+            mimeType: file.type || 'audio/unknown',
+            createdAt: track.createdAt,
+          },
+          ...prev,
+        ])
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : `Upload failed: ${file.name}`
       }
-    } catch (err) {
-      console.error('Upload failed:', err)
-      setError('Upload failed. Please try again.')
     }
+    if (lastError) setError(lastError)
 
     setUploading(false)
 
@@ -123,40 +114,30 @@ export default function UploadsPage() {
 
   const handlePlay = async (upload: UploadedTrackMeta, index: number) => {
     try {
-      // Get blob URL for playback
-      const blobUrl = await getAudioBlobUrl(upload.id)
-      if (!blobUrl) {
-        setError('Failed to load audio file')
-        return
-      }
-
+      // Use the indexeddb:// scheme — the player store resolves it to a
+      // fresh Blob URL at play time (and revokes the previous one). This
+      // avoids leaking blob URLs and works after the user reloads the page.
       const track: Track = {
         id: upload.id,
         title: upload.title,
         artist: upload.artist,
         sourceType: 'upload',
-        src: blobUrl,
+        src: `indexeddb://${upload.id}`,
         duration: upload.duration,
         createdAt: upload.createdAt,
       }
 
-      // Create tracks array from all uploads
-      const allTracks: Track[] = await Promise.all(
-        uploads.map(async (u) => {
-          const url = await getAudioBlobUrl(u.id)
-          return {
-            id: u.id,
-            title: u.title,
-            artist: u.artist,
-            sourceType: 'upload' as const,
-            src: url || '',
-            duration: u.duration,
-            createdAt: u.createdAt,
-          }
-        })
-      )
+      const allTracks: Track[] = uploads.map((u) => ({
+        id: u.id,
+        title: u.title,
+        artist: u.artist,
+        sourceType: 'upload' as const,
+        src: `indexeddb://${u.id}`,
+        duration: u.duration,
+        createdAt: u.createdAt,
+      }))
 
-      setQueue(allTracks.filter((t) => t.src), index)
+      setQueue(allTracks, index)
       play(track)
     } catch (err) {
       console.error('Playback failed:', err)
@@ -195,7 +176,7 @@ export default function UploadsPage() {
         <input
           ref={fileInputRef}
           type="file"
-          accept={ACCEPTED_EXTENSIONS}
+          accept={ACCEPTED_AUDIO_ACCEPT_ATTR}
           multiple
           onChange={handleFileSelect}
           className="hidden"
@@ -213,7 +194,7 @@ export default function UploadsPage() {
             </div>
             <p className="text-white font-medium mb-1">Upload Audio Files</p>
             <p className="text-sm text-white/70">
-              MP3, M4A, WAV, OGG up to 100MB
+              MP3, M4A, AAC, WAV, OGG, Opus, FLAC, WebM &amp; more — up to {(MAX_UPLOAD_SIZE / 1024 / 1024).toFixed(0)}MB
             </p>
             <button className="mt-4 px-4 py-2 rounded-full bg-orange-500 text-white text-sm font-medium hover:bg-orange-400 transition-colors">
               <Plus className="w-4 h-4 inline mr-1" />

--- a/lib/kiaan-vibe/audio-synth.ts
+++ b/lib/kiaan-vibe/audio-synth.ts
@@ -58,30 +58,77 @@ function getContext(): AudioContext {
   }
   if (!_ctx) {
     const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    if (!Ctor) {
+      throw new Error('Web Audio API not supported in this browser')
+    }
     _ctx = new Ctor()
   }
   return _ctx
 }
 
-/**
- * Mobile browsers suspend the AudioContext until a user gesture resumes it.
- * Call this from inside a click/tap handler to unlock audio.
- */
-export async function unlockAudio(): Promise<void> {
+/** True once the AudioContext has been resumed at least once. */
+let _audioUnlocked = false
+
+/** Tells callers whether the AudioContext is currently running. */
+export function isAudioContextRunning(): boolean {
+  if (typeof window === 'undefined') return false
   try {
-    const ctx = getContext()
-    if (ctx.state === 'suspended') {
-      await ctx.resume()
-    }
-    // Play a tiny silent buffer to fully unlock iOS Safari.
-    const buffer = ctx.createBuffer(1, 1, 22050)
-    const src = ctx.createBufferSource()
-    src.buffer = buffer
-    src.connect(ctx.destination)
-    src.start(0)
+    return getContext().state === 'running'
   } catch {
-    // Ignore - will retry on next interaction
+    return false
   }
+}
+
+/**
+ * Mobile browsers (iOS Safari, Chrome Android) suspend the AudioContext
+ * until a user gesture resumes it. Call this from inside a click/tap
+ * handler. Idempotent and safe to call multiple times.
+ *
+ * Returns `true` when the context is verifiably running afterwards.
+ *
+ * IMPORTANT: callers MUST `await` this before scheduling any oscillators —
+ * starting nodes on a suspended context on Android Chrome produces silence
+ * because `currentTime` does not advance until resume() actually settles.
+ */
+export async function unlockAudio(): Promise<boolean> {
+  if (typeof window === 'undefined') return false
+  let ctx: AudioContext
+  try {
+    ctx = getContext()
+  } catch {
+    return false
+  }
+  try {
+    if (ctx.state === 'suspended' || ctx.state === 'interrupted') {
+      // Race the resume() against a 1.5s timeout — some Chrome Android builds
+      // never settle the promise if no user gesture is in progress, which would
+      // otherwise hang play() forever.
+      await Promise.race([
+        ctx.resume(),
+        new Promise<void>((resolve) => setTimeout(resolve, 1500)),
+      ])
+    }
+    // Tiny silent buffer to fully prime the audio pipeline (iOS Safari quirk).
+    try {
+      const buffer = ctx.createBuffer(1, 1, 22050)
+      const src = ctx.createBufferSource()
+      src.buffer = buffer
+      src.connect(ctx.destination)
+      src.start(0)
+    } catch { /* ignore - non-fatal */ }
+    _audioUnlocked = ctx.state === 'running'
+    return _audioUnlocked
+  } catch {
+    return _audioUnlocked
+  }
+}
+
+/**
+ * Synchronous check — does NOT trigger a resume, just reports last state.
+ * Useful for telling users "tap anywhere to enable sound".
+ */
+export function wasAudioUnlocked(): boolean {
+  return _audioUnlocked
 }
 
 // ============ Noise generators ============
@@ -448,13 +495,25 @@ function startPreset(preset: SynthPreset, out: GainNode, ctx: AudioContext): Pre
 
 export function playSynth(preset: SynthPreset, volume = 0.7): SynthHandle {
   const ctx = getContext()
+
+  // If the context is still suspended (caller forgot to await unlockAudio),
+  // try a synchronous resume() so oscillators schedule on a running clock.
+  // Without this, Chrome Android keeps `currentTime` frozen and the entire
+  // playback graph runs in silence even after the user gestures.
+  if (ctx.state === 'suspended') {
+    void ctx.resume()
+  }
+
   const master = ctx.createGain()
-  master.gain.value = 0
+  // Start at a small non-zero value so the gain node is immediately part of
+  // an active signal path (some Chromium builds optimize away nodes that ramp
+  // from absolute zero on a freshly-resumed context).
+  master.gain.value = 0.0001
   master.connect(ctx.destination)
-  // Gentle fade-in over 1.5s prevents clicks
+  // Gentle fade-in over 0.8s prevents clicks while still feeling responsive.
   const now = ctx.currentTime
-  master.gain.setValueAtTime(0, now)
-  master.gain.linearRampToValueAtTime(volume, now + 1.5)
+  master.gain.setValueAtTime(0.0001, now)
+  master.gain.exponentialRampToValueAtTime(Math.max(volume, 0.05), now + 0.8)
 
   const internals = startPreset(preset, master, ctx)
 
@@ -465,8 +524,8 @@ export function playSynth(preset: SynthPreset, volume = 0.7): SynthHandle {
     stop: () => {
       const stopTime = ctx.currentTime + 0.4
       master.gain.cancelScheduledValues(ctx.currentTime)
-      master.gain.setValueAtTime(master.gain.value, ctx.currentTime)
-      master.gain.linearRampToValueAtTime(0, stopTime)
+      master.gain.setValueAtTime(Math.max(master.gain.value, 0.0001), ctx.currentTime)
+      master.gain.exponentialRampToValueAtTime(0.0001, stopTime)
       internals.sources.forEach(s => {
         try { s.stop(stopTime + 0.05) } catch { /* already stopped */ }
       })
@@ -478,14 +537,18 @@ export function playSynth(preset: SynthPreset, volume = 0.7): SynthHandle {
     setVolume: (v: number) => {
       stored = v
       if (!paused) {
+        const target = Math.max(v, 0.0001)
         master.gain.cancelScheduledValues(ctx.currentTime)
-        master.gain.linearRampToValueAtTime(v, ctx.currentTime + 0.1)
+        master.gain.setValueAtTime(Math.max(master.gain.value, 0.0001), ctx.currentTime)
+        master.gain.exponentialRampToValueAtTime(target, ctx.currentTime + 0.1)
       }
     },
     setPaused: (p: boolean) => {
       paused = p
+      const target = p ? 0.0001 : Math.max(stored, 0.0001)
       master.gain.cancelScheduledValues(ctx.currentTime)
-      master.gain.linearRampToValueAtTime(p ? 0 : stored, ctx.currentTime + 0.2)
+      master.gain.setValueAtTime(Math.max(master.gain.value, 0.0001), ctx.currentTime)
+      master.gain.exponentialRampToValueAtTime(target, ctx.currentTime + 0.2)
     },
   }
 }

--- a/lib/kiaan-vibe/persistence.ts
+++ b/lib/kiaan-vibe/persistence.ts
@@ -355,68 +355,170 @@ export async function deletePlaylist(id: string): Promise<void> {
 // ============ Upload Helper ============
 
 /**
- * Upload and save a track from a File
+ * Comprehensive list of audio MIME types we accept for upload.
+ *
+ * Browsers report wildly inconsistent MIME types for the same file
+ * (e.g. m4a may be `audio/mp4`, `audio/x-m4a`, `audio/aac`, or empty).
+ * We accept the union of every common variant. Files with an empty
+ * MIME type are accepted too — `audioFileLooksValid()` falls back to
+ * extension-based validation.
  */
-export async function uploadTrack(file: File): Promise<Track | null> {
-  try {
-    const id = `upload-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+export const ACCEPTED_AUDIO_MIME_TYPES: readonly string[] = [
+  // MP3
+  'audio/mpeg', 'audio/mp3', 'audio/mpeg3', 'audio/x-mpeg-3',
+  // MP4 / AAC / M4A
+  'audio/mp4', 'audio/x-m4a', 'audio/m4a', 'audio/aac', 'audio/x-aac', 'audio/aacp',
+  // WAV
+  'audio/wav', 'audio/wave', 'audio/x-wav', 'audio/x-pn-wav', 'audio/vnd.wave',
+  // OGG / Vorbis / Opus
+  'audio/ogg', 'audio/oga', 'audio/vorbis', 'audio/opus', 'audio/x-opus',
+  // FLAC
+  'audio/flac', 'audio/x-flac',
+  // WebM
+  'audio/webm', 'audio/weba',
+  // 3GPP
+  'audio/3gpp', 'audio/3gpp2', 'audio/amr', 'audio/amr-wb',
+  // MIDI
+  'audio/midi', 'audio/x-midi', 'audio/mid',
+  // WMA
+  'audio/x-ms-wma', 'audio/ms-wma',
+  // Generic / catch-all
+  'audio/basic', 'audio/L16', 'audio/L24',
+]
 
-    // Extract basic metadata from filename
-    const fileName = file.name
-    const title = fileName.replace(/\.[^/.]+$/, '') // Remove extension
+/**
+ * Common audio file extensions we accept (lowercase, with leading dot).
+ * Used as a fallback when the browser's MIME detection is unreliable.
+ */
+export const ACCEPTED_AUDIO_EXTENSIONS: readonly string[] = [
+  '.mp3', '.m4a', '.m4b', '.mp4', '.aac', '.aacp',
+  '.wav', '.wave',
+  '.ogg', '.oga', '.opus',
+  '.flac',
+  '.webm', '.weba',
+  '.3gp', '.3gpp', '.amr',
+  '.mid', '.midi',
+  '.wma',
+  '.aiff', '.aif',
+]
 
-    // Save the blob
-    await saveAudioBlob(id, file)
+/**
+ * Comma-separated `accept` attribute string for `<input type="file">`.
+ * Includes both MIME types AND extensions (browsers honor either).
+ */
+export const ACCEPTED_AUDIO_ACCEPT_ATTR: string = [
+  ...ACCEPTED_AUDIO_MIME_TYPES,
+  ...ACCEPTED_AUDIO_EXTENSIONS,
+  'audio/*', // Final wildcard catches anything browser identifies as audio
+].join(',')
 
-    // Create metadata
-    const meta: UploadedTrackMeta = {
-      id,
-      title,
-      fileName,
-      fileSize: file.size,
-      mimeType: file.type,
-      createdAt: Date.now(),
-    }
+/**
+ * Validate a File looks like an audio file we can play.
+ * Accepts if EITHER the MIME type matches OR the extension matches.
+ * This is intentionally permissive — the audio element decides at play time
+ * whether the codec is supported, and a friendly error is shown if not.
+ */
+export function audioFileLooksValid(file: File): boolean {
+  if (!file) return false
+  const mime = (file.type || '').toLowerCase()
+  if (mime.startsWith('audio/')) return true
+  if (ACCEPTED_AUDIO_MIME_TYPES.includes(mime)) return true
+  const lower = file.name.toLowerCase()
+  return ACCEPTED_AUDIO_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
 
-    // Get duration (optional, may fail)
+/** Maximum upload size — 250MB covers long mantra recordings without abuse. */
+export const MAX_UPLOAD_SIZE = 250 * 1024 * 1024
+
+/**
+ * Upload and save a track from a File. Accepts the full spectrum of
+ * audio formats listed in ACCEPTED_AUDIO_MIME_TYPES / ACCEPTED_AUDIO_EXTENSIONS.
+ *
+ * Throws (rather than returning null) so callers can surface specific errors
+ * like "file too large" or "unsupported format" to the user.
+ */
+export async function uploadTrack(file: File): Promise<Track> {
+  if (!file) {
+    throw new Error('No file provided')
+  }
+  if (file.size === 0) {
+    throw new Error(`${file.name} is empty (0 bytes).`)
+  }
+  if (file.size > MAX_UPLOAD_SIZE) {
+    const mb = (MAX_UPLOAD_SIZE / 1024 / 1024).toFixed(0)
+    throw new Error(`${file.name} is too large. Maximum ${mb}MB.`)
+  }
+  if (!audioFileLooksValid(file)) {
+    throw new Error(`${file.name} does not look like an audio file.`)
+  }
+
+  const id = `upload-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
+  // Pretty-print the title from the filename: drop the extension and
+  // turn separators into spaces so "om_chant.mp3" → "om chant".
+  const fileName = file.name
+  const title = fileName
+    .replace(/\.[^/.]+$/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim() || fileName
+
+  // Save the blob first — even if metadata extraction fails, the audio is safe.
+  await saveAudioBlob(id, file)
+
+  // Build base metadata
+  const meta: UploadedTrackMeta = {
+    id,
+    title,
+    fileName,
+    fileSize: file.size,
+    mimeType: file.type || 'audio/unknown',
+    createdAt: Date.now(),
+  }
+
+  // Try to extract duration via a hidden <audio> element.
+  // This is best-effort: some formats (e.g. raw WAV without a header,
+  // certain WebM variants) don't expose duration, but the file still plays.
+  if (typeof window !== 'undefined' && typeof Audio !== 'undefined') {
     try {
       const audio = new Audio()
+      audio.preload = 'metadata'
       const blobUrl = URL.createObjectURL(file)
       audio.src = blobUrl
 
-      await new Promise<void>((resolve, reject) => {
-        audio.addEventListener('loadedmetadata', () => {
-          meta.duration = audio.duration
+      await new Promise<void>((resolve) => {
+        const cleanup = () => {
           URL.revokeObjectURL(blobUrl)
+          audio.removeEventListener('loadedmetadata', onMeta)
+          audio.removeEventListener('error', onErr)
+        }
+        const onMeta = () => {
+          if (Number.isFinite(audio.duration) && audio.duration > 0) {
+            meta.duration = audio.duration
+          }
+          cleanup()
           resolve()
-        })
-        audio.addEventListener('error', () => {
-          URL.revokeObjectURL(blobUrl)
-          reject(new Error('Failed to load audio metadata'))
-        })
+        }
+        const onErr = () => { cleanup(); resolve() } // Resolve, not reject
+        audio.addEventListener('loadedmetadata', onMeta)
+        audio.addEventListener('error', onErr)
+        // Hard timeout — never block the upload UI on a slow decoder.
+        setTimeout(() => { cleanup(); resolve() }, 4000)
       })
     } catch {
-      // Duration extraction failed, continue without it
+      // Duration extraction failed — continue without it.
     }
+  }
 
-    // Save metadata
-    await saveTrackMeta(meta)
+  await saveTrackMeta(meta)
 
-    // Return as Track
-    const track: Track = {
-      id: meta.id,
-      title: meta.title,
-      artist: meta.artist,
-      sourceType: 'upload',
-      src: `indexeddb://${id}`, // Special protocol for our uploaded tracks
-      duration: meta.duration,
-      createdAt: meta.createdAt,
-    }
-
-    return track
-  } catch (error) {
-    console.warn('[Persistence] Failed to upload track:', error)
-    return null
+  return {
+    id: meta.id,
+    title: meta.title,
+    artist: meta.artist,
+    sourceType: 'upload',
+    src: `indexeddb://${id}`, // Resolved by the player store at play time.
+    duration: meta.duration,
+    createdAt: meta.createdAt,
   }
 }
 

--- a/lib/kiaan-vibe/store.ts
+++ b/lib/kiaan-vibe/store.ts
@@ -22,6 +22,7 @@ import {
   unlockAudio,
   type SynthHandle,
 } from './audio-synth'
+import { getAudioBlob } from './persistence'
 
 // Initial state
 const initialState = {
@@ -165,6 +166,22 @@ function cancelBrowserTTS(): void {
  */
 function isApiSourceTrack(track: Track): boolean {
   return track.src.startsWith('/api/voice/')
+}
+
+/**
+ * Resolve a track's playable URL. Uploaded tracks store `indexeddb://<id>`
+ * which is not a real URL — we must read the Blob from IndexedDB and create
+ * an Object URL the <audio> element understands. Returns the original src
+ * for any other scheme.
+ */
+async function resolvePlayableSrc(track: Track): Promise<string | null> {
+  if (!track.src.startsWith('indexeddb://')) {
+    return track.src
+  }
+  const id = track.src.slice('indexeddb://'.length)
+  const blob = await getAudioBlob(id)
+  if (!blob) return null
+  return URL.createObjectURL(blob)
 }
 
 /**
@@ -318,10 +335,12 @@ export const usePlayerStore = create<PlayerStore>()(
       const state = get()
       const audio = getAudioElement()
 
-      // Unlock AudioContext on every play(). unlockAudio() is idempotent and
-      // this catches the first user gesture on mobile browsers that require
-      // it to start any audio.
-      void unlockAudio()
+      // Unlock AudioContext on every play() AND wait for resume() to settle.
+      // On Android Chrome, scheduling oscillators on a still-suspended context
+      // produces silent playback because `currentTime` does not advance until
+      // the resume promise resolves. Awaiting here is the single most
+      // important line of this whole player on mobile.
+      await unlockAudio()
 
       // Cancel any active browser TTS before starting new playback
       cancelBrowserTTS()
@@ -475,18 +494,44 @@ export const usePlayerStore = create<PlayerStore>()(
         return
       }
 
-      // Standard tracks (meditation music, etc.) - direct audio element playback
-      audio.src = targetTrack.src
+      // Standard tracks (meditation music, uploaded files, etc.)
+      // Resolve indexeddb:// scheme to a real Blob URL so the audio element
+      // can actually load it.
+      const playableSrc = await resolvePlayableSrc(targetTrack)
+      if (!playableSrc) {
+        console.warn('[PlayerStore] Could not resolve track source:', targetTrack.id)
+        set({
+          isPlaying: false,
+          isLoading: false,
+          audioError: 'This audio file is no longer available. It may have been removed.',
+        })
+        markTrackUnavailable(targetTrack.id)
+        return
+      }
+
+      // Track the blob URL so we can revoke it later (uploaded tracks).
+      if (playableSrc.startsWith('blob:')) {
+        activeBlobUrl = playableSrc
+      }
+
+      audio.src = playableSrc
 
       try {
         await safePlay(audio)
-        set({ isPlaying: true, isLoading: false })
+        set({ isPlaying: true, isLoading: false, audioError: null })
+        markTrackAvailable(targetTrack.id)
         updateMediaSession(targetTrack)
       } catch (error) {
         // AbortError is benign - another play() call interrupted this one
         if (error instanceof DOMException && error.name === 'AbortError') return
         console.warn('[PlayerStore] Play error:', error)
-        set({ isPlaying: false, isLoading: false })
+        set({
+          isPlaying: false,
+          isLoading: false,
+          audioError: error instanceof Error
+            ? `Could not play audio: ${error.message}`
+            : 'Could not play this track.',
+        })
       }
     },
 


### PR DESCRIPTION
Root cause of the silent player on Android Chrome was a race in the
playback path: store.play() called `void unlockAudio()` (fire-and-forget),
then immediately scheduled oscillators on an AudioContext that was still
suspended. Chrome Android keeps `currentTime` frozen until the resume
promise actually settles, so the entire synth graph rendered in silence.

This change:

- audio-synth.ts: unlockAudio() now races resume() against a 1.5s timeout
  and reports whether the context is verifiably running. playSynth() also
  attempts a synchronous resume guard and starts the master gain at a
  small non-zero floor with exponential ramps (some Chromium builds
  optimize away nodes that ramp from absolute zero on a fresh context).
- store.ts: play() now awaits unlockAudio() before doing anything else,
  resolves indexeddb:// upload sources to fresh Blob URLs at play time
  (previously the audio element was handed a non-URL scheme it could not
  load), and surfaces real errors rather than silently going inert.
- persistence.ts: expand uploadTrack() to accept the full spectrum of
  audio formats (MP3, M4A/AAC, WAV, OGG, Opus, FLAC, WebM, 3GP, AMR,
  WMA, MIDI, AIFF), validate by MIME *or* extension since Android's
  reported MIME types are unreliable, raise the size cap to 250MB, and
  throw descriptive errors callers can show to the user.
- mobile vibe page: add an always-visible "Upload your own music" card,
  a new "My Music" category that lists uploaded tracks with delete
  controls, surface uploads first in the All view, and wire the inline
  file picker with broad accept attributes.
- desktop uploads page: switch to indexeddb:// queueing (no more leaked
  blob URLs) and use the shared validators.

All 13 player-store tests and the full 534-test frontend suite pass.