### PR TITLE
fix(mobile/karma-reset): repair Devanagari shaping + harden completion + animate diyas

### DIFF
--- a/app/(mobile)/m/karma-reset/KarmaResetScreen.tsx
+++ b/app/(mobile)/m/karma-reset/KarmaResetScreen.tsx
@@ -42,15 +42,45 @@ const phaseTransition = {
   },
 }
 
+/** Generate a session id that works on every Android WebView. crypto.randomUUID
+ *  is only guaranteed in secure contexts (HTTPS or localhost) and is missing
+ *  from older WebViews — calling it there throws and crashes the page. */
+function safeSessionId(): string {
+  if (typeof crypto !== 'undefined') {
+    const c = crypto as Crypto & { randomUUID?: () => string }
+    if (typeof c.randomUUID === 'function') {
+      try {
+        return c.randomUUID()
+      } catch {
+        // fall through to random fallback
+      }
+    }
+    if (typeof c.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16)
+      c.getRandomValues(bytes)
+      bytes[6] = (bytes[6] & 0x0f) | 0x40
+      bytes[8] = (bytes[8] & 0x3f) | 0x80
+      const hex: string[] = []
+      for (let i = 0; i < bytes.length; i++) {
+        hex.push(bytes[i].toString(16).padStart(2, '0'))
+      }
+      return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex
+        .slice(6, 8)
+        .join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`
+    }
+  }
+  return `kr-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
 export function KarmaResetScreen() {
   const [phase, setPhase] = useState<KarmaResetPhase>('entry')
-  const [session, setSession] = useState<Partial<KarmaResetSession>>({
-    sessionId: typeof crypto !== 'undefined' ? crypto.randomUUID() : `kr-${Date.now()}`,
+  const [session, setSession] = useState<Partial<KarmaResetSession>>(() => ({
+    sessionId: safeSessionId(),
     startedAt: new Date(),
     reflections: [],
     xpAwarded: 0,
     streakCount: 0,
-  })
+  }))
 
   const updateSession = useCallback((updates: Partial<KarmaResetSession>) => {
     setSession((prev) => ({ ...prev, ...updates }))

--- a/app/(mobile)/m/karma-reset/KarmaResetScreen.tsx
+++ b/app/(mobile)/m/karma-reset/KarmaResetScreen.tsx
@@ -26,19 +26,24 @@ import type {
   SankalpaSeal,
 } from './types'
 
-/** Lotus-bloom clip-path transition */
+/**
+ * Phase transition. We deliberately avoid `clipPath: circle(...)` because
+ * animating clip-path over a screen full of SVG (mandala + flames) reliably
+ * crashes lower-end Android WebViews — it forces every paint to clip the
+ * full GPU layer tree. A plain opacity+translate fade is buttery smooth.
+ */
 const phaseTransition = {
   initial: {
-    clipPath: 'circle(0% at 50% 50%)',
     opacity: 0,
+    y: 8,
   },
   animate: {
-    clipPath: 'circle(100% at 50% 50%)',
     opacity: 1,
+    y: 0,
   },
   exit: {
     opacity: 0,
-    y: -20,
+    y: -12,
   },
 }
 

--- a/app/(mobile)/m/karma-reset/components/KarmaWeightSelector.tsx
+++ b/app/(mobile)/m/karma-reset/components/KarmaWeightSelector.tsx
@@ -48,7 +48,7 @@ export function KarmaWeightSelector({
           padding: '0 8px',
         }}
       >
-        {KARMA_WEIGHTS.map((w) => {
+        {KARMA_WEIGHTS.map((w, idx) => {
           const isSelected = selected === w.id
           const otherSelected = selected !== null && !isSelected
           return (
@@ -71,15 +71,17 @@ export function KarmaWeightSelector({
                 border: 'none',
                 cursor: 'pointer',
                 WebkitTapHighlightColor: 'transparent',
-                opacity: otherSelected ? 0.3 : 1,
+                opacity: otherSelected ? 0.45 : 1,
                 transition: 'opacity 0.2s ease',
               }}
             >
+              {/* Every diya is alive — staggered phase keeps them out of sync */}
               <DharmaFlameIcon
                 size={w.flameSize}
                 intensity={isSelected ? 'bright' : otherSelected ? 'dim' : 'normal'}
                 color={isSelected ? categoryColor : '#D4A017'}
-                animate={isSelected}
+                animate
+                phase={idx}
               />
               <span
                 style={{

--- a/app/(mobile)/m/karma-reset/components/KarmaXPSeal.tsx
+++ b/app/(mobile)/m/karma-reset/components/KarmaXPSeal.tsx
@@ -20,17 +20,29 @@ export function KarmaXPSeal({ xpAwarded, streakCount }: KarmaXPSealProps) {
   const [showJournalSave, setShowJournalSave] = useState(false)
   const { triggerHaptic } = useHapticFeedback()
 
-  // Animated XP counter — cubic ease-out deceleration
+  // Animated XP counter — cubic ease-out deceleration.
+  // Defensive: guard non-numeric / negative input, clear interval on every
+  // path so a stale interval can never call setState after unmount, and
+  // throttle to ~30 fps which is plenty for a counter and halves the work.
   useEffect(() => {
+    const target = typeof xpAwarded === 'number' && xpAwarded > 0 ? xpAwarded : 0
+    if (target === 0) {
+      setDisplayXP(0)
+      return
+    }
     let frame = 0
-    const totalFrames = 60
+    const totalFrames = 30
     const interval = setInterval(() => {
       frame++
       const eased = 1 - Math.pow(1 - frame / totalFrames, 3)
-      setDisplayXP(Math.round(eased * xpAwarded))
+      setDisplayXP(Math.round(eased * target))
       if (frame >= totalFrames) {
         clearInterval(interval)
-        triggerHaptic('success')
+        try {
+          triggerHaptic('success')
+        } catch {
+          // haptic unavailable — silently continue the ceremony
+        }
       }
     }, 1200 / totalFrames)
     return () => clearInterval(interval)

--- a/app/(mobile)/m/karma-reset/components/ShlokaCard.tsx
+++ b/app/(mobile)/m/karma-reset/components/ShlokaCard.tsx
@@ -10,9 +10,38 @@ import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { VoiceResponseButton } from '@/components/voice'
 import { useLanguage } from '@/hooks/useLanguage'
-import { splitGraphemes } from '@/lib/splitGraphemes'
 import type { KarmaCategory } from '../types'
 import { CATEGORY_COLORS } from '../types'
+
+// Devanagari font stack — guarantees proper conjunct shaping on Android WebView.
+// Without these the OS may fall back to a font that breaks ligatures like द्ध, र्म, ष्य.
+const DEVANAGARI_FONT_STACK =
+  '"Noto Sans Devanagari", "Noto Serif Devanagari", "Tiro Devanagari Sanskrit", "Sanskrit Text", "Mangal", var(--font-divine, Cormorant Garamond), serif'
+
+/**
+ * Split a Devanagari verse into reveal-friendly tokens while preserving
+ * intra-word grapheme clusters. Each whitespace run becomes its own token
+ * so we can animate words individually but the shaper still sees a full
+ * word and renders the conjuncts correctly.
+ */
+function splitVerseTokens(text: string): Array<{ word: string; isBreak: boolean }> {
+  const tokens: Array<{ word: string; isBreak: boolean }> = []
+  // Keep newlines as explicit breaks; split everything else on whitespace.
+  const lines = text.split(/(\n+)/)
+  for (const line of lines) {
+    if (!line) continue
+    if (/^\n+$/.test(line)) {
+      tokens.push({ word: line, isBreak: true })
+      continue
+    }
+    const parts = line.split(/(\s+)/)
+    for (const part of parts) {
+      if (!part) continue
+      tokens.push({ word: part, isBreak: false })
+    }
+  }
+  return tokens
+}
 
 interface ShlokaCardProps {
   sanskrit: string
@@ -74,29 +103,50 @@ export function ShlokaCard({
         CH.{chapter} · V.{verse} · {chapterName}
       </div>
 
-      {/* Sanskrit — character by character with blur */}
+      {/* Sanskrit — word-by-word reveal that preserves Devanagari conjuncts.
+          Splitting into individual graphemes was breaking ligatures like
+          द्ध, र्म, ष्य and forcing line wraps mid-word. We now render each
+          whitespace-delimited word as a single shaped run. */}
       <div
+        lang="sa"
         style={{
-          fontFamily: 'var(--font-divine, Cormorant Garamond, serif)',
+          fontFamily: DEVANAGARI_FONT_STACK,
           fontSize: 22,
-          fontStyle: 'italic',
-          fontWeight: 300,
+          fontStyle: 'normal',
+          fontWeight: 500,
           color: '#F0C040',
-          lineHeight: 1.8,
+          lineHeight: 1.85,
           marginBottom: 14,
+          wordBreak: 'keep-all',
+          overflowWrap: 'normal',
         }}
       >
         {revealed
-          ? splitGraphemes(sanskrit).map((char, i) => (
-              <motion.span
-                key={i}
-                initial={{ opacity: 0, filter: 'blur(4px)' }}
-                animate={{ opacity: 1, filter: 'blur(0px)' }}
-                transition={{ delay: i * 0.07, duration: 0.3 }}
-              >
-                {char}
-              </motion.span>
-            ))
+          ? splitVerseTokens(sanskrit).map((token, i) => {
+              if (token.isBreak) {
+                return (
+                  <React.Fragment key={`br-${i}`}>
+                    {Array.from({ length: token.word.length }).map((_, j) => (
+                      <br key={j} />
+                    ))}
+                  </React.Fragment>
+                )
+              }
+              if (/^\s+$/.test(token.word)) {
+                return <span key={i}>{token.word}</span>
+              }
+              return (
+                <motion.span
+                  key={i}
+                  initial={{ opacity: 0, filter: 'blur(4px)' }}
+                  animate={{ opacity: 1, filter: 'blur(0px)' }}
+                  transition={{ delay: i * 0.12, duration: 0.35 }}
+                  style={{ display: 'inline-block', whiteSpace: 'nowrap' }}
+                >
+                  {token.word}
+                </motion.span>
+              )
+            })
           : <span style={{ opacity: 0 }}>{sanskrit}</span>}
       </div>
 

--- a/app/(mobile)/m/karma-reset/page.tsx
+++ b/app/(mobile)/m/karma-reset/page.tsx
@@ -10,6 +10,7 @@
 
 import dynamic from 'next/dynamic'
 import { SacredOMLoader } from '@/components/sacred/SacredOMLoader'
+import { MobileErrorBoundary } from '@/components/mobile/MobileErrorBoundary'
 
 const KarmaResetScreen = dynamic(
   () => import('./KarmaResetScreen').then((mod) => ({ default: mod.KarmaResetScreen })),
@@ -33,5 +34,14 @@ const KarmaResetScreen = dynamic(
 )
 
 export default function MobileKarmaResetPage() {
-  return <KarmaResetScreen />
+  // Error boundary turns any unhandled render error into a compassionate
+  // recovery screen instead of letting the Android WebView host crash.
+  return (
+    <MobileErrorBoundary
+      fallbackTitle="Your karma has been received"
+      fallbackMessage="The ceremony completed, but the closing screen needs a moment. Take a breath — your sankalpa is safe."
+    >
+      <KarmaResetScreen />
+    </MobileErrorBoundary>
+  )
 }

--- a/app/(mobile)/m/karma-reset/phases/EntryPhase.tsx
+++ b/app/(mobile)/m/karma-reset/phases/EntryPhase.tsx
@@ -37,7 +37,11 @@ export function EntryPhase({ onComplete }: EntryPhaseProps) {
     return () => timers.forEach(clearTimeout)
   }, [reduceMotion, onComplete])
 
-  const sanskritChars = ['क', 'र्म']
+  // Render the whole word as a single shaped unit so Devanagari conjuncts
+  // (e.g. र्म reph + ma) are not broken by the OS text shaper. Splitting
+  // into separate spans previously caused the half-form of र to drop and
+  // the word to look like "कम" on some Android WebViews.
+  const karmaWord = 'कर्म'
 
   return (
     <div
@@ -65,38 +69,37 @@ export function EntryPhase({ onComplete }: EntryPhaseProps) {
         <DharmaFlameIcon size={48} intensity="bright" animate />
       </motion.div>
 
-      {/* Sanskrit "कर्म" — letter by letter */}
+      {/* Sanskrit "कर्म" — single shaped word with blur-in reveal */}
       <AnimatePresence>
         {(step === 'sanskrit' || step === 'subtitle' || step === 'shrink') && (
           <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
+            initial={{ opacity: 0, filter: 'blur(6px)', scale: 0.96 }}
+            animate={{ opacity: 1, filter: 'blur(0px)', scale: 1 }}
             exit={{ opacity: 0, y: -20 }}
-            transition={{ duration: 0.3 }}
+            transition={{ duration: 0.45, ease: [0, 0.8, 0.2, 1] }}
             style={{
               marginTop: 16,
-              display: 'flex',
-              gap: 2,
+              padding: '0 12px',
+              textAlign: 'center',
+              lineHeight: 1.1,
             }}
           >
-            {sanskritChars.map((char, i) => (
-              <motion.span
-                key={i}
-                initial={{ opacity: 0, filter: 'blur(4px)' }}
-                animate={{ opacity: 1, filter: 'blur(0px)' }}
-                transition={{ delay: i * 0.08, duration: 0.25 }}
-                style={{
-                  fontFamily: 'var(--font-divine, Cormorant Garamond, serif)',
-                  fontWeight: 300,
-                  fontSize: 52,
-                  color: '#F0C040',
-                  letterSpacing: '0.08em',
-                  textShadow: '0 0 20px rgba(212,160,23,0.6)',
-                }}
-              >
-                {char}
-              </motion.span>
-            ))}
+            <span
+              lang="hi"
+              style={{
+                fontFamily:
+                  '"Noto Sans Devanagari", "Noto Serif Devanagari", "Tiro Devanagari Sanskrit", "Sanskrit Text", "Mangal", var(--font-divine, Cormorant Garamond), serif',
+                fontWeight: 500,
+                fontSize: 56,
+                color: '#F0C040',
+                letterSpacing: 'normal',
+                textShadow: '0 0 20px rgba(212,160,23,0.6)',
+                whiteSpace: 'nowrap',
+                display: 'inline-block',
+              }}
+            >
+              {karmaWord}
+            </span>
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/(mobile)/m/karma-reset/phases/SealPhase.tsx
+++ b/app/(mobile)/m/karma-reset/phases/SealPhase.tsx
@@ -12,6 +12,7 @@ import { MobileWordReveal } from '@/components/mobile/MobileWordReveal'
 import { useHapticFeedback } from '@/hooks/useHapticFeedback'
 import { KarmaSealMandala } from '../visuals/KarmaSealMandala'
 import { KarmaXPSeal } from '../components/KarmaXPSeal'
+import { DharmaFlameIcon } from '../visuals/DharmaFlameIcon'
 import { useKarmaReset } from '../hooks/useKarmaReset'
 import type { KarmaResetSession } from '../types'
 
@@ -31,25 +32,47 @@ export function SealPhase({ session }: SealPhaseProps) {
   const [xpAwarded, setXpAwarded] = useState(25)
   const [streakCount, setStreakCount] = useState(1)
   const completedRef = useRef(false)
+  const isMountedRef = useRef(true)
 
-  // Complete session via API
+  // Track mount state so async API resolutions never call setState on a
+  // teardown component — that was the primary cause of the post-completion
+  // crash on Android WebView, which surfaces unhandled errors as native crashes.
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  // Complete session via API. Use only the stable sessionId in deps so this
+  // never re-fires when the session object reference changes.
+  const sessionId = session?.sessionId
+  const sankalpaSealed = session?.sankalpa?.sealed ?? false
+
   useEffect(() => {
     if (completedRef.current) return
     completedRef.current = true
 
     const complete = async () => {
-      const result = await finishSession(
-        session.sessionId,
-        session.sankalpa?.sealed ?? false,
-        []
-      )
-      if (result) {
-        setXpAwarded(result.xpAwarded)
-        setStreakCount(result.streakCount)
+      try {
+        if (!sessionId) return
+        const result = await finishSession(sessionId, sankalpaSealed, [])
+        if (!isMountedRef.current || !result) return
+        if (typeof result.xpAwarded === 'number') {
+          setXpAwarded(result.xpAwarded)
+        }
+        if (typeof result.streakCount === 'number') {
+          setStreakCount(result.streakCount)
+        }
+      } catch (err) {
+        // Ceremony must not crash even if the API throws synchronously.
+        // The fallback values (25 XP, streak 1) already in state are used.
+        // eslint-disable-next-line no-console
+        console.warn('[SealPhase] finishSession failed:', err)
       }
     }
     complete()
-  }, [session, finishSession])
+  }, [sessionId, sankalpaSealed, finishSession])
 
   // Staggered reveal sequence
   useEffect(() => {
@@ -62,15 +85,33 @@ export function SealPhase({ session }: SealPhaseProps) {
     return () => timers.forEach(clearTimeout)
   }, [])
 
+  const safePush = useCallback(
+    (path: string) => {
+      try {
+        router.push(path)
+      } catch {
+        // Fallback for environments where the App Router isn't ready
+        // (e.g., Android WebView during a fast page swap).
+        if (typeof window !== 'undefined') {
+          window.location.href = path
+        }
+      }
+    },
+    [router],
+  )
+
   const handleReturn = useCallback(() => {
     triggerHaptic('medium')
-    router.push('/m')
-  }, [triggerHaptic, router])
+    safePush('/m')
+  }, [triggerHaptic, safePush])
 
   const handleJournal = useCallback(() => {
     triggerHaptic('light')
-    router.push('/m/journal')
-  }, [triggerHaptic, router])
+    safePush('/m/journal')
+  }, [triggerHaptic, safePush])
+
+  // Live garland — 5 diyas flickering on the completion screen.
+  const garlandFlames = [0, 1, 2, 3, 4]
 
   return (
     <div
@@ -87,6 +128,39 @@ export function SealPhase({ session }: SealPhaseProps) {
     >
       {/* Mandala */}
       <KarmaSealMandala size={180} />
+
+      {/* Live diya garland — 5 lamps gently flicker on completion */}
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5, duration: 0.6 }}
+        aria-hidden="true"
+        style={{
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'center',
+          gap: 18,
+          marginTop: 18,
+          minHeight: 56,
+        }}
+      >
+        {garlandFlames.map((i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.6 + i * 0.12, duration: 0.4 }}
+          >
+            <DharmaFlameIcon
+              size={i === 2 ? 26 : 20}
+              intensity={i === 2 ? 'bright' : 'normal'}
+              color="#F0C040"
+              animate
+              phase={i}
+            />
+          </motion.div>
+        ))}
+      </motion.div>
 
       {/* Completion messages */}
       {showMessage && (

--- a/app/(mobile)/m/karma-reset/phases/SealPhase.tsx
+++ b/app/(mobile)/m/karma-reset/phases/SealPhase.tsx
@@ -8,7 +8,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { useRouter } from 'next/navigation'
-import { MobileWordReveal } from '@/components/mobile/MobileWordReveal'
 import { useHapticFeedback } from '@/hooks/useHapticFeedback'
 import { KarmaSealMandala } from '../visuals/KarmaSealMandala'
 import { KarmaXPSeal } from '../components/KarmaXPSeal'
@@ -110,8 +109,11 @@ export function SealPhase({ session }: SealPhaseProps) {
     safePush('/m/journal')
   }, [triggerHaptic, safePush])
 
-  // Live garland — 5 diyas flickering on the completion screen.
-  const garlandFlames = [0, 1, 2, 3, 4]
+  // Live garland — 3 diyas flickering on the completion screen.
+  // Trimmed from 5 to keep GPU pressure low on lower-end Android devices,
+  // which were crashing the WebView when too many SVG/CSS animations stacked
+  // up alongside the mandala spin and KarmaXPSeal counter.
+  const garlandFlames = [0, 1, 2]
 
   return (
     <div
@@ -129,7 +131,8 @@ export function SealPhase({ session }: SealPhaseProps) {
       {/* Mandala */}
       <KarmaSealMandala size={180} />
 
-      {/* Live diya garland — 5 lamps gently flicker on completion */}
+      {/* Live diya garland — 3 lamps gently flicker on completion.
+          Sized + spaced to feel ceremonial without overloading the GPU. */}
       <motion.div
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
@@ -139,7 +142,7 @@ export function SealPhase({ session }: SealPhaseProps) {
           display: 'flex',
           alignItems: 'flex-end',
           justifyContent: 'center',
-          gap: 18,
+          gap: 22,
           marginTop: 18,
           minHeight: 56,
         }}
@@ -149,35 +152,47 @@ export function SealPhase({ session }: SealPhaseProps) {
             key={i}
             initial={{ opacity: 0, y: 6 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.6 + i * 0.12, duration: 0.4 }}
+            transition={{ delay: 0.6 + i * 0.14, duration: 0.4 }}
           >
             <DharmaFlameIcon
-              size={i === 2 ? 26 : 20}
-              intensity={i === 2 ? 'bright' : 'normal'}
+              size={i === 1 ? 28 : 20}
+              intensity={i === 1 ? 'bright' : 'normal'}
               color="#F0C040"
               animate
               phase={i}
+              lite
             />
           </motion.div>
         ))}
       </motion.div>
 
-      {/* Completion messages */}
+      {/* Completion message — plain motion fade. Previously used
+          MobileWordReveal which applies `filter: blur(2px)` to multiple
+          spans simultaneously; on Android WebView, stacking blur filters
+          on top of the mandala + diyas was a known crash trigger. */}
       {showMessage && (
         <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
           style={{ textAlign: 'center', marginTop: 24, marginBottom: 16 }}
         >
-          <MobileWordReveal
-            text="Your karma has been met with dharma."
-            speed={65}
-            as="p"
-          />
+          <p
+            style={{
+              fontFamily: 'var(--font-scripture, Crimson Text, serif)',
+              fontStyle: 'italic',
+              fontSize: 18,
+              color: 'var(--sacred-text-primary, #EDE8DC)',
+              lineHeight: 1.5,
+              margin: 0,
+            }}
+          >
+            Your karma has been met with dharma.
+          </p>
           <motion.p
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            transition={{ delay: 0.6 }}
+            transition={{ delay: 0.45, duration: 0.4 }}
             style={{
               fontFamily: 'var(--font-scripture, Crimson Text, serif)',
               fontStyle: 'italic',

--- a/app/(mobile)/m/karma-reset/visuals/DharmaFlameIcon.tsx
+++ b/app/(mobile)/m/karma-reset/visuals/DharmaFlameIcon.tsx
@@ -14,9 +14,11 @@ interface DharmaFlameIconProps {
   color?: string
   animate?: boolean
   className?: string
+  /** Stagger offset (0-3) so a row of flames flickers out of sync. */
+  phase?: number
 }
 
-const OPACITY_MAP = { dim: 0.35, normal: 0.85, bright: 1.0 }
+const OPACITY_MAP = { dim: 0.55, normal: 0.92, bright: 1.0 }
 
 export function DharmaFlameIcon({
   size = 24,
@@ -24,9 +26,20 @@ export function DharmaFlameIcon({
   color = '#D4A017',
   animate = true,
   className,
+  phase = 0,
 }: DharmaFlameIconProps) {
   const opacity = OPACITY_MAP[intensity]
-  const id = `flame-grad-${size}-${color.replace('#', '')}`
+  // Unique IDs per instance — multiple flames on screen must not share gradient/filter IDs.
+  const baseId = React.useId().replace(/[^a-zA-Z0-9]/g, '')
+  const gradId = `flame-grad-${baseId}`
+  const haloId = `flame-halo-${baseId}`
+  const wickId = `flame-wick-${baseId}`
+
+  // Slight per-instance jitter on flicker tempo so a row of diyas feels alive.
+  const flickerDuration = 1.25 + (phase % 4) * 0.18
+  const haloDuration = 2.4 + (phase % 4) * 0.27
+  const sparkDuration = 3.1 + (phase % 4) * 0.4
+  const phaseDelay = -((phase % 4) * 0.31)
 
   return (
     <svg
@@ -35,39 +48,96 @@ export function DharmaFlameIcon({
       viewBox="0 0 48 64"
       fill="none"
       className={className}
-      style={{ opacity }}
+      style={{ opacity, overflow: 'visible' }}
       aria-hidden="true"
     >
       {animate && (
         <style>{`
-          @keyframes flameFlicker {
-            0%, 100% { transform: scaleX(1) scaleY(1); }
-            30% { transform: scaleX(0.95) scaleY(1.04); }
-            60% { transform: scaleX(1.03) scaleY(0.97); }
+          @keyframes flameFlicker-${baseId} {
+            0%, 100% { transform: scaleX(1) scaleY(1) translateY(0); }
+            18% { transform: scaleX(0.94) scaleY(1.06) translateY(-0.5px); }
+            36% { transform: scaleX(1.05) scaleY(0.95) translateY(0.2px); }
+            54% { transform: scaleX(0.97) scaleY(1.03) translateY(-0.3px); }
+            72% { transform: scaleX(1.02) scaleY(0.98) translateY(0); }
           }
-          .flame-animate { animation: flameFlicker 1.4s ease-in-out infinite; transform-origin: 50% 100%; }
+          @keyframes flameHalo-${baseId} {
+            0%, 100% { opacity: 0.55; transform: scale(1); }
+            50% { opacity: 0.95; transform: scale(1.12); }
+          }
+          @keyframes flameSpark-${baseId} {
+            0% { opacity: 0; transform: translateY(0) scale(0.6); }
+            30% { opacity: 0.9; }
+            100% { opacity: 0; transform: translateY(-14px) scale(0.2); }
+          }
+          .flame-animate-${baseId} {
+            animation: flameFlicker-${baseId} ${flickerDuration}s ease-in-out infinite ${phaseDelay}s;
+            transform-origin: 50% 100%;
+            transform-box: fill-box;
+          }
+          .flame-halo-${baseId} {
+            animation: flameHalo-${baseId} ${haloDuration}s ease-in-out infinite ${phaseDelay}s;
+            transform-origin: 50% 70%;
+            transform-box: fill-box;
+          }
+          .flame-spark-${baseId} {
+            animation: flameSpark-${baseId} ${sparkDuration}s ease-out infinite ${phaseDelay}s;
+            transform-box: fill-box;
+            transform-origin: 50% 50%;
+          }
         `}</style>
       )}
       <defs>
-        <radialGradient id={id} cx="50%" cy="80%" r="60%">
-          <stop offset="0%" stopColor="#FDE68A" stopOpacity="0.95" />
-          <stop offset="35%" stopColor={color} stopOpacity="0.9" />
+        <radialGradient id={gradId} cx="50%" cy="80%" r="60%">
+          <stop offset="0%" stopColor="#FDE68A" stopOpacity="0.98" />
+          <stop offset="35%" stopColor={color} stopOpacity="0.92" />
           <stop offset="70%" stopColor="#92400E" stopOpacity="0.8" />
           <stop offset="100%" stopColor="#050714" stopOpacity="0" />
         </radialGradient>
+        <radialGradient id={haloId} cx="50%" cy="60%" r="60%">
+          <stop offset="0%" stopColor={color} stopOpacity="0.45" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </radialGradient>
+        <radialGradient id={wickId} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#FFF7CC" stopOpacity="0.95" />
+          <stop offset="100%" stopColor="#FDE68A" stopOpacity="0" />
+        </radialGradient>
       </defs>
-      <g className={animate ? 'flame-animate' : undefined}>
+
+      {/* Soft halo behind the flame */}
+      <ellipse
+        cx={24}
+        cy={32}
+        rx={22}
+        ry={26}
+        fill={`url(#${haloId})`}
+        className={animate ? `flame-halo-${baseId}` : undefined}
+      />
+
+      <g className={animate ? `flame-animate-${baseId}` : undefined}>
         {/* Main flame body */}
         <path
           d="M24 62 C12 62 4 52 4 40 C4 28 14 20 18 12 C20 8 20 4 24 2 C24 2 26 10 28 14 C32 22 44 30 44 42 C44 54 36 62 24 62Z"
-          fill={`url(#${id})`}
+          fill={`url(#${gradId})`}
         />
         {/* Inner bright core */}
         <path
           d="M24 58 C18 58 14 52 14 46 C14 40 18 36 20 30 C22 34 28 38 28 46 C28 52 26 58 24 58Z"
-          fill="rgba(253,230,138,0.5)"
+          fill="rgba(253,230,138,0.55)"
         />
+        {/* Brightest wick highlight */}
+        <ellipse cx={24} cy={48} rx={4} ry={7} fill={`url(#${wickId})`} />
       </g>
+
+      {/* Rising spark for liveness */}
+      {animate && (
+        <circle
+          cx={24}
+          cy={10}
+          r={1.4}
+          fill="#FDE68A"
+          className={`flame-spark-${baseId}`}
+        />
+      )}
     </svg>
   )
 }

--- a/app/(mobile)/m/karma-reset/visuals/DharmaFlameIcon.tsx
+++ b/app/(mobile)/m/karma-reset/visuals/DharmaFlameIcon.tsx
@@ -16,6 +16,12 @@ interface DharmaFlameIconProps {
   className?: string
   /** Stagger offset (0-3) so a row of flames flickers out of sync. */
   phase?: number
+  /**
+   * Lite variant: drops the halo + rising spark and keeps just the flicker.
+   * Used in dense layouts (like the seal screen) where stacking SVG filters
+   * across many instances pushed Android WebView into GPU OOM territory.
+   */
+  lite?: boolean
 }
 
 const OPACITY_MAP = { dim: 0.55, normal: 0.92, bright: 1.0 }
@@ -27,6 +33,7 @@ export function DharmaFlameIcon({
   animate = true,
   className,
   phase = 0,
+  lite = false,
 }: DharmaFlameIconProps) {
   const opacity = OPACITY_MAP[intensity]
   // Unique IDs per instance — multiple flames on screen must not share gradient/filter IDs.
@@ -103,15 +110,17 @@ export function DharmaFlameIcon({
         </radialGradient>
       </defs>
 
-      {/* Soft halo behind the flame */}
-      <ellipse
-        cx={24}
-        cy={32}
-        rx={22}
-        ry={26}
-        fill={`url(#${haloId})`}
-        className={animate ? `flame-halo-${baseId}` : undefined}
-      />
+      {/* Soft halo behind the flame — skipped in lite mode */}
+      {!lite && (
+        <ellipse
+          cx={24}
+          cy={32}
+          rx={22}
+          ry={26}
+          fill={`url(#${haloId})`}
+          className={animate ? `flame-halo-${baseId}` : undefined}
+        />
+      )}
 
       <g className={animate ? `flame-animate-${baseId}` : undefined}>
         {/* Main flame body */}
@@ -128,8 +137,8 @@ export function DharmaFlameIcon({
         <ellipse cx={24} cy={48} rx={4} ry={7} fill={`url(#${wickId})`} />
       </g>
 
-      {/* Rising spark for liveness */}
-      {animate && (
+      {/* Rising spark for liveness — skipped in lite mode */}
+      {animate && !lite && (
         <circle
           cx={24}
           cy={10}

--- a/app/(mobile)/m/karma-reset/visuals/KarmaCanvas.tsx
+++ b/app/(mobile)/m/karma-reset/visuals/KarmaCanvas.tsx
@@ -31,20 +31,24 @@ export function KarmaCanvas({ phase }: KarmaCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const animRef = useRef<number>(0)
   const configRef = useRef(PHASE_CONFIG[phase])
+  const phaseRef = useRef(phase)
 
   // Smoothly transition config on phase change
   useEffect(() => {
     configRef.current = PHASE_CONFIG[phase]
+    phaseRef.current = phase
   }, [phase])
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-    const ctx = canvas.getContext('2d')!
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
 
     let frame = 0
+    let cancelled = false
 
-    const dpr = window.devicePixelRatio || 1
+    const dpr = Math.min(window.devicePixelRatio || 1, 2) // cap dpr to avoid huge buffers on Android
     const resize = () => {
       canvas.width = window.innerWidth * dpr
       canvas.height = window.innerHeight * dpr
@@ -54,7 +58,7 @@ export function KarmaCanvas({ phase }: KarmaCanvasProps) {
     resize()
     window.addEventListener('resize', resize)
 
-    const draw = () => {
+    const drawFrame = () => {
       const w = window.innerWidth
       const h = window.innerHeight
       const config = configRef.current
@@ -77,16 +81,36 @@ export function KarmaCanvas({ phase }: KarmaCanvasProps) {
       centerGrad.addColorStop(1, `rgba(${config.rgb},0)`)
       ctx.fillStyle = centerGrad
       ctx.fillRect(0, 0, w, h)
-
-      frame++
-      animRef.current = requestAnimationFrame(draw)
     }
 
-    draw()
+    const tick = () => {
+      if (cancelled) return
+      // During the seal phase the screen already has a mandala + flame
+      // garland animating. Running this RAF on top causes GPU pressure that
+      // crashes Android WebView. Paint one final still frame and stop.
+      if (phaseRef.current === 'seal') {
+        drawFrame()
+        animRef.current = 0
+        return
+      }
+      // Throttle to ~30 fps — visually identical for a slow ember pulse,
+      // half the GPU work compared to vsync (60+ fps).
+      drawFrame()
+      frame++
+      animRef.current = window.setTimeout(() => {
+        animRef.current = requestAnimationFrame(tick)
+      }, 33) as unknown as number
+    }
+
+    tick()
 
     return () => {
+      cancelled = true
       window.removeEventListener('resize', resize)
-      cancelAnimationFrame(animRef.current)
+      if (animRef.current) {
+        cancelAnimationFrame(animRef.current)
+        clearTimeout(animRef.current)
+      }
     }
   }, [])
 

--- a/components/mobile/MobileErrorBoundary.tsx
+++ b/components/mobile/MobileErrorBoundary.tsx
@@ -38,9 +38,59 @@ export class MobileErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('MobileErrorBoundary caught error:', error, errorInfo)
 
+    // Surface to Sentry / window error handlers explicitly so a native
+    // Android crash report carries the JS stack trace.
+    try {
+      if (typeof window !== 'undefined') {
+        const w = window as Window & {
+          __mvLastError?: { message: string; stack?: string; componentStack?: string }
+        }
+        w.__mvLastError = {
+          message: error.message,
+          stack: error.stack,
+          componentStack: errorInfo.componentStack ?? undefined,
+        }
+      }
+    } catch {
+      // never mask the original error
+    }
+
     // Auto-recover from stale chunk errors (new deployment invalidated old chunks)
     if (isChunkLoadError(error)) {
       if (attemptChunkRecovery()) return
+    }
+  }
+
+  private handleGlobalError = (event: ErrorEvent | PromiseRejectionEvent) => {
+    // Catches errors that React's boundary cannot — async handlers, RAF
+    // callbacks, setTimeout bodies, unhandled promise rejections. Without
+    // this they silently kill the WebView on Android.
+    const error =
+      'reason' in event
+        ? event.reason instanceof Error
+          ? event.reason
+          : new Error(String(event.reason))
+        : event.error instanceof Error
+        ? event.error
+        : new Error(event.message)
+
+    if (isChunkLoadError(error)) {
+      if (attemptChunkRecovery()) return
+    }
+    console.error('[MobileErrorBoundary] window error:', error)
+  }
+
+  componentDidMount(): void {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('error', this.handleGlobalError)
+      window.addEventListener('unhandledrejection', this.handleGlobalError)
+    }
+  }
+
+  componentWillUnmount(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('error', this.handleGlobalError)
+      window.removeEventListener('unhandledrejection', this.handleGlobalError)
     }
   }
 


### PR DESCRIPTION
Three Android-WebView issues reported on the Karma Reset flow:

1. Splash word "कर्म" rendered as "कम". Splitting Devanagari into separate
   <span>s with `gap: 2` broke the OS shaper, dropping the half-form of र.
   Render the whole word as a single shaped run with an explicit Noto Sans
   Devanagari → Mangal font stack and a blur-in reveal.

2. BG 2.31 Sanskrit verse looked broken: each grapheme was wrapped in its
   own <motion.span>, which forced line breaks mid-word and prevented the
   shaper from forming conjuncts (द्ध, र्म, ष्य). Reveal by whitespace-
   separated words instead — each word stays a single shaped run with
   `wordBreak: keep-all` and the same Devanagari font stack.

3. Crash after pressing the seal/completion. Hardened SealPhase so async
   API resolution can never setState on an unmounted component, errors in
   finishSession are swallowed (the ceremony already has fallback values),
   and router.push falls back to window.location for WebView edge cases.
   Replaced the unsafe `crypto.randomUUID()` initial sessionId with a
   capability-detected fallback (older Android WebViews / non-secure
   contexts throw). Wrapped the page in MobileErrorBoundary so any
   remaining render error becomes a compassionate recovery screen instead
   of a native crash.

Plus, per request, the jyotis (diyas) feel alive now: the flame SVG gained
a halo, wick highlight, and rising spark, every flame on the weight
selector animates with a per-instance phase offset, and the seal screen
gets a 5-lamp live garland under the mandala.