### PR TITLE
fix(mobile): stop Relationship Compass from crashing the Play Store build

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -11,14 +11,21 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: 'Kiaanverse',
   slug: 'kiaanverse',
-  // 1.3.0 bundles native additions that landed after the 1.2.0 Play build:
-  // expo-document-picker (Vibe Player "My Music" import) and the transitive
-  // native pieces pulled in by the Sacred Reflections / Sakha chat PRs. With
-  // runtimeVersion: { policy: 'appVersion' } every OTA is scoped to the
-  // `version` string, so bumping from 1.2.0 → 1.3.0 prevents expo-updates
-  // from pushing JS that imports new native modules to APKs compiled before
-  // those modules existed. The matching versionCode bump is required by Play.
-  version: '1.3.0',
+  // 1.3.1 ships the Relationship Compass Android-release crash fix:
+  //   • R8/Proguard keep rules for react-native-svg, react-native-reanimated,
+  //     gesture-handler, lottie and the Hermes Intl bridge (without these the
+  //     Compass radar + compass-rose chambers crash the JNI bridge with
+  //     NoClassDefFoundError on the first render of the screen);
+  //   • Hermes-safe date formatting in the Seal + Gita Counsel chambers
+  //     (Intl.DateTimeFormat / toLocaleDateString were aborting render);
+  //   • numeric-only animated props for the SVG chamber animations
+  //     (animating SVG transform strings via useAnimatedProps was NPE-ing
+  //     react-native-svg's ViewManager off the UI thread).
+  // 1.3.0 bundled native additions (expo-document-picker, Sakha chat).
+  // runtimeVersion: { policy: 'appVersion' } scopes OTAs to `version`, so
+  // bumping prevents expo-updates from pushing the new JS to the broken
+  // 1.3.0 APK. The matching versionCode bump is required by Play.
+  version: '1.3.1',
   orientation: 'portrait',
   icon: './assets/icon.png',
   scheme: 'kiaanverse',
@@ -68,7 +75,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 
   android: {
     package: 'com.kiaanverse.app',
-    versionCode: 21,
+    versionCode: 22,
     adaptiveIcon: {
       foregroundImage: './assets/adaptive-icon.png',
       // COSMIC_VOID — canonical KIAANVERSE cosmic backdrop
@@ -136,7 +143,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
           // `with-track-player-android` plugin appends the same block as
           // a fail-safe in case this property is ignored by an older
           // expo-build-properties version. Stripping any of these classes
-          // breaks audio output silently in release builds.
+          // breaks audio output silently in release builds — and, as of
+          // 1.3.1, breaks Relationship Compass on Play Store (the SVG +
+          // Reanimated chambers crash the JNI bridge when their native
+          // classes are stripped, which manifests as instant app shutdown
+          // the moment the user taps the tool).
           extraProguardRules: [
             '# react-native-track-player audio pipeline (keep — see app.config.ts)',
             '-keep class com.doublesymmetry.** { *; }',
@@ -153,6 +164,51 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             '-dontwarn com.google.android.exoplayer2.**',
             '-dontwarn androidx.media3.**',
             '-keep class * extends androidx.media.session.MediaButtonReceiver { *; }',
+            '',
+            '# react-native-svg (Relationship Compass radar + compass-rose). R8',
+            '# strips the Fabric/JSI ViewManager classes because they are loaded',
+            '# reflectively from JS — the JS bridge instantiates a native view',
+            '# whose class is gone, and the resulting NoClassDefFoundError on',
+            '# the UI thread aborts the app.',
+            '-keep class com.horcrux.svg.** { *; }',
+            '-keep interface com.horcrux.svg.** { *; }',
+            '-dontwarn com.horcrux.svg.**',
+            '',
+            '# react-native-reanimated (worklet runtime + animated props).',
+            '# Reanimated registers C++ JSI bindings on a background thread;',
+            '# stripping its Java entry points crashes the worklet runtime',
+            '# the first time a useSharedValue / useAnimatedProps fires.',
+            '-keep class com.swmansion.reanimated.** { *; }',
+            '-keep interface com.swmansion.reanimated.** { *; }',
+            '-keep class com.facebook.react.turbomodule.** { *; }',
+            '-dontwarn com.swmansion.reanimated.**',
+            '',
+            '# react-native-gesture-handler — wired through Reanimated, same',
+            '# reflective lookup pattern.',
+            '-keep class com.swmansion.gesturehandler.** { *; }',
+            '-keep interface com.swmansion.gesturehandler.** { *; }',
+            '',
+            '# lottie-react-native — used by arrival + sacred animations,',
+            '# loaded by JS class name from JSON specs.',
+            '-keep class com.airbnb.android.react.lottie.** { *; }',
+            '-keep class com.airbnb.lottie.** { *; }',
+            '-dontwarn com.airbnb.lottie.**',
+            '',
+            '# Hermes Intl ICU bridge — keeps `new Intl.DateTimeFormat(...)`',
+            '# from throwing NoClassDefFoundError on stripped builds. Even',
+            '# though we replaced our Intl calls with manual formatters in',
+            '# 1.3.1, third-party libs (date-fns/intl, RN core) may still',
+            '# touch these symbols.',
+            '-keep class com.facebook.hermes.intl.** { *; }',
+            '-dontwarn com.facebook.hermes.intl.**',
+            '',
+            '# React Native core — keep ReactPackage / ReactModule / view',
+            '# manager metadata so autolinked native modules survive R8.',
+            '-keep @com.facebook.react.module.annotations.ReactModule class * { *; }',
+            '-keep @com.facebook.react.module.annotations.ReactModuleList class * { *; }',
+            '-keep class * implements com.facebook.react.bridge.ReactPackage { *; }',
+            '-keep class * extends com.facebook.react.uimanager.ViewManager { *; }',
+            '-keepclassmembers,includedescriptorclasses class * { native <methods>; }',
           ].join('\n'),
         },
       },

--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -18,9 +18,15 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   //     NoClassDefFoundError on the first render of the screen);
   //   • Hermes-safe date formatting in the Seal + Gita Counsel chambers
   //     (Intl.DateTimeFormat / toLocaleDateString were aborting render);
-  //   • numeric-only animated props for the SVG chamber animations
-  //     (animating SVG transform strings via useAnimatedProps was NPE-ing
-  //     react-native-svg's ViewManager off the UI thread).
+  //   • numeric-only animated props for the SVG chamber animations in both
+  //     Relationship Compass (CompassRose, DharmaRadar) and Karma Reset
+  //     (KarmaSealMandala) — animating SVG transform strings via
+  //     useAnimatedProps was NPE-ing react-native-svg's ViewManager off
+  //     the UI thread;
+  //   • Hermes-safe sentence splitter in useCompassWisdom (the previous
+  //     regex used lookbehind + Unicode property escapes, both unsupported
+  //     by Hermes — every API response was being silently swapped for the
+  //     offline fallback because the regex literal threw SyntaxError).
   // 1.3.0 bundled native additions (expo-document-picker, Sakha chat).
   // runtimeVersion: { policy: 'appVersion' } scopes OTAs to `version`, so
   // bumping prevents expo-updates from pushing the new JS to the broken

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/CompassSealChamber.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/CompassSealChamber.tsx
@@ -24,6 +24,7 @@ import { GoldenButton } from '@kiaanverse/ui';
 
 import { CompassRose } from '../components/CompassRose';
 import type { GunaName } from '../hooks/useGunaCalculation';
+import { formatLongDate } from '../utils/formatDate';
 
 const SACRED_WHITE = '#F5F0E8';
 const TEXT_MUTED = 'rgba(200, 191, 168, 0.65)';
@@ -66,13 +67,10 @@ export function CompassSealChamber({
   const dominantLabel =
     dominantGuna.charAt(0).toUpperCase() + dominantGuna.slice(1);
 
-  const formattedDate = useMemo(() => {
-    return new Intl.DateTimeFormat('en-IN', {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-    }).format(new Date(sealedAt));
-  }, [sealedAt]);
+  // Hermes-safe formatting — see utils/formatDate.ts. Using Intl.DateTimeFormat
+  // here was crashing the Play Store AAB build the moment the Seal chamber
+  // rendered, taking the whole app down.
+  const formattedDate = useMemo(() => formatLongDate(sealedAt), [sealedAt]);
 
   const goHome = () => router.replace('/(tabs)' as never);
   const goJournal = () => {

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/GitaCounselChamber.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/GitaCounselChamber.tsx
@@ -32,6 +32,7 @@ import Svg, { Circle, Line, Path } from 'react-native-svg';
 import { GoldenButton } from '@kiaanverse/ui';
 
 import type { CompassTransmission } from '../hooks/useCompassWisdom';
+import { formatShortDateTime } from '../utils/formatDate';
 
 /**
  * Optional clipboard support — `expo-clipboard` may or may not be linked
@@ -274,11 +275,14 @@ export function GitaCounselChamber({
     });
   }, [isSpeaking, transmission]);
 
-  const formattedTimestamp = useMemo(() => {
-    if (!transmission) return '';
-    const d = new Date(transmission.generatedAt);
-    return `${d.toLocaleDateString('en-IN')}, ${d.toLocaleTimeString('en-IN', { hour12: false })}`;
-  }, [transmission]);
+  // Hermes-safe formatting — see utils/formatDate.ts. The previous
+  // toLocaleDateString / toLocaleTimeString calls could throw on Android
+  // release builds when the bundled ICU data is missing the requested
+  // locale, taking the screen down with them.
+  const formattedTimestamp = useMemo(
+    () => (transmission ? formatShortDateTime(transmission.generatedAt) : ''),
+    [transmission]
+  );
 
   if (loading || !transmission) {
     return (

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/components/CompassRose.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/components/CompassRose.tsx
@@ -33,7 +33,22 @@ export interface CompassRoseProps {
   readonly testID?: string;
 }
 
-/** A single animated petal at a fixed angle. */
+/** A single animated petal at a fixed angle.
+ *
+ * Animation strategy (Android-release-safe):
+ *   - Rotation is FIXED per petal — rendered as a static SVG `transform`
+ *     prop. Static props go through the regular Fabric props path and are
+ *     parsed by react-native-svg synchronously at mount, so they never
+ *     touch the Reanimated UI-thread JSI fast-path.
+ *   - The bloom effect (scale 0 → 1) is implemented by interpolating `rx`
+ *     and `ry` from 0 → final value rather than by animating an SVG
+ *     transform string. Animating numeric SVG props through
+ *     `useAnimatedProps` is well-supported on every react-native-svg /
+ *     Reanimated combination; animating string transforms via the same
+ *     hook crashes the JNI bridge on Hermes release AABs (the ViewManager
+ *     receives a partially-parsed transform off the UI thread and aborts).
+ *   - Opacity is a plain numeric prop, also safe to animate.
+ */
 function Petal({
   angle,
   index,
@@ -43,11 +58,17 @@ function Petal({
   readonly index: number;
   readonly size: number;
 }) {
-  const scale = useSharedValue(0);
+  const grow = useSharedValue(0);
   const opacity = useSharedValue(0);
 
+  const targetRx = size * 0.067;
+  const targetRy = size * 0.23;
+  const cx = size / 2;
+  const cy = size * 0.23;
+  const pivot = size / 2;
+
   useEffect(() => {
-    scale.value = withDelay(
+    grow.value = withDelay(
       index * 80,
       withSpring(1, { damping: 12, stiffness: 120 })
     );
@@ -55,24 +76,24 @@ function Petal({
       index * 80,
       withTiming(1, { duration: 320, easing: Easing.out(Easing.cubic) })
     );
-  }, [scale, opacity, index]);
+  }, [grow, opacity, index]);
 
   const animatedProps = useAnimatedProps(() => ({
     opacity: opacity.value,
-    transform: `rotate(${angle} ${size / 2} ${size / 2}) scale(${scale.value})`,
+    rx: targetRx * grow.value,
+    ry: targetRy * grow.value,
   }));
 
   return (
     <AnimatedEllipse
       animatedProps={animatedProps}
-      cx={size / 2}
-      cy={size * 0.23}
-      rx={size * 0.067}
-      ry={size * 0.23}
+      cx={cx}
+      cy={cy}
+      rx={0}
+      ry={0}
       fill={PETAL_COLOR}
       fillOpacity={0.7}
-      // Initial transform so petals start at centre (scale 0)
-      transform={`rotate(${angle} ${size / 2} ${size / 2})`}
+      transform={`rotate(${angle} ${pivot} ${pivot})`}
     />
   );
 }

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/components/DharmaRadar.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/components/DharmaRadar.tsx
@@ -95,23 +95,25 @@ function DharmaRadarInner({
 }: DharmaRadarProps): React.JSX.Element {
   const scale = size / VIEWPORT;
   const polygonOpacity = useSharedValue(0);
-  const polygonScale = useSharedValue(0);
   const dotOpacity = useSharedValue(0);
 
   useEffect(() => {
+    // Polygon fades in. The previous "bloom from centre" effect was driven
+    // by an animated SVG transform string fed through `useAnimatedProps`,
+    // which crashed react-native-svg's native ViewManager on Android release
+    // builds (the worklet writes the prop directly to the UI thread, the
+    // ViewManager NPEs while parsing the partially-applied transform). We
+    // animate only the numeric `opacity` prop here; the visual is a soft
+    // fade-in instead of a scale-up bloom.
     polygonOpacity.value = withDelay(
       150,
       withTiming(1, { duration: 480, easing: Easing.out(Easing.cubic) })
-    );
-    polygonScale.value = withDelay(
-      150,
-      withTiming(1, { duration: 600, easing: Easing.out(Easing.cubic) })
     );
     dotOpacity.value = withDelay(
       400,
       withTiming(1, { duration: 320, easing: Easing.out(Easing.cubic) })
     );
-  }, [polygonOpacity, polygonScale, dotOpacity, dharmaValues]);
+  }, [polygonOpacity, dotOpacity, dharmaValues]);
 
   const points = useMemo(
     () =>
@@ -127,7 +129,6 @@ function DharmaRadarInner({
 
   const polygonAnimProps = useAnimatedProps(() => ({
     opacity: polygonOpacity.value,
-    transform: `scale(${polygonScale.value}) translate(${(1 - polygonScale.value) * CENTER * scale}, ${(1 - polygonScale.value) * CENTER * scale})`,
   }));
 
   const dotAnimProps = useAnimatedProps(() => ({ opacity: dotOpacity.value }));

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/hooks/useCompassWisdom.ts
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/hooks/useCompassWisdom.ts
@@ -133,9 +133,29 @@ function splitIntoSteps(
   fallback: CompassTransmission
 ): readonly CompassTransmissionStep[] {
   // Split at sentence boundaries that precede a capital letter (English
-  // upper-case OR any Devanagari letter, both covered by \p{Lu}/\p{L}).
-  const sentences = guidance
-    .split(/(?<=[.!?])\s+(?=\p{Lu}|\p{L})/u)
+  // upper-case A-Z) or any Devanagari letter (U+0900–U+097F).
+  //
+  // The previous implementation used `/(?<=[.!?])\s+(?=\p{Lu}|\p{L})/u`,
+  // which combined a lookbehind assertion AND Unicode property escapes —
+  // BOTH unsupported by Hermes (the engine used in our Android release
+  // builds). On Hermes the regex literal threw a `SyntaxError` the first
+  // time `splitIntoSteps` ran, the surrounding try/catch silently swapped
+  // in the offline fallback, and every API response was discarded — users
+  // saw the canned offline transmission no matter what the backend
+  // actually returned.
+  //
+  // Hermes-safe replacement strategy: replace the boundary with a sentinel
+  // string using a forward-only regex (lookahead is supported, lookbehind
+  // is not) and explicit Unicode ranges (no `\p{...}`), then split on the
+  // sentinel. The captured punctuation `$1` is preserved so sentences
+  // keep their terminators.
+  const SENTINEL = '__COMPASS_SPLIT__';
+  const marked = guidance.replace(
+    /([.!?])\s+(?=[A-Zऀ-ॿ])/g,
+    `$1${SENTINEL}`
+  );
+  const sentences = marked
+    .split(SENTINEL)
     .map((s) => s.trim())
     .filter(Boolean);
 

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/utils/formatDate.ts
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/utils/formatDate.ts
@@ -1,0 +1,63 @@
+/**
+ * Hermes-safe date formatters for the Relationship Compass.
+ *
+ * Why this file exists
+ * --------------------
+ * `new Intl.DateTimeFormat('en-IN', …)` and `Date.prototype.toLocaleDateString`
+ * are technically supported by Hermes on Android, but in Hermes builds shipped
+ * with React Native 0.74.5 (Expo SDK 51) calling them on the UI thread inside
+ * a useMemo / render path can throw `ReferenceError: Intl is not defined` or
+ * `RangeError: Invalid time value` when:
+ *   • the bundled ICU data does not carry the requested locale
+ *   • R8 has stripped `com.facebook.hermes.intl.*`
+ *   • the Date is invalid (sealedAt missing / malformed)
+ *
+ * On a release AAB any of those throws inside render unwinds straight past
+ * the JS exception handler and aborts the process — the user sees the app
+ * "shut down" the moment the Compass Seal chamber mounts. To remove the
+ * entire risk we format dates with explicit string concatenation here. No
+ * locale support, but the Compass UI only ever needs `25 April 2026` and a
+ * 24-hour clock.
+ */
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+const pad2 = (n: number): string => (n < 10 ? `0${n}` : String(n));
+
+/** Coerce input into a valid Date, falling back to "now" on garbage input. */
+function safeDate(input: string | number | Date | null | undefined): Date {
+  if (input instanceof Date && !isNaN(input.getTime())) return input;
+  if (input === null || input === undefined || input === '') return new Date();
+  const d = new Date(input);
+  return isNaN(d.getTime()) ? new Date() : d;
+}
+
+/** "25 April 2026" — used by the Compass Seal summary card. */
+export function formatLongDate(input: string | number | Date | null | undefined): string {
+  const d = safeDate(input);
+  const month = MONTHS[d.getMonth()] ?? '';
+  return `${d.getDate()} ${month} ${d.getFullYear()}`;
+}
+
+/** "25/04/2026, 14:32" — used by the Gita Counsel transmission timestamp. */
+export function formatShortDateTime(
+  input: string | number | Date | null | undefined
+): string {
+  const d = safeDate(input);
+  const date = `${pad2(d.getDate())}/${pad2(d.getMonth() + 1)}/${d.getFullYear()}`;
+  const time = `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+  return `${date}, ${time}`;
+}

--- a/kiaanverse-mobile/apps/mobile/components/karma-reset/visuals/KarmaSealMandala.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/karma-reset/visuals/KarmaSealMandala.tsx
@@ -52,6 +52,9 @@ function Petal({
 }: PetalProps): React.JSX.Element {
   const progress = useSharedValue(0);
   const angle = (360 / PETAL_COUNT) * index;
+  const targetRx = petalWidth / 2;
+  const targetRy = petalLength / 2;
+  const targetCy = -petalLength / 2 - 8;
 
   useEffect(() => {
     progress.value = withDelay(
@@ -60,20 +63,35 @@ function Petal({
     );
   }, [progress, index]);
 
-  // react-native-svg reads `opacity` and `transform` from animatedProps
+  // Animation strategy (Android-release-safe):
+  //   - Rotation per petal is FIXED — rendered as a static SVG `transform`
+  //     prop on the AnimatedEllipse. Static transforms travel through the
+  //     standard Fabric props path, parsed by react-native-svg at mount.
+  //   - The "bloom from centre" effect is reproduced by interpolating
+  //     numeric SVG props (`rx`, `ry`, `cy`, `opacity`) from 0 → final
+  //     value. As `progress` goes 0 → 1 the petal grows AND moves outward
+  //     along its rotated axis, producing the same visual as the previous
+  //     `scale(progress)` transform.
+  //   - The previous animated SVG `transform` STRING was crashing
+  //     react-native-svg's ViewManager on Hermes release builds — the
+  //     Reanimated worklet writes the partial string to the UI thread via
+  //     JSI and the SVG ViewManager NPEs while parsing it.
   const animatedProps = useAnimatedProps(() => ({
     opacity: progress.value,
-    transform: `rotate(${angle}) scale(${progress.value})`,
+    rx: targetRx * progress.value,
+    ry: targetRy * progress.value,
+    cy: targetCy * progress.value,
   }));
 
   return (
     <AnimatedEllipse
       cx={0}
-      cy={-petalLength / 2 - 8}
-      rx={petalWidth / 2}
-      ry={petalLength / 2}
+      cy={0}
+      rx={0}
+      ry={0}
       fill={isGold ? 'url(#petal-gold)' : 'url(#petal-saffron)'}
       animatedProps={animatedProps}
+      transform={`rotate(${angle})`}
     />
   );
 }

--- a/kiaanverse-mobile/apps/mobile/plugins/with-track-player-android.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/with-track-player-android.js
@@ -2,7 +2,10 @@
  * with-track-player-android.js
  *
  * Expo Config Plugin — fixes audio playback for `react-native-track-player`
- * in production AAB / signed-APK builds on Android 14+ (targetSdk 34/35).
+ * AND prevents R8/Proguard from stripping the native classes used by the
+ * Relationship Compass screen (react-native-svg + react-native-reanimated +
+ * lottie + Hermes Intl) in production AAB / signed-APK builds on Android
+ * 14+ (targetSdk 34/35).
  *
  * Why this exists
  * ---------------
@@ -88,6 +91,35 @@ const PROGUARD_RULES = [
   '-keep class * extends android.support.v4.media.session.MediaSessionCompat$Callback { *; }',
   '-keep class * extends androidx.media.session.MediaButtonReceiver { *; }',
   '# === end react-native-track-player ===',
+  '',
+  '# === Relationship Compass + Sacred animations (added by with-track-player-android.js) ===',
+  '# react-native-svg — radar chart + compass-rose chambers crash with',
+  '# NoClassDefFoundError when these ViewManager classes are stripped.',
+  '-keep class com.horcrux.svg.** { *; }',
+  '-keep interface com.horcrux.svg.** { *; }',
+  '-dontwarn com.horcrux.svg.**',
+  '# react-native-reanimated — worklet runtime + animated props.',
+  '-keep class com.swmansion.reanimated.** { *; }',
+  '-keep interface com.swmansion.reanimated.** { *; }',
+  '-keep class com.facebook.react.turbomodule.** { *; }',
+  '-dontwarn com.swmansion.reanimated.**',
+  '# react-native-gesture-handler — wired through Reanimated.',
+  '-keep class com.swmansion.gesturehandler.** { *; }',
+  '-keep interface com.swmansion.gesturehandler.** { *; }',
+  '# lottie-react-native — JSON-driven sacred animations.',
+  '-keep class com.airbnb.android.react.lottie.** { *; }',
+  '-keep class com.airbnb.lottie.** { *; }',
+  '-dontwarn com.airbnb.lottie.**',
+  '# Hermes Intl ICU bridge.',
+  '-keep class com.facebook.hermes.intl.** { *; }',
+  '-dontwarn com.facebook.hermes.intl.**',
+  '# React Native core ViewManagers / ReactPackages — autolinked, reflective.',
+  '-keep @com.facebook.react.module.annotations.ReactModule class * { *; }',
+  '-keep @com.facebook.react.module.annotations.ReactModuleList class * { *; }',
+  '-keep class * implements com.facebook.react.bridge.ReactPackage { *; }',
+  '-keep class * extends com.facebook.react.uimanager.ViewManager { *; }',
+  '-keepclassmembers,includedescriptorclasses class * { native <methods>; }',
+  '# === end Relationship Compass + Sacred animations ===',
 ].join('\n');
 
 /**


### PR DESCRIPTION
Three independent native crash causes were aborting the Android release
APK the moment a user opened Relationship Compass. Debug builds were
unaffected because none of these failure modes engage in dev:

1. R8/Proguard was stripping the native classes for react-native-svg,
   react-native-reanimated, gesture-handler, lottie and the Hermes Intl
   bridge. The Compass entry screen renders SVG (compass-rose, lucide
   icons) and Reanimated worklets on first paint, so the JS bridge
   immediately tries to instantiate ViewManagers whose Java classes no
   longer exist -> NoClassDefFoundError on the UI thread -> process
   abort. Added keep rules for all of the above to both
   `extraProguardRules` in app.config.ts and the `with-track-player-
   android` dangerous-mod (belt + braces, matching the existing audio
   pipeline pattern), plus generic ReactPackage / ViewManager keeps so
   future autolinked modules don't regress the same way.

2. CompassSealChamber and GitaCounselChamber were calling
   `new Intl.DateTimeFormat('en-IN', ...)` and
   `Date.prototype.toLocaleDateString('en-IN')` inside render. Hermes on
   Android ships ICU data that may not carry every requested locale, and
   in release builds the resulting throw unwinds straight through React
   and aborts the process. Replaced both with explicit string
   concatenation in a new `utils/formatDate.ts` module that tolerates
   invalid input.

3. CompassRose (rendered on Chamber I, the very first thing the user
   sees) and DharmaRadar (Chamber III) were animating SVG `transform`
   strings via `useAnimatedProps`. Reanimated 3.10 writes those props
   directly to the UI thread via JSI; react-native-svg 15.2's
   ViewManager NPEs when it receives a partially-applied transform string
   off the bridge. Refactored CompassRose to animate `rx`/`ry`/opacity
   (numeric, safe) with the rotation kept as a static `transform` prop,
   and dropped DharmaRadar's polygon scale animation in favour of a pure
   opacity fade-in.

Bumped `version` 1.3.0 -> 1.3.1 and `versionCode` 21 -> 22 so the new JS
isn't OTA-pushed onto the broken 1.3.0 APK (runtimeVersion policy is
`appVersion`).

Files:
- app.config.ts: keep rules + version bump
- plugins/with-track-player-android.js: matching keep rules in dangerous-mod
- chambers/CompassSealChamber.tsx: formatLongDate
- chambers/GitaCounselChamber.tsx: formatShortDateTime
- components/CompassRose.tsx: numeric animated props
- components/DharmaRadar.tsx: opacity-only animation
- utils/formatDate.ts: new Hermes-safe date formatters