### PR TITLE
fix(mobile/vibe): make prev/next buttons actually change tracks

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/vibe-player/player.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/vibe-player/player.tsx
@@ -42,7 +42,7 @@ import {
 import { useRouter } from 'expo-router';
 import { DivineBackground } from '@kiaanverse/ui';
 import { useVibePlayerStore, type RepeatMode } from '@kiaanverse/store';
-import TrackPlayer, { useProgress } from 'react-native-track-player';
+import { useProgress } from 'react-native-track-player';
 
 import {
   PlaybackControls,
@@ -55,6 +55,8 @@ import {
   pause as bridgePause,
   resume as bridgeResume,
   seekTo as bridgeSeekTo,
+  playNextInQueue,
+  playPreviousInQueue,
 } from '../../components/vibe-player/trackPlayerBridge';
 
 const SACRED_WHITE = '#F5F0E8';
@@ -90,8 +92,6 @@ export default function VibePlayerScreen(): React.JSX.Element {
   const isPlaying = useVibePlayerStore((s) => s.isPlaying);
   const repeatMode = useVibePlayerStore((s) => s.repeatMode);
   const togglePlay = useVibePlayerStore((s) => s.togglePlay);
-  const nextTrack = useVibePlayerStore((s) => s.nextTrack);
-  const prevTrack = useVibePlayerStore((s) => s.prevTrack);
   const setRepeatMode = useVibePlayerStore((s) => s.setRepeatMode);
 
   // Live playback position from RNTP. While RNTP isn't loaded (e.g. the
@@ -108,15 +108,20 @@ export default function VibePlayerScreen(): React.JSX.Element {
     else void bridgeResume();
   }, [isPlaying, togglePlay]);
 
+  // `playNextInQueue` / `playPreviousInQueue` advance the store's queue
+  // AND replay the new track on RNTP through the same `playTrack()` path
+  // tapping a tile uses. The previous implementation called the store's
+  // mutators (which only updated Zustand) and then `TrackPlayer.skipToNext()`
+  // (which silently no-op'd because RNTP's queue is always size-1 — every
+  // playTrack starts with reset()). Both halves were broken; one consolidated
+  // call replaces them.
   const handleNext = useCallback(() => {
-    nextTrack();
-    void TrackPlayer.skipToNext().catch(() => undefined);
-  }, [nextTrack]);
+    void playNextInQueue();
+  }, []);
 
   const handlePrev = useCallback(() => {
-    prevTrack();
-    void TrackPlayer.skipToPrevious().catch(() => undefined);
-  }, [prevTrack]);
+    void playPreviousInQueue();
+  }, []);
 
   const handleRepeatCycle = useCallback(() => {
     const next = nextRepeatMode(repeatMode);

--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/trackPlayerBridge.ts
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/trackPlayerBridge.ts
@@ -21,6 +21,7 @@
  */
 
 import TrackPlayer, { State } from 'react-native-track-player';
+import { useVibePlayerStore, type VibeTrack } from '@kiaanverse/store';
 import { setupTrackPlayer } from '../../services/trackPlayerSetup';
 import {
   isLikelyPlayableUrl,
@@ -285,4 +286,68 @@ export async function seekTo(seconds: number): Promise<void> {
       console.warn('[trackPlayerBridge] seekTo failed:', err);
     }
   }
+}
+
+// ─── Queue-aware navigation ──────────────────────────────────────────────
+//
+// The Vibe Player keeps its catalog queue in the Zustand store
+// (`vibePlayerStore.queue`) — that's what populates the visible track list
+// and what `nextTrack()` / `prevTrack()` advance through. The previous
+// implementation tried to drive transport via `TrackPlayer.skipToNext()`
+// directly, which was broken: `playTrack()` always calls `reset()` and
+// adds a SINGLE track, so RNTP's internal queue is permanently size-1.
+// Skipping in a size-1 queue silently no-ops, which is why the prev/next
+// buttons did nothing on the Play Store APK.
+//
+// The fix is to keep one source of truth — the Zustand queue — and replay
+// each next/prev track through the same `playTrack()` path that already
+// handles URL coercion, bundled-asset preference, watchdog retry, volume
+// reset, and the rest of the resilience layer added in earlier commits.
+// `playNextInQueue` / `playPreviousInQueue` are the public entry points;
+// they're called from the player UI handlers AND from the headless
+// playback service (lock-screen + AirPods), so all transport sources
+// converge on the same code path.
+
+/** Convert a store `VibeTrack` into the bridge's `BridgeTrack` shape. */
+function vibeToBridgeTrack(t: VibeTrack): BridgeTrack {
+  return {
+    id: t.id,
+    title: t.title,
+    artist: t.artist,
+    audioUrl: t.audioUrl,
+    duration: t.duration,
+    ...(t.artworkUrl ? { artworkUrl: t.artworkUrl } : {}),
+  };
+}
+
+/**
+ * Advance the queue by one and replay the new track on RNTP. Honors the
+ * store's existing shuffle / repeat / end-of-queue logic via
+ * `nextTrack()`. Returns the play result, or `null` when there's nothing
+ * to play (empty queue).
+ */
+export async function playNextInQueue(): Promise<PlayResult | null> {
+  const store = useVibePlayerStore.getState();
+  if (store.queue.length === 0) return null;
+
+  store.nextTrack();
+  const next = useVibePlayerStore.getState().currentTrack;
+  if (!next) return null;
+  return playTrack(vibeToBridgeTrack(next));
+}
+
+/**
+ * Mirror of `playNextInQueue` for the previous track. Honors the store's
+ * "if more than ~5% in, restart current" rule via `prevTrack()` — which
+ * resets `progress` without changing `currentTrack`; the replay below
+ * then restarts the same track from position 0.
+ */
+export async function playPreviousInQueue(): Promise<PlayResult | null> {
+  const store = useVibePlayerStore.getState();
+  if (store.queue.length === 0) return null;
+
+  store.prevTrack();
+  const prev = useVibePlayerStore.getState().currentTrack;
+  if (!prev) return null;
+  return playTrack(vibeToBridgeTrack(prev));
 }

--- a/kiaanverse-mobile/apps/mobile/services/playbackService.ts
+++ b/kiaanverse-mobile/apps/mobile/services/playbackService.ts
@@ -18,8 +18,11 @@
  *   - RemotePlay        → resume playback
  *   - RemotePause       → pause playback
  *   - RemoteStop        → stop and clear; the OS hides the now-playing card
- *   - RemoteNext        → skip to next track in TrackPlayer's internal queue
- *   - RemotePrevious    → skip to previous track
+ *   - RemoteNext        → advance the Vibe queue and replay (was previously
+ *                         a direct TrackPlayer.skipToNext, which silently
+ *                         no-op'd because every playTrack() resets RNTP's
+ *                         internal queue to size 1)
+ *   - RemotePrevious    → mirror of RemoteNext for the previous track
  *   - RemoteSeek        → seek to position (in seconds, comes from the OS)
  *   - RemoteJumpForward → jump forward by the configured forwardJumpInterval
  *   - RemoteJumpBackward→ jump backward by the configured backwardJumpInterval
@@ -36,6 +39,10 @@
  */
 
 import TrackPlayer, { Event } from 'react-native-track-player';
+import {
+  playNextInQueue,
+  playPreviousInQueue,
+} from '../components/vibe-player/trackPlayerBridge';
 
 /**
  * Register all remote control event handlers.
@@ -58,12 +65,26 @@ module.exports = async function playbackService(): Promise<void> {
     void TrackPlayer.stop();
   });
 
+  // Lock-screen / AirPods / Bluetooth "next" and "previous" advance the
+  // Zustand queue and replay through the same bridge path the in-app UI
+  // uses. Calling `TrackPlayer.skipToNext()` directly is a no-op here
+  // because every `playTrack()` calls `reset()` and adds a single track —
+  // RNTP's internal queue is permanently size-1.
   TrackPlayer.addEventListener(Event.RemoteNext, () => {
-    void TrackPlayer.skipToNext();
+    void playNextInQueue();
   });
 
   TrackPlayer.addEventListener(Event.RemotePrevious, () => {
-    void TrackPlayer.skipToPrevious();
+    void playPreviousInQueue();
+  });
+
+  // Natural end of a track → advance to the next one in the queue.
+  // Without this, audio just stops at the end of every meditation track
+  // because RNTP's queue is size-1; ExoPlayer fires PlaybackQueueEnded
+  // and there's nothing else loaded. Routing through the bridge means
+  // shuffle / repeat / end-of-queue rules from the store are honored.
+  TrackPlayer.addEventListener(Event.PlaybackQueueEnded, () => {
+    void playNextInQueue();
   });
 
   TrackPlayer.addEventListener(Event.RemoteSeek, (event) => {


### PR DESCRIPTION
User report: on the Play Store APK, audio plays correctly when tapping a track tile, but the prev/next transport buttons do nothing. Same problem affects lock-screen / AirPods controls and end-of-track auto-advance.

## Root cause

`playTrack()` in the bridge always calls `TrackPlayer.reset()` and adds a single track, so RNTP's internal queue is permanently **size 1**. The UI handlers were calling:

```ts
nextTrack();                                  // updates Zustand only
TrackPlayer.skipToNext().catch(() => {});     // size-1 queue → silent no-op
```

Both halves were broken:
- The store mutator updated Zustand's `currentTrack` but nothing propagated that to RNTP, so playback continued with the previous track.
- The direct `skipToNext()` had nothing to skip to and silently no-op'd, with the error swallowed by the `.catch`.

Lock-screen handlers had the same flaw. `PlaybackQueueEnded` had no listener at all — playback simply stopped at the end of every meditation track.

## Fix

Single source of truth: the Zustand queue. The bridge gets two new public functions that update the store AND replay the new track through the same `playTrack()` path that already handles URL coercion, bundled-asset preference, watchdog retry, and volume reset.

| File | Change |
|---|---|
| `components/vibe-player/trackPlayerBridge.ts` | Adds `playNextInQueue()` and `playPreviousInQueue()`. Each delegates to the store's existing `nextTrack()` / `prevTrack()` (honoring shuffle, repeat, and "restart current if past ~5%"), reads the new `currentTrack`, and replays it via `playTrack()`. Imports `useVibePlayerStore` and `VibeTrack` from `@kiaanverse/store`. |
| `app/vibe-player/player.tsx` | `handleNext` / `handlePrev` now call the new bridge functions and nothing else. Removed the now-unused `TrackPlayer` default import and the dangling `nextTrack` / `prevTrack` store selectors. |
| `services/playbackService.ts` | `RemoteNext` / `RemotePrevious` wired to the same bridge functions so lock-screen, headphone in-line buttons, and AirPods all converge on one code path. Added `PlaybackQueueEnded` → `playNextInQueue()` so a track ending naturally advances the queue instead of silently stopping. |

## Verification

| Check | Result |
|---|---|
| Workspace typecheck (5 packages) | ✅ clean |
| Mobile ESLint | ✅ 0 errors on touched files (20 pre-existing warnings in unrelated files, unchanged) |
| Workspace test suite | ✅ 302 pass (api 19 + ui 30 + store 100 + mobile 153) |

## Test plan (manual, post-merge)

- [ ] Play a track → tap next → next track plays
- [ ] Play a track → tap prev within first ~5% of duration → prev track plays  
- [ ] Play a track → seek past ~5% → tap prev → current track restarts at 0
- [ ] Toggle repeat = `one` → tap next → current track restarts
- [ ] Toggle repeat = `all` → reach end of queue via natural playback → wraps to first
- [ ] Lock screen → tap next on the media tile → next track plays in background
- [ ] Plug in wired headphones → triple-click forward → next track plays
- [ ] Pair Bluetooth headset → tap next on headset → next track plays

## Why a separate branch / PR

This is a logically distinct issue from the PR #1631 changes (audio resilience, bundled assets, backend mount) — that PR is already in flight and shouldn't gain unrelated commits. Reviewing this prev/next fix in isolation keeps the diff small and the test plan focused. No file overlap with #1631 except `trackPlayerBridge.ts`, where this PR appends new exports without touching existing functions.

https://claude.ai/code/session_012q98B2wbq3kMXCiuJ6sQ7e

---
_Generated by [Claude Code](https://claude.ai/code/session_012q98B2wbq3kMXCiuJ6sQ7e)_