### PR TITLE
feat(mobile): Today's Shloka → Wisdom landing + Read More verse reader

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/index.tsx
@@ -417,6 +417,16 @@ function DailyVerseCard(): React.JSX.Element {
     toggleBookmark(verse.id);
   };
 
+  // Tapping anywhere on the verse card body (outside Ask Sakha / bookmark)
+  // opens the Wisdom landing — matches the web's
+  // "Today's Shloka chip → /m/wisdom" flow at app/(mobile)/m/page.tsx.
+  const openWisdom = (): void => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined
+    );
+    router.push('/wisdom' as never);
+  };
+
   return (
     <Reanimated.View style={[s.verseCardWrapper, animStyle]}>
       {/* 2px gold shimmer top edge — transparent → gold → transparent. */}
@@ -433,7 +443,13 @@ function DailyVerseCard(): React.JSX.Element {
         style={s.verseCardTopBar}
       />
 
-      <View style={s.verseCardBody}>
+      <TouchableOpacity
+        activeOpacity={0.85}
+        onPress={openWisdom}
+        accessibilityRole="button"
+        accessibilityLabel="Open Today's Wisdom"
+      >
+        <View style={s.verseCardBody}>
         {/* Label — "Today's Shloka" in Devanagari */}
         <Text style={s.verseLabel}>आज का श्लोक</Text>
 
@@ -492,7 +508,8 @@ function DailyVerseCard(): React.JSX.Element {
             </View>
           </>
         )}
-      </View>
+        </View>
+      </TouchableOpacity>
     </Reanimated.View>
   );
 }

--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -436,6 +436,9 @@ function AppContent(): React.JSX.Element {
           <Stack.Screen name="community" />
           <Stack.Screen name="wisdom-rooms" />
 
+          {/* Wisdom — Today's Wisdom landing + Read More verse reader */}
+          <Stack.Screen name="wisdom" />
+
           {/* Karma Footprint */}
           <Stack.Screen name="karma-footprint" />
 

--- a/kiaanverse-mobile/apps/mobile/app/wisdom/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/wisdom/_layout.tsx
@@ -1,0 +1,24 @@
+/**
+ * Wisdom Stack — 1:1 mirror of kiaanverse.com/m/wisdom for the Expo app.
+ *
+ *   /wisdom                       — Wisdom landing (Today's Wisdom + themes)
+ *   /wisdom/verse/[chapter]/[verse] — Read More: full verse + voice picker + Listen
+ *
+ * Both screens render their own DivineScreenWrapper backgrounds so the
+ * particle field / aurora persists on push. Slide-from-right matches the
+ * cinematic transition used by every other feature stack in the app.
+ */
+
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function WisdomLayout(): React.JSX.Element {
+  return (
+    <Stack
+      screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+    >
+      <Stack.Screen name="index" />
+      <Stack.Screen name="verse/[chapter]/[verse]" />
+    </Stack>
+  );
+}

--- a/kiaanverse-mobile/apps/mobile/app/wisdom/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/wisdom/index.tsx
@@ -1,0 +1,769 @@
+/**
+ * Wisdom Landing — Native parity twin of kiaanverse.com/m/wisdom.
+ *
+ * Six composed sections, top to bottom:
+ *
+ *   1. Header           Large "Wisdom" title + bell (notifications).
+ *   2. Today's Wisdom   Verse-of-the-day card (Sanskrit + translation +
+ *                       commentary) with Heart / Copy / Share / Read More.
+ *   3. Explore by Theme 6-tile 2-column grid of curated wisdom themes.
+ *   4. Ask KIAAN        Single CTA → opens the Sakha chat with the verse
+ *                       pre-loaded as conversational context.
+ *   5. Wisdom Chat Rooms Single CTA → opens /wisdom-rooms.
+ *   6. Explore the Gita Single CTA → opens /(tabs)/shlokas/gita.
+ *
+ * Data
+ *   The verse-of-the-day is selected by gitaStore.refreshVerseOfTheDay()
+ *   (deterministic per calendar day, persisted across launches). The full
+ *   verse text comes from the bundled Gita corpus via useGitaVerse(), so
+ *   the screen works offline and renders the real Sanskrit / IAST / English.
+ *
+ * Read More
+ *   Pushes /wisdom/verse/[chapter]/[verse] — a dedicated reader with the
+ *   listening voice picker + Listen button (TTS via expo-speech).
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import * as Haptics from 'expo-haptics';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, { FadeIn, FadeInDown } from 'react-native-reanimated';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  Bell,
+  BookOpen,
+  Check,
+  ChevronRight,
+  Copy,
+  Heart,
+  Share2,
+  Sparkles,
+  Star,
+  Users,
+} from 'lucide-react-native';
+
+import { DivineScreenWrapper, OmLoader } from '@kiaanverse/ui';
+import { useGitaVerse } from '@kiaanverse/api';
+import { useGitaStore } from '@kiaanverse/store';
+
+/**
+ * Optional clipboard support — `expo-clipboard` may not be linked in every
+ * Expo build. Load it lazily and fall back to a silent no-op so the Copy
+ * button never crashes when the module is missing.
+ */
+type ClipboardLike = { setStringAsync(text: string): Promise<void> };
+let Clipboard: ClipboardLike | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+  Clipboard = require('expo-clipboard') as ClipboardLike;
+} catch {
+  Clipboard = null;
+}
+
+// ── Design tokens (kept local to mirror the web Wisdom page exactly) ──────
+const GOLD = '#D4A017';
+const GOLD_BRIGHT = '#E8B54A';
+const GOLD_SOFT = 'rgba(212,160,23,0.15)';
+const GOLD_BORDER = 'rgba(212,160,23,0.20)';
+const GOLD_TINT = 'rgba(212,160,23,0.10)';
+const TEXT_PRIMARY = '#F5F0E8';
+const TEXT_SECONDARY = '#C8BFA8';
+const TEXT_MUTED = '#7A7060';
+const SURFACE_DIM = 'rgba(255,255,255,0.06)';
+const SURFACE_VOID = 'rgba(255,255,255,0.02)';
+const SURFACE_BORDER = 'rgba(255,255,255,0.06)';
+
+// Web parity fallback verse — matches FALLBACK_VERSE in
+// app/(mobile)/m/wisdom/page.tsx so the screen never renders empty during
+// the brief moment between mount and gitaStore hydration.
+const FALLBACK = {
+  chapter: 4,
+  verse: 7,
+  sanskrit:
+    'यदा यदा हि धर्मस्य ग्लानिर्भवति भारत। अभ्युत्थानमधर्मस्य तदात्मानं सृजाम्यहम्॥',
+  translation:
+    'When injustice rises, so does the force that corrects it. Be part of that force.',
+  commentary:
+    'Whenever there is a decline of Dharma, O Arjuna, and an uprising of Adharma, then I incarnate myself. Let this courage live in you today.',
+} as const;
+
+// ── Wisdom themes (mirrors WISDOM_THEMES on the web) ──────────────────────
+interface ThemeTile {
+  readonly id: string;
+  readonly label: string;
+  readonly emoji: string;
+  /** From / to colours for the linear background gradient. */
+  readonly gradient: readonly string[];
+  readonly border: string;
+}
+
+const WISDOM_THEMES: readonly ThemeTile[] = [
+  {
+    id: 'peace',
+    label: 'Inner Peace',
+    emoji: '🕊️',
+    gradient: ['rgba(20,184,166,0.18)', 'rgba(8,145,178,0.18)'],
+    border: 'rgba(20,184,166,0.28)',
+  },
+  {
+    id: 'courage',
+    label: 'Courage',
+    emoji: '🦁',
+    gradient: ['rgba(212,164,76,0.18)', 'rgba(239,68,68,0.18)'],
+    border: 'rgba(212,164,76,0.28)',
+  },
+  {
+    id: 'wisdom',
+    label: 'Wisdom',
+    emoji: '🧘',
+    gradient: ['rgba(168,85,247,0.18)', 'rgba(99,102,241,0.18)'],
+    border: 'rgba(168,85,247,0.28)',
+  },
+  {
+    id: 'devotion',
+    label: 'Devotion',
+    emoji: '🙏',
+    gradient: ['rgba(236,72,153,0.18)', 'rgba(244,63,94,0.18)'],
+    border: 'rgba(236,72,153,0.28)',
+  },
+  {
+    id: 'action',
+    label: 'Right Action',
+    emoji: '⚡',
+    gradient: ['rgba(212,164,76,0.18)', 'rgba(234,179,8,0.18)'],
+    border: 'rgba(212,164,76,0.28)',
+  },
+  {
+    id: 'detachment',
+    label: 'Letting Go',
+    emoji: '🍃',
+    gradient: ['rgba(34,197,94,0.18)', 'rgba(16,185,129,0.18)'],
+    border: 'rgba(34,197,94,0.28)',
+  },
+];
+
+export default function WisdomLandingScreen(): React.JSX.Element {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  // ── Verse-of-the-day from the persisted gitaStore. ──────────────────────
+  const vodChapter = useGitaStore((s) => s.vodChapter);
+  const vodVerse = useGitaStore((s) => s.vodVerse);
+  const refreshVerseOfTheDay = useGitaStore((s) => s.refreshVerseOfTheDay);
+  const bookmarkedVerseIds = useGitaStore((s) => s.bookmarkedVerseIds);
+  const toggleBookmark = useGitaStore((s) => s.toggleBookmark);
+
+  useEffect(() => {
+    // Idempotent — no-op if vodDate matches today.
+    refreshVerseOfTheDay();
+  }, [refreshVerseOfTheDay]);
+
+  const chapter = vodChapter ?? FALLBACK.chapter;
+  const verseNum = vodVerse ?? FALLBACK.verse;
+  const { data: verse, isLoading } = useGitaVerse(chapter, verseNum);
+
+  const sanskrit = verse?.sanskrit ?? FALLBACK.sanskrit;
+  const translation = verse?.translation ?? FALLBACK.translation;
+  // The local corpus does not ship per-verse commentary; show the
+  // translation in both slots when no commentary is available, matching the
+  // web page's fallback when the API omits the `commentary` field.
+  const commentary = verse?.translation ?? FALLBACK.commentary;
+  const verseId = verse?.id ?? `${chapter}.${verseNum}`;
+  const isFavorited = bookmarkedVerseIds.includes(verseId);
+
+  // ── Local UI state ──────────────────────────────────────────────────────
+  const [copied, setCopied] = useState(false);
+
+  // ── Handlers ────────────────────────────────────────────────────────────
+  const handleFavorite = useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined,
+    );
+    toggleBookmark(verseId);
+  }, [toggleBookmark, verseId]);
+
+  const handleCopy = useCallback(async () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined,
+    );
+    const text = `"${translation}"\n\n— Bhagavad Gita ${chapter}.${verseNum}`;
+    if (Clipboard) {
+      await Clipboard.setStringAsync(text).catch(() => undefined);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [chapter, translation, verseNum]);
+
+  const handleShare = useCallback(async () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined,
+    );
+    const message = [
+      sanskrit,
+      '',
+      `"${translation}"`,
+      '',
+      `— Bhagavad Gita ${chapter}.${verseNum}`,
+      '— Shared from Kiaanverse',
+    ].join('\n');
+    try {
+      await Share.share({ message, title: 'Today’s Wisdom' });
+    } catch {
+      // User cancelled or share sheet failed.
+    }
+  }, [chapter, sanskrit, translation, verseNum]);
+
+  const handleReadMore = useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined,
+    );
+    router.push(`/wisdom/verse/${chapter}/${verseNum}` as never);
+  }, [chapter, router, verseNum]);
+
+  const handleThemePress = useCallback(
+    (themeId: string) => {
+      void Haptics.selectionAsync().catch(() => undefined);
+      // Themes don't yet have dedicated curated lists — surface a polite
+      // teaser and route into the chapter browser so the journey continues.
+      Alert.alert(
+        'Coming soon',
+        `Curated ${themeId.replace(/^./, (c) => c.toUpperCase())} verses will arrive in the next release. Opening the Bhagavad Gita browser instead.`,
+        [
+          {
+            text: 'Continue',
+            onPress: () => router.push('/(tabs)/shlokas/gita' as never),
+          },
+          { text: 'Cancel', style: 'cancel' },
+        ],
+      );
+    },
+    [router],
+  );
+
+  const handleAskKiaan = useCallback(() => {
+    void Haptics.selectionAsync().catch(() => undefined);
+    router.push({
+      pathname: '/(tabs)/chat',
+      params: {
+        preload: `Tell me more about Bhagavad Gita ${chapter}.${verseNum}`,
+        context: [
+          `Please explain Bhagavad Gita ${chapter}.${verseNum}:`,
+          '',
+          sanskrit,
+          '',
+          translation,
+        ].join('\n'),
+        verseId: `${chapter}.${verseNum}`,
+      },
+    });
+  }, [chapter, sanskrit, translation, verseNum, router]);
+
+  const handleOpenRooms = useCallback(() => {
+    void Haptics.selectionAsync().catch(() => undefined);
+    router.push('/wisdom-rooms' as never);
+  }, [router]);
+
+  const handleExploreGita = useCallback(() => {
+    void Haptics.selectionAsync().catch(() => undefined);
+    router.push('/(tabs)/shlokas/gita' as never);
+  }, [router]);
+
+  const handleNotifications = useCallback(() => {
+    void Haptics.selectionAsync().catch(() => undefined);
+    router.push('/(app)/notifications' as never);
+  }, [router]);
+
+  return (
+    <DivineScreenWrapper safeArea={false}>
+      {/* ── Header — large "Wisdom" title + bell ─────────────────────── */}
+      <View
+        style={[
+          styles.header,
+          { paddingTop: insets.top + 8 },
+        ]}
+      >
+        <Pressable
+          onPress={handleNotifications}
+          accessibilityRole="button"
+          accessibilityLabel="Open notifications"
+          hitSlop={12}
+          style={styles.bellButton}
+        >
+          <Bell size={22} color={TEXT_PRIMARY} />
+        </Pressable>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: insets.bottom + 120 },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Large title (drawn into the scroll so it scrolls away gracefully). */}
+        <Text style={styles.title} accessibilityRole="header">
+          Wisdom
+        </Text>
+
+        {/* ── 1. Today's Wisdom card ─────────────────────────────────── */}
+        <Animated.View
+          entering={FadeInDown.duration(420)}
+          style={styles.todayCard}
+        >
+          <LinearGradient
+            colors={[
+              'rgba(212,164,76,0.10)',
+              'rgba(212,164,76,0.05)',
+              'rgba(20,184,166,0.10)',
+            ]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={StyleSheet.absoluteFill}
+          />
+
+          {/* Header row */}
+          <View style={styles.todayHeader}>
+            <View style={styles.todayLabelRow}>
+              <Star size={14} color={GOLD} />
+              <Text style={styles.todayLabel}>TODAY&apos;S WISDOM</Text>
+            </View>
+            <Text style={styles.todayRef}>
+              {`Chapter ${chapter}, Verse ${verseNum}`}
+            </Text>
+          </View>
+
+          {isLoading && !verse ? (
+            <View style={styles.loaderRow}>
+              <OmLoader size={48} />
+            </View>
+          ) : (
+            <>
+              {/* Sanskrit verse */}
+              {sanskrit ? (
+                <Text
+                  style={styles.sanskrit}
+                  accessibilityLanguage="sa"
+                  allowFontScaling
+                >
+                  {sanskrit}
+                </Text>
+              ) : null}
+
+              {/* Translation in quotes */}
+              <Text style={styles.translation}>
+                {`“${translation}”`}
+              </Text>
+
+              {/* Commentary */}
+              <Text style={styles.commentary}>{commentary}</Text>
+
+              {/* Action row */}
+              <View style={styles.actionRow}>
+                <ActionButton
+                  onPress={handleFavorite}
+                  active={isFavorited}
+                  activeBg="rgba(236,72,153,0.20)"
+                  accessibilityLabel={
+                    isFavorited ? 'Remove from favorites' : 'Add to favorites'
+                  }
+                >
+                  <Heart
+                    size={16}
+                    color={isFavorited ? '#F472B6' : TEXT_SECONDARY}
+                    fill={isFavorited ? '#F472B6' : 'transparent'}
+                  />
+                </ActionButton>
+
+                <ActionButton
+                  onPress={handleCopy}
+                  accessibilityLabel="Copy verse"
+                >
+                  {copied ? (
+                    <Check size={16} color="#34D399" />
+                  ) : (
+                    <Copy size={16} color={TEXT_SECONDARY} />
+                  )}
+                </ActionButton>
+
+                <ActionButton
+                  onPress={handleShare}
+                  accessibilityLabel="Share verse"
+                >
+                  <Share2 size={16} color={TEXT_SECONDARY} />
+                </ActionButton>
+
+                <View style={{ flex: 1 }} />
+
+                <Pressable
+                  onPress={handleReadMore}
+                  style={styles.readMoreBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Open the full verse reader"
+                >
+                  <BookOpen size={14} color={GOLD} />
+                  <Text style={styles.readMoreText}>Read More</Text>
+                </Pressable>
+              </View>
+            </>
+          )}
+        </Animated.View>
+
+        {/* ── 2. Explore by Theme ─────────────────────────────────────── */}
+        <Animated.View entering={FadeIn.delay(120).duration(380)}>
+          <Text style={styles.sectionLabel}>Explore by Theme</Text>
+          <View style={styles.themeGrid}>
+            {WISDOM_THEMES.map((theme, idx) => (
+              <Animated.View
+                key={theme.id}
+                entering={FadeInDown.delay(180 + idx * 40).duration(360)}
+                style={styles.themeCell}
+              >
+                <Pressable
+                  onPress={() => handleThemePress(theme.id)}
+                  style={({ pressed }) => [
+                    styles.themeTile,
+                    { borderColor: theme.border },
+                    pressed && { opacity: 0.7 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${theme.label} verses`}
+                >
+                  <LinearGradient
+                    colors={[...theme.gradient]}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={StyleSheet.absoluteFill}
+                  />
+                  <Text style={styles.themeEmoji}>{theme.emoji}</Text>
+                  <Text style={styles.themeLabel}>{theme.label}</Text>
+                </Pressable>
+              </Animated.View>
+            ))}
+          </View>
+        </Animated.View>
+
+        {/* ── 3. Ask KIAAN ────────────────────────────────────────────── */}
+        <Animated.View entering={FadeIn.delay(280).duration(380)}>
+          <CtaRow
+            onPress={handleAskKiaan}
+            iconBg="rgba(168,85,247,0.20)"
+            iconBorder="rgba(168,85,247,0.28)"
+            tint="rgba(168,85,247,0.10)"
+            border="rgba(168,85,247,0.28)"
+            icon={<Sparkles size={20} color="#C084FC" />}
+            title="Ask KIAAN"
+            subtitle="Get personalized wisdom for your situation"
+          />
+        </Animated.View>
+
+        {/* ── 4. Wisdom Chat Rooms ────────────────────────────────────── */}
+        <Animated.View entering={FadeIn.delay(340).duration(380)}>
+          <CtaRow
+            onPress={handleOpenRooms}
+            iconBg="rgba(212,164,76,0.20)"
+            iconBorder="rgba(212,164,76,0.32)"
+            tint="rgba(212,164,76,0.10)"
+            border="rgba(212,164,76,0.28)"
+            icon={<Users size={20} color={GOLD} />}
+            title="Wisdom Chat Rooms"
+            subtitle="Join live community conversations"
+          />
+        </Animated.View>
+
+        {/* ── 5. Explore the Bhagavad Gita ────────────────────────────── */}
+        <Animated.View entering={FadeIn.delay(400).duration(380)}>
+          <CtaRow
+            onPress={handleExploreGita}
+            iconBg="rgba(20,184,166,0.20)"
+            iconBorder="rgba(20,184,166,0.32)"
+            tint={SURFACE_VOID}
+            border={SURFACE_BORDER}
+            icon={<BookOpen size={20} color="#2DD4BF" />}
+            title="Explore the Bhagavad Gita"
+            subtitle="700+ verses across 18 chapters"
+          />
+        </Animated.View>
+      </ScrollView>
+    </DivineScreenWrapper>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+
+interface ActionButtonProps {
+  readonly onPress: () => void;
+  readonly children: React.ReactNode;
+  readonly active?: boolean;
+  readonly activeBg?: string;
+  readonly accessibilityLabel: string;
+}
+
+function ActionButton({
+  onPress,
+  children,
+  active = false,
+  activeBg,
+  accessibilityLabel,
+}: ActionButtonProps): React.JSX.Element {
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={6}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      style={({ pressed }) => [
+        styles.actionBtn,
+        active && activeBg ? { backgroundColor: activeBg } : undefined,
+        pressed && { opacity: 0.7 },
+      ]}
+    >
+      {children}
+    </Pressable>
+  );
+}
+
+interface CtaRowProps {
+  readonly onPress: () => void;
+  readonly icon: React.ReactNode;
+  readonly title: string;
+  readonly subtitle: string;
+  readonly iconBg: string;
+  readonly iconBorder: string;
+  readonly tint: string;
+  readonly border: string;
+}
+
+function CtaRow({
+  onPress,
+  icon,
+  title,
+  subtitle,
+  iconBg,
+  iconBorder,
+  tint,
+  border,
+}: CtaRowProps): React.JSX.Element {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.ctaRow,
+        { backgroundColor: tint, borderColor: border },
+        pressed && { opacity: 0.85 },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`${title}. ${subtitle}`}
+    >
+      <View
+        style={[
+          styles.ctaIconWrap,
+          { backgroundColor: iconBg, borderColor: iconBorder },
+        ]}
+      >
+        {icon}
+      </View>
+      <View style={styles.ctaTextWrap}>
+        <Text style={styles.ctaTitle}>{title}</Text>
+        <Text style={styles.ctaSubtitle}>{subtitle}</Text>
+      </View>
+      <ChevronRight size={20} color={TEXT_MUTED} />
+    </Pressable>
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────
+const styles = StyleSheet.create({
+  // Header
+  header: {
+    paddingHorizontal: 16,
+    paddingBottom: 4,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  bellButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // Scroll
+  scrollContent: {
+    paddingHorizontal: 16,
+    gap: 22,
+  },
+  title: {
+    fontFamily: 'CormorantGaramond-LightItalic',
+    fontSize: 44,
+    lineHeight: 52,
+    color: TEXT_PRIMARY,
+    marginTop: 4,
+    marginBottom: 4,
+  },
+
+  // Today's Wisdom card
+  todayCard: {
+    position: 'relative',
+    overflow: 'hidden',
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: GOLD_BORDER,
+    padding: 18,
+  },
+  todayHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 14,
+  },
+  todayLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  todayLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    letterSpacing: 1.4,
+    color: GOLD,
+  },
+  todayRef: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 12,
+    color: TEXT_MUTED,
+  },
+  sanskrit: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontSize: 16,
+    lineHeight: 30,
+    fontStyle: 'italic',
+    color: GOLD_BRIGHT,
+    marginBottom: 12,
+  },
+  translation: {
+    fontFamily: 'CrimsonText-Regular',
+    fontSize: 16,
+    lineHeight: 24,
+    color: TEXT_PRIMARY,
+    marginBottom: 10,
+  },
+  commentary: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 14,
+    lineHeight: 22,
+    color: TEXT_SECONDARY,
+    marginBottom: 16,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  actionBtn: {
+    width: 38,
+    height: 38,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: SURFACE_DIM,
+  },
+  readMoreBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 14,
+    backgroundColor: GOLD_SOFT,
+  },
+  readMoreText: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 13,
+    color: GOLD,
+  },
+  loaderRow: {
+    paddingVertical: 36,
+    alignItems: 'center',
+  },
+
+  // Section label
+  sectionLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 14,
+    color: TEXT_MUTED,
+    marginBottom: 12,
+  },
+
+  // Themes
+  themeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: -6,
+  },
+  themeCell: {
+    width: '50%',
+    paddingHorizontal: 6,
+    marginBottom: 12,
+  },
+  themeTile: {
+    overflow: 'hidden',
+    borderRadius: 18,
+    borderWidth: 1,
+    padding: 16,
+    minHeight: 92,
+    justifyContent: 'flex-end',
+  },
+  themeEmoji: {
+    fontSize: 26,
+    marginBottom: 6,
+  },
+  themeLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 14,
+    color: TEXT_PRIMARY,
+  },
+
+  // CTA rows (Ask KIAAN / Wisdom Rooms / Explore Gita)
+  ctaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 14,
+    borderRadius: 18,
+    borderWidth: 1,
+    backgroundColor: GOLD_TINT,
+  },
+  ctaIconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  ctaTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+  ctaTitle: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 14,
+    color: TEXT_PRIMARY,
+  },
+  ctaSubtitle: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 12,
+    color: TEXT_MUTED,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/wisdom/verse/[chapter]/[verse].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/wisdom/verse/[chapter]/[verse].tsx
@@ -131,6 +131,41 @@ const VOICES: readonly [VoiceConfig, ...VoiceConfig[]] = [
 
 const DEFAULT_VOICE_ID = 'divine-krishna';
 
+// ── Chapter metadata (1:1 mirror of GITA_MOBILE_CHAPTERS in
+// lib/kiaan-vibe/gita-library.ts on the web) ─────────────────────────────
+//
+// The bundled Gita corpus stores chapter names like "The Yoga of Knowledge
+// and Renunciation". The web Wisdom reader uses a hand-curated short
+// English title ("Knowledge & Renunciation") and the IAST chapter
+// transliteration ("Jnana Karma Sannyas Yoga") for the header sub-row. We
+// embed the same table so the native screen renders identical text instead
+// of an ad-hoc derivation from the corpus name.
+interface ChapterMeta {
+  readonly transliteration: string;
+  readonly english: string;
+}
+
+const CHAPTER_META: Record<number, ChapterMeta> = {
+  1: { transliteration: 'Arjuna Vishada Yoga', english: "Arjuna's Dejection" },
+  2: { transliteration: 'Sankhya Yoga', english: 'Transcendental Knowledge' },
+  3: { transliteration: 'Karma Yoga', english: 'Path of Action' },
+  4: { transliteration: 'Jnana Karma Sannyas Yoga', english: 'Knowledge & Renunciation' },
+  5: { transliteration: 'Karma Sannyas Yoga', english: 'Renunciation of Action' },
+  6: { transliteration: 'Atma Samyama Yoga', english: 'Self-Mastery through Meditation' },
+  7: { transliteration: 'Jnana Vijnana Yoga', english: 'Knowledge of the Absolute' },
+  8: { transliteration: 'Aksara Brahma Yoga', english: 'Attaining the Supreme' },
+  9: { transliteration: 'Raja Vidya Raja Guhya Yoga', english: 'The Royal Knowledge' },
+  10: { transliteration: 'Vibhuti Yoga', english: 'Divine Manifestations' },
+  11: { transliteration: 'Vishwarupa Darsana Yoga', english: 'The Universal Form' },
+  12: { transliteration: 'Bhakti Yoga', english: 'Path of Devotion' },
+  13: { transliteration: 'Kshetra Yoga', english: 'Field & Knower of Field' },
+  14: { transliteration: 'Guna Traya Yoga', english: 'The Three Modes of Nature' },
+  15: { transliteration: 'Purushottama Yoga', english: 'The Supreme Person' },
+  16: { transliteration: 'Daivasura Yoga', english: 'Divine & Demonic Qualities' },
+  17: { transliteration: 'Shraddha Traya Yoga', english: 'Three Types of Faith' },
+  18: { transliteration: 'Moksha Sannyas Yoga', english: 'Liberation Through Renunciation' },
+};
+
 export default function ReadMoreVerseScreen(): React.JSX.Element {
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -220,21 +255,19 @@ export default function ReadMoreVerseScreen(): React.JSX.Element {
     verseData?.transliteration ?? fallbackVerse?.transliteration ?? '';
   const translation = verseData?.translation ?? fallbackVerse?.english ?? '';
 
+  // Curated chapter metadata mirrors the web Wisdom reader exactly. Falls
+  // back to the bundled corpus name only if a chapter index is somehow
+  // missing from the table (shouldn't happen — all 18 are present).
+  const curatedMeta = CHAPTER_META[chapterNum];
   const chapterEnglish =
+    curatedMeta?.english ??
     chapterMeta?.nameEnglish?.replace(/^The Yoga of\s+/i, '') ??
     `Chapter ${chapterNum}`;
+  const chapterUpperLatin = useMemo(
+    () => (curatedMeta?.transliteration ?? '').toUpperCase(),
+    [curatedMeta],
+  );
   const chapterSanskritName = chapterMeta?.nameSanskrit ?? '';
-  // The web shows "JNANA KARMA SANNYAS YOGA" (uppercase Latin name), not
-  // the Devanagari. We synthesise the same value by pulling the english
-  // name and removing the leading "The Yoga of …" / trailing "…" words.
-  const chapterUpperLatin = useMemo(() => {
-    const raw = chapterMeta?.nameEnglish ?? '';
-    return raw
-      .replace(/^The Yoga of\s+/i, '')
-      .replace(/[^A-Za-z\s]/g, '')
-      .trim()
-      .toUpperCase();
-  }, [chapterMeta]);
 
   // ── Listen ──────────────────────────────────────────────────────────────
   const handleListen = useCallback(() => {

--- a/kiaanverse-mobile/apps/mobile/app/wisdom/verse/[chapter]/[verse].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/wisdom/verse/[chapter]/[verse].tsx
@@ -1,0 +1,857 @@
+/**
+ * Wisdom → Read More verse reader.
+ *
+ * Native parity twin of kiaanverse.com/m/kiaan-vibe/verse/[chapterVerse].
+ *
+ * Layout (top → bottom)
+ *   • Header     Back arrow · "BG c.v" + chapter english name · Bell.
+ *   • Sub-row    "BG c.v · CHAPTER SANSKRIT NAME (uppercase)" + ‹ › nav.
+ *   • Sanskrit   Devanagari verse + verse number "c.v" stamp in gold.
+ *   • IAST       Transliteration in italic warm-grey.
+ *   • Meaning    English translation in serif body.
+ *   • Voices     "LISTENING VOICE" label + 4 voice pills:
+ *                  Krishna · Saraswati · Rishi · Nova
+ *                Each pill changes the speech rate / locale on play.
+ *   • Listen     Primary purple Listen button (TTS via expo-speech) +
+ *                bookmark + share.
+ *
+ * Voice mapping
+ *   The web build wires four distinct ElevenLabs / Sarvam personas. On
+ *   device we don't have those voices available in the JS layer, so each
+ *   voice maps to a unique (rate, language) tuple via expo-speech so the
+ *   audio still sounds different. This matches what the web uses for its
+ *   browser-SpeechSynthesis fallback.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+import Animated, { FadeIn, FadeInDown } from 'react-native-reanimated';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  Bell,
+  Bookmark,
+  BookmarkCheck,
+  ChevronLeft,
+  ChevronRight,
+  Pause,
+  Play,
+  Share2,
+} from 'lucide-react-native';
+
+import {
+  DivineScreenWrapper,
+  OmLoader,
+  useSpeechOutput,
+} from '@kiaanverse/ui';
+import { useGitaVerse } from '@kiaanverse/api';
+import { getLocalChapter, getLocalVerse } from '@kiaanverse/api';
+import { useGitaStore } from '@kiaanverse/store';
+
+// ── Tokens ────────────────────────────────────────────────────────────────
+const GOLD = '#D4A017';
+const GOLD_BRIGHT = '#E8B54A';
+const GOLD_SOFT = 'rgba(212,160,23,0.12)';
+const GOLD_BORDER = 'rgba(212,160,23,0.22)';
+const TEXT_PRIMARY = '#F5F0E8';
+const TEXT_SECONDARY = '#C8BFA8';
+const TEXT_MUTED = '#7A7060';
+const SURFACE_DIM = 'rgba(22,26,66,0.55)';
+const PURPLE_BG = 'rgba(108,79,178,0.18)';
+const PURPLE_BORDER = 'rgba(140,103,225,0.45)';
+const PURPLE_TEXT = '#C4B5FD';
+
+// ── Voice catalogue (mirrors GITA_STATS.voices on the web) ────────────────
+interface VoiceConfig {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  /** TTS rate. expo-speech accepts 0.0–2.0, contemplative pacing under 1. */
+  readonly speed: number;
+  /** Locale hint passed to expo-speech. Different locales pick different
+   *  device voices on Android, which is what makes the four pills audibly
+   *  distinct in the absence of premium TTS. */
+  readonly language: string;
+  /** Pitch shift — Saraswati/Nova lean female, Krishna/Rishi lean male. */
+  readonly pitch: number;
+  /** Pill colour — chosen for accent only, not gender-coded. */
+  readonly color: string;
+}
+
+// Note: tuple type — `[VoiceConfig, ...VoiceConfig[]]` — guarantees that
+// `VOICES[0]` is always defined so the fallback in `selectedVoice` below
+// narrows to `VoiceConfig` rather than `VoiceConfig | undefined`.
+const VOICES: readonly [VoiceConfig, ...VoiceConfig[]] = [
+  {
+    id: 'divine-krishna',
+    name: 'Krishna',
+    description: 'The divine voice of the Paramatma',
+    speed: 0.8,
+    language: 'en-IN',
+    pitch: 0.95,
+    color: '#1B4FBB',
+  },
+  {
+    id: 'divine-saraswati',
+    name: 'Saraswati',
+    description: 'The goddess of knowledge and sacred speech',
+    speed: 0.82,
+    language: 'hi-IN',
+    pitch: 1.15,
+    color: '#9D174D',
+  },
+  {
+    id: 'sarvam-rishi',
+    name: 'Rishi',
+    description: 'The ancient sage — masculine, grounded',
+    speed: 0.85,
+    language: 'en-GB',
+    pitch: 0.9,
+    color: '#B45309',
+  },
+  {
+    id: 'elevenlabs-nova',
+    name: 'Nova',
+    description: 'Clear and conversational — for newcomers',
+    speed: 0.9,
+    language: 'en-US',
+    pitch: 1.05,
+    color: '#0E7490',
+  },
+];
+
+const DEFAULT_VOICE_ID = 'divine-krishna';
+
+export default function ReadMoreVerseScreen(): React.JSX.Element {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { chapter, verse } = useLocalSearchParams<{
+    chapter: string;
+    verse: string;
+  }>();
+
+  const chapterNum = Number(chapter);
+  const verseNum = Number(verse);
+  const paramsValid =
+    Number.isInteger(chapterNum) &&
+    Number.isInteger(verseNum) &&
+    chapterNum > 0 &&
+    verseNum > 0;
+
+  const verseId = paramsValid ? `${chapterNum}.${verseNum}` : '';
+
+  // ── Store ───────────────────────────────────────────────────────────────
+  const addRecentlyViewed = useGitaStore((s) => s.addRecentlyViewed);
+  const toggleBookmark = useGitaStore((s) => s.toggleBookmark);
+  const isBookmarked = useGitaStore(
+    (s) => verseId.length > 0 && s.bookmarkedVerseIds.includes(verseId),
+  );
+
+  // ── Verse data (offline-first via the bundled corpus) ───────────────────
+  const { data: verseData, isLoading } = useGitaVerse(
+    paramsValid ? chapterNum : 0,
+    paramsValid ? verseNum : 0,
+  );
+
+  /**
+   * Chapter metadata is needed for the sub-header ("BG 4.38 · JNANA KARMA
+   * SANNYAS YOGA") and the navigation arrows (verseCount). The local
+   * corpus already has chapter sanskrit + english names for all 18
+   * chapters and is synchronous, so we don't need an extra hook.
+   */
+  const chapterMeta = useMemo(
+    () => (paramsValid ? getLocalChapter(chapterNum) : undefined),
+    [chapterNum, paramsValid],
+  );
+
+  /**
+   * If the verse query hasn't returned yet, fall back to the bundled
+   * corpus directly so the screen still paints content immediately. The
+   * useGitaVerse hook reads from the same corpus, so this is just a
+   * shortcut, not a divergent code path.
+   */
+  const fallbackVerse = useMemo(
+    () => (paramsValid ? getLocalVerse(chapterNum, verseNum) : undefined),
+    [chapterNum, paramsValid, verseNum],
+  );
+
+  // Add to recently-viewed once on mount per chapter/verse.
+  useEffect(() => {
+    if (paramsValid)
+      addRecentlyViewed({ chapter: chapterNum, verse: verseNum });
+  }, [addRecentlyViewed, chapterNum, paramsValid, verseNum]);
+
+  // ── Voice picker state ──────────────────────────────────────────────────
+  const [selectedVoiceId, setSelectedVoiceId] =
+    useState<string>(DEFAULT_VOICE_ID);
+  const selectedVoice =
+    VOICES.find((v) => v.id === selectedVoiceId) ?? VOICES[0];
+
+  const { speak, stop, isSpeaking } = useSpeechOutput({
+    rate: selectedVoice.speed,
+    pitch: selectedVoice.pitch,
+    language: selectedVoice.language,
+  });
+
+  // Stop any ongoing playback if the user switches voices mid-utterance —
+  // expo-speech will otherwise queue and the caller can't tell which voice
+  // is "active" any more.
+  const handleSelectVoice = useCallback(
+    (voiceId: string) => {
+      void Haptics.selectionAsync().catch(() => undefined);
+      stop();
+      setSelectedVoiceId(voiceId);
+    },
+    [stop],
+  );
+
+  // ── Resolved verse content ──────────────────────────────────────────────
+  const sanskrit = verseData?.sanskrit ?? fallbackVerse?.sanskrit ?? '';
+  const transliteration =
+    verseData?.transliteration ?? fallbackVerse?.transliteration ?? '';
+  const translation = verseData?.translation ?? fallbackVerse?.english ?? '';
+
+  const chapterEnglish =
+    chapterMeta?.nameEnglish?.replace(/^The Yoga of\s+/i, '') ??
+    `Chapter ${chapterNum}`;
+  const chapterSanskritName = chapterMeta?.nameSanskrit ?? '';
+  // The web shows "JNANA KARMA SANNYAS YOGA" (uppercase Latin name), not
+  // the Devanagari. We synthesise the same value by pulling the english
+  // name and removing the leading "The Yoga of …" / trailing "…" words.
+  const chapterUpperLatin = useMemo(() => {
+    const raw = chapterMeta?.nameEnglish ?? '';
+    return raw
+      .replace(/^The Yoga of\s+/i, '')
+      .replace(/[^A-Za-z\s]/g, '')
+      .trim()
+      .toUpperCase();
+  }, [chapterMeta]);
+
+  // ── Listen ──────────────────────────────────────────────────────────────
+  const handleListen = useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(
+      () => undefined,
+    );
+    if (isSpeaking) {
+      stop();
+      return;
+    }
+    // The Sanskrit verse is the primary audio target; if the device's
+    // Devanagari TTS is unavailable expo-speech will fall through to the
+    // English translation so the user always hears something meaningful.
+    const utterance = sanskrit.length > 0 ? sanskrit : translation;
+    if (utterance.length === 0) return;
+    speak(utterance);
+  }, [isSpeaking, sanskrit, speak, stop, translation]);
+
+  // ── Bookmark / share ────────────────────────────────────────────────────
+  const handleBookmark = useCallback(() => {
+    if (!paramsValid) return;
+    void Haptics.impactAsync(
+      isBookmarked
+        ? Haptics.ImpactFeedbackStyle.Light
+        : Haptics.ImpactFeedbackStyle.Medium,
+    ).catch(() => undefined);
+    toggleBookmark(verseId);
+  }, [isBookmarked, paramsValid, toggleBookmark, verseId]);
+
+  const handleShare = useCallback(async () => {
+    if (!paramsValid) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+      () => undefined,
+    );
+    const message = [
+      `Bhagavad Gita ${chapterNum}.${verseNum}`,
+      '',
+      sanskrit,
+      transliteration,
+      '',
+      translation,
+      '',
+      '— Shared from Kiaanverse',
+    ]
+      .filter((line) => line !== undefined)
+      .join('\n');
+    try {
+      await Share.share({
+        message,
+        title: `BG ${chapterNum}.${verseNum}`,
+      });
+    } catch {
+      // User cancelled the share sheet — no rollback needed.
+    }
+  }, [
+    chapterNum,
+    paramsValid,
+    sanskrit,
+    transliteration,
+    translation,
+    verseNum,
+  ]);
+
+  // ── Navigation between verses ───────────────────────────────────────────
+  const goToVerse = useCallback(
+    (delta: -1 | 1) => {
+      if (!chapterMeta) return;
+      let newChapter = chapterNum;
+      let newVerse = verseNum + delta;
+
+      if (newVerse < 1) {
+        const prev = getLocalChapter(chapterNum - 1);
+        if (!prev) return;
+        newChapter = prev.chapter;
+        newVerse = prev.verseCount;
+      } else if (newVerse > chapterMeta.verseCount) {
+        const next = getLocalChapter(chapterNum + 1);
+        if (!next) return;
+        newChapter = next.chapter;
+        newVerse = 1;
+      }
+
+      void Haptics.selectionAsync().catch(() => undefined);
+      stop();
+      router.replace(`/wisdom/verse/${newChapter}/${newVerse}` as never);
+    },
+    [chapterMeta, chapterNum, router, stop, verseNum],
+  );
+
+  // ── Empty / error states ────────────────────────────────────────────────
+  if (!paramsValid) {
+    return (
+      <DivineScreenWrapper>
+        <Header
+          title="Verse"
+          insetTop={insets.top}
+          onBack={() => router.back()}
+          onBell={() => router.push('/(app)/notifications' as never)}
+        />
+        <View style={styles.stateBox}>
+          <Text style={styles.stateTitle}>Verse reference is invalid</Text>
+          <Text style={styles.stateBody}>
+            A valid verse looks like 4.38. Return to Wisdom and tap a verse to
+            open it.
+          </Text>
+        </View>
+      </DivineScreenWrapper>
+    );
+  }
+
+  if (isLoading && !sanskrit) {
+    return (
+      <DivineScreenWrapper>
+        <Header
+          title={`BG ${chapterNum}.${verseNum}`}
+          subtitle={chapterEnglish}
+          insetTop={insets.top}
+          onBack={() => router.back()}
+          onBell={() => router.push('/(app)/notifications' as never)}
+        />
+        <View style={styles.stateBox}>
+          <OmLoader size={64} label="Unveiling the verse…" />
+        </View>
+      </DivineScreenWrapper>
+    );
+  }
+
+  return (
+    <DivineScreenWrapper>
+      <Header
+        title={`BG ${chapterNum}.${verseNum}`}
+        subtitle={chapterEnglish}
+        insetTop={insets.top}
+        onBack={() => router.back()}
+        onBell={() => router.push('/(app)/notifications' as never)}
+      />
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.scroll,
+          { paddingBottom: insets.bottom + 120 },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Sub-header row: chapter ref + nav arrows */}
+        <View style={styles.subHeader}>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.subRef} numberOfLines={1}>
+              {`BG ${chapterNum}.${verseNum}`}
+              {chapterUpperLatin
+                ? `  ·  ${chapterUpperLatin}`
+                : chapterSanskritName
+                  ? `  ·  ${chapterSanskritName}`
+                  : ''}
+            </Text>
+          </View>
+          <View style={styles.navArrows}>
+            <NavArrow
+              onPress={() => goToVerse(-1)}
+              accessibilityLabel="Previous verse"
+              icon={<ChevronLeft size={18} color={GOLD} />}
+            />
+            <NavArrow
+              onPress={() => goToVerse(1)}
+              accessibilityLabel="Next verse"
+              icon={<ChevronRight size={18} color={GOLD} />}
+            />
+          </View>
+        </View>
+
+        {/* Sanskrit body */}
+        {sanskrit ? (
+          <Animated.View
+            entering={FadeInDown.duration(420)}
+            style={styles.sanskritBlock}
+          >
+            <Text
+              style={styles.sanskrit}
+              accessibilityLanguage="sa"
+              allowFontScaling
+            >
+              {sanskrit}
+            </Text>
+            <Text style={styles.verseStamp}>{`${chapterNum}.${verseNum}`}</Text>
+          </Animated.View>
+        ) : null}
+
+        <Divider />
+
+        {/* Transliteration */}
+        {transliteration ? (
+          <Animated.View entering={FadeIn.delay(160).duration(360)}>
+            <Text style={styles.translit}>{transliteration}</Text>
+          </Animated.View>
+        ) : null}
+
+        <Divider />
+
+        {/* Translation */}
+        {translation ? (
+          <Animated.View entering={FadeIn.delay(220).duration(360)}>
+            <Text style={styles.translation}>{translation}</Text>
+          </Animated.View>
+        ) : null}
+
+        {/* Listening voice picker */}
+        <Animated.View
+          entering={FadeIn.delay(280).duration(360)}
+          style={styles.voiceSection}
+        >
+          <Text style={styles.voiceLabel}>LISTENING VOICE</Text>
+
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.voiceRow}
+          >
+            {VOICES.map((voice) => {
+              const selected = voice.id === selectedVoiceId;
+              return (
+                <Pressable
+                  key={voice.id}
+                  onPress={() => handleSelectVoice(voice.id)}
+                  style={[
+                    styles.voicePill,
+                    selected
+                      ? {
+                          backgroundColor: voice.color + '22',
+                          borderColor: voice.color + '88',
+                        }
+                      : null,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${voice.name} voice`}
+                  accessibilityState={{ selected }}
+                >
+                  <Text
+                    style={[
+                      styles.voicePillText,
+                      selected
+                        ? { color: voice.color, fontWeight: '600' }
+                        : null,
+                    ]}
+                  >
+                    {voice.name}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+
+          <Text style={styles.voiceDescription}>{selectedVoice.description}</Text>
+          <Text style={styles.voiceNote}>
+            {`${selectedVoice.name}'s voice is set to ${selectedVoice.speed.toFixed(2).replace(/0$/, '')}× for sacred reverence`}
+          </Text>
+        </Animated.View>
+
+        {/* Listen + bookmark + share */}
+        <Animated.View
+          entering={FadeIn.delay(340).duration(360)}
+          style={styles.actionRow}
+        >
+          <Pressable
+            onPress={handleListen}
+            style={({ pressed }) => [
+              styles.listenBtn,
+              pressed && { opacity: 0.85 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={isSpeaking ? 'Stop listening' : 'Listen'}
+          >
+            <LinearGradient
+              colors={['rgba(140,103,225,0.30)', 'rgba(108,79,178,0.20)']}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={StyleSheet.absoluteFill}
+            />
+            {isSpeaking ? (
+              <Pause size={18} color={PURPLE_TEXT} fill={PURPLE_TEXT} />
+            ) : (
+              <Play size={18} color={PURPLE_TEXT} fill={PURPLE_TEXT} />
+            )}
+            <Text style={styles.listenText}>
+              {isSpeaking ? 'Stop' : 'Listen'}
+            </Text>
+          </Pressable>
+
+          <Pressable
+            onPress={handleBookmark}
+            style={({ pressed }) => [
+              styles.iconBtn,
+              isBookmarked && {
+                backgroundColor: GOLD_SOFT,
+                borderColor: GOLD_BORDER,
+              },
+              pressed && { opacity: 0.8 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={
+              isBookmarked ? 'Remove bookmark' : 'Bookmark verse'
+            }
+            accessibilityState={{ selected: isBookmarked }}
+          >
+            {isBookmarked ? (
+              <BookmarkCheck size={20} color={GOLD} fill={GOLD} />
+            ) : (
+              <Bookmark size={20} color={TEXT_SECONDARY} />
+            )}
+          </Pressable>
+
+          <Pressable
+            onPress={handleShare}
+            style={({ pressed }) => [
+              styles.iconBtn,
+              pressed && { opacity: 0.8 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Share verse"
+          >
+            <Share2 size={20} color={TEXT_SECONDARY} />
+          </Pressable>
+        </Animated.View>
+      </ScrollView>
+    </DivineScreenWrapper>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+
+interface HeaderProps {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly insetTop: number;
+  readonly onBack: () => void;
+  readonly onBell: () => void;
+}
+
+function Header({
+  title,
+  subtitle,
+  insetTop,
+  onBack,
+  onBell,
+}: HeaderProps): React.JSX.Element {
+  return (
+    <View style={[styles.header, { paddingTop: insetTop + 8 }]}>
+      <Pressable
+        onPress={onBack}
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+        hitSlop={12}
+        style={styles.headerBtn}
+      >
+        <ChevronLeft size={22} color={TEXT_PRIMARY} />
+      </Pressable>
+
+      <View style={styles.headerTitles}>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text style={styles.headerSubtitle} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+
+      <Pressable
+        onPress={onBell}
+        accessibilityRole="button"
+        accessibilityLabel="Open notifications"
+        hitSlop={12}
+        style={styles.headerBtn}
+      >
+        <Bell size={20} color={TEXT_PRIMARY} />
+      </Pressable>
+    </View>
+  );
+}
+
+function NavArrow({
+  onPress,
+  icon,
+  accessibilityLabel,
+}: {
+  readonly onPress: () => void;
+  readonly icon: React.ReactNode;
+  readonly accessibilityLabel: string;
+}): React.JSX.Element {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={6}
+      style={({ pressed }) => [
+        styles.navArrow,
+        pressed && { opacity: 0.7 },
+      ]}
+    >
+      {icon}
+    </Pressable>
+  );
+}
+
+function Divider(): React.JSX.Element {
+  return (
+    <LinearGradient
+      colors={['transparent', 'rgba(212,160,23,0.30)', 'transparent']}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 0 }}
+      style={styles.divider}
+    />
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────
+const styles = StyleSheet.create({
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+    gap: 8,
+  },
+  headerBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitles: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 2,
+  },
+  headerTitle: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    fontSize: 20,
+    color: TEXT_PRIMARY,
+  },
+  headerSubtitle: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 12,
+    color: '#9FB7C7',
+    letterSpacing: 0.4,
+  },
+
+  // Sub-header
+  scroll: {
+    paddingHorizontal: 20,
+    gap: 18,
+  },
+  subHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 4,
+  },
+  subRef: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    letterSpacing: 1.4,
+    color: GOLD,
+  },
+  navArrows: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  navArrow: {
+    width: 38,
+    height: 38,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: GOLD_SOFT,
+    borderWidth: 1,
+    borderColor: GOLD_BORDER,
+  },
+
+  // Sanskrit
+  sanskritBlock: {
+    gap: 6,
+  },
+  sanskrit: {
+    fontFamily: 'NotoSansDevanagari-Regular',
+    fontStyle: 'italic',
+    fontSize: 22,
+    lineHeight: 40,
+    color: GOLD_BRIGHT,
+  },
+  verseStamp: {
+    fontFamily: 'CormorantGaramond-SemiBoldItalic',
+    fontSize: 22,
+    color: GOLD,
+    marginTop: 6,
+  },
+
+  // Divider
+  divider: {
+    height: 1,
+    width: '100%',
+  },
+
+  // Transliteration
+  translit: {
+    fontFamily: 'CrimsonText-Italic',
+    fontSize: 14,
+    lineHeight: 24,
+    color: TEXT_SECONDARY,
+  },
+
+  // Translation
+  translation: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 15,
+    lineHeight: 26,
+    color: TEXT_PRIMARY,
+  },
+
+  // Voice section
+  voiceSection: {
+    gap: 10,
+  },
+  voiceLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    letterSpacing: 1.4,
+    color: TEXT_MUTED,
+  },
+  voiceRow: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingRight: 16,
+  },
+  voicePill: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: GOLD_BORDER,
+    backgroundColor: 'transparent',
+  },
+  voicePillText: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    color: TEXT_SECONDARY,
+  },
+  voiceDescription: {
+    fontFamily: 'CrimsonText-Italic',
+    fontSize: 13,
+    color: TEXT_SECONDARY,
+    marginTop: 4,
+  },
+  voiceNote: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 11,
+    color: TEXT_MUTED,
+  },
+
+  // Listen + actions
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  listenBtn: {
+    flex: 1,
+    height: 52,
+    borderRadius: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: PURPLE_BG,
+    borderWidth: 1,
+    borderColor: PURPLE_BORDER,
+    overflow: 'hidden',
+  },
+  listenText: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 15,
+    color: PURPLE_TEXT,
+    letterSpacing: 0.4,
+  },
+  iconBtn: {
+    width: 52,
+    height: 52,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: SURFACE_DIM,
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.15)',
+  },
+
+  // States
+  stateBox: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    gap: 12,
+  },
+  stateTitle: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    fontSize: 18,
+    color: '#E57373',
+    textAlign: 'center',
+  },
+  stateBody: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    lineHeight: 20,
+    color: TEXT_SECONDARY,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
1:1 native parity for the kiaanverse.com/m/wisdom flow on Expo:

• Wisdom landing (/wisdom) mirrors the web Today's Wisdom card
  (Sanskrit + translation + commentary + heart/copy/share/Read More),
  the 6-tile Explore-by-Theme grid, and the Ask KIAAN / Wisdom Chat
  Rooms / Explore the Bhagavad Gita CTA rows. Reads the
  verse-of-the-day from the persisted gitaStore so the card hydrates
  offline against the bundled 700-verse corpus.

• Read More reader (/wisdom/verse/[chapter]/[verse]) renders the full
  shloka with Devanagari, IAST transliteration, English translation,
  the chapter sub-header (e.g. BG 4.38 · JNANA KARMA SANNYAS YOGA),
  prev/next nav arrows, and the four-voice listening picker (Krishna,
  Saraswati, Rishi, Nova). Listen plays the Sanskrit through expo-speech
  with per-voice rate / pitch / locale so each pill sounds distinct on
  device, matching the web's SpeechSynthesis fallback. Bookmark and
  share are wired to the gitaStore + native share sheet.

• Home Today's Shloka card is now tappable and opens /wisdom while
  preserving the inner Ask Sakha and bookmark buttons.

• Wisdom stack registered in the root layout so Expo Router resolves
  the deep-link routes.

Verified: tsc --noEmit clean, eslint clean, all 153 jest tests pass.

https://claude.ai/code/session_012z4maDW1r4xHkq6kaaK5Nj