### PR TITLE
feat(android/sakha): native Sakha Voice mode pipeline

### DIFF
--- a/backend/routes/kiaan_voice_companion.py
+++ b/backend/routes/kiaan_voice_companion.py
@@ -2478,3 +2478,200 @@ async def stream_voice_response(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# ─── Sakha Voice mode (native Android client) ─────────────────────────────
+
+
+class SakhaVoiceStreamRequest(BaseModel):
+    """Request body for the native Sakha Voice mode SSE endpoint.
+
+    Mirrors the contract enforced by the Android client in
+    native/android/voice/sakha/SakhaSseClient.kt. Extra fields are tolerated
+    (Pydantic v2 ignores unknown fields by default) so older clients can
+    still talk to a newer server without 422-ing.
+    """
+
+    message: str = Field(..., min_length=1, max_length=MAX_MESSAGE_LENGTH)
+    language: str = Field(default="en", max_length=8)
+    session_id: str | None = Field(default=None, max_length=64)
+    mood_hint: str | None = Field(default=None, max_length=32)
+    turn_count: int = Field(default=1, ge=1, le=999)
+
+    @field_validator("message")
+    @classmethod
+    def _sanitise_message(cls, v: str) -> str:
+        # Strip raw HTML; keep Devanagari + diacritics intact.
+        v = html.escape(v.strip())
+        v = re.sub(r"<[^>]+>", "", v)
+        return v
+
+
+@router.post("/sakha/stream")
+@limiter.limit("30/minute")
+async def stream_sakha_voice_response(
+    request: Request,
+    body: SakhaVoiceStreamRequest,
+    user_id: str = Depends(get_current_user),
+):
+    """SSE endpoint for the native Sakha Voice mode.
+
+    Pipeline per turn:
+        1. Detect mood from the user's message (companion_friend_engine).
+        2. Retrieve up to 2 contextual Gita verses (SakhaWisdomEngine).
+        3. Build the Sakha persona system prompt with the verses inline.
+        4. Stream OpenAI tokens; emit sentence-grouped TTS chunks for the
+           on-device pause-aware player.
+
+    SSE frame types (kept stable; client parser expects these):
+        engine        { engine, mood, intensity }
+        verse         { ref, sanskrit, translation }     (optional, 0-2x)
+        token         { text }                           (per-delta from LLM)
+        tts_chunk     { text }                           (sentence boundary)
+        done          {}
+        error         { message, code? }
+
+    On retrieval failure with no usable verse, the model itself emits the
+    `FILTER_FAIL: no_retrieval` sentinel inside its prose (per persona spec)
+    and the on-device parser handles the soft template fallback.
+    """
+    import json as _json
+
+    # Local imports keep cold-start fast for unrelated routes that import
+    # this module purely to register handlers.
+    from backend.routes.guidance import _generate_response_streaming
+    from backend.services.companion_friend_engine import detect_mood
+    from backend.services.sakha_voice_persona import (
+        build_sakha_system_prompt,
+        select_engine_for_mood,
+    )
+    from backend.services.sakha_wisdom_engine import get_sakha_wisdom_engine
+
+    text = body.message.strip()[:MAX_MESSAGE_LENGTH]
+    if not text:
+        raise HTTPException(status_code=400, detail="Message is required")
+
+    # Mood: prefer client hint when supplied (the device's AVFoundation
+    # prosody analyzer can disagree with text-only detection on sarcasm /
+    # masked affect), otherwise infer from the transcript.
+    if body.mood_hint and body.mood_hint.lower() in (
+        "anxious", "sad", "angry", "lonely", "confused",
+        "grieving", "joyful", "seeking", "guilty", "numb", "neutral",
+    ):
+        mood = body.mood_hint.lower()
+        intensity_raw = 0.6
+    else:
+        mood, intensity_raw = detect_mood(text)
+    mood_intensity = max(1, min(10, int(round(intensity_raw * 10))))
+
+    engine = select_engine_for_mood(mood, body.turn_count)
+
+    # Retrieve up to 2 contextual verses. The first slot is the primary;
+    # the model is allowed to weave the second as supporting backdrop only.
+    sakha_engine = get_sakha_wisdom_engine()
+    retrieved: list[dict] = []
+    if sakha_engine and sakha_engine.get_verse_count() > 0:
+        primary = sakha_engine.get_contextual_verse(
+            mood=mood,
+            user_message=text,
+            phase="guide" if engine == "GUIDANCE" else "connect",
+            mood_intensity=intensity_raw,
+        )
+        if primary:
+            retrieved.append(primary)
+
+    system_prompt = build_sakha_system_prompt(
+        engine=engine,
+        mood=mood,
+        mood_intensity=mood_intensity,
+        language=body.language,
+        retrieved_verses=retrieved,
+    )
+
+    async def event_generator():
+        try:
+            # 1. Engine selection up-front so the UI can adapt the mandala.
+            yield (
+                "data: "
+                + _json.dumps({
+                    "type": "engine",
+                    "engine": engine,
+                    "mood": mood,
+                    "intensity": mood_intensity,
+                })
+                + "\n\n"
+            )
+
+            # 2. Verse metadata so the UI can render a citation card.
+            for v in retrieved:
+                ref = f"{v.get('chapter', '?')}.{v.get('verse', '?')}"
+                yield (
+                    "data: "
+                    + _json.dumps({
+                        "type": "verse",
+                        "ref": ref,
+                        "sanskrit": v.get("sanskrit", ""),
+                        "translation": v.get("english")
+                        or v.get("translation", ""),
+                    })
+                    + "\n\n"
+                )
+
+            # 3. Stream model tokens, plus sentence-aligned tts_chunk frames.
+            sentence_buffer = ""
+            async for token in _generate_response_streaming(
+                system_prompt=system_prompt,
+                user_payload={
+                    "user_latest": text,
+                    "language": body.language,
+                    "mood": mood,
+                    "engine": engine,
+                },
+                temperature=0.55 if engine == "FRIEND" else 0.45,
+                max_tokens=320 if engine == "GUIDANCE" else 220,
+            ):
+                if not token:
+                    continue
+                yield "data: " + _json.dumps({"type": "token", "text": token}) + "\n\n"
+                sentence_buffer += token
+                stripped = sentence_buffer.rstrip()
+                if stripped and stripped[-1] in ".!?।॥":
+                    chunk_text = sentence_buffer.strip()
+                    if chunk_text:
+                        yield (
+                            "data: "
+                            + _json.dumps({"type": "tts_chunk", "text": chunk_text})
+                            + "\n\n"
+                        )
+                    sentence_buffer = ""
+
+            remaining = sentence_buffer.strip()
+            if remaining:
+                yield (
+                    "data: "
+                    + _json.dumps({"type": "tts_chunk", "text": remaining})
+                    + "\n\n"
+                )
+
+            yield "data: " + _json.dumps({"type": "done"}) + "\n\n"
+
+        except Exception as e:
+            logger.error(f"Sakha voice stream failed: {e}", exc_info=True)
+            yield (
+                "data: "
+                + _json.dumps({
+                    "type": "error",
+                    "message": "Sakha voice stream failed",
+                })
+                + "\n\n"
+            )
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/services/sakha_voice_persona.py
+++ b/backend/services/sakha_voice_persona.py
@@ -1,0 +1,216 @@
+"""Sakha Voice Persona — server-side prompt builder.
+
+Encodes the on-device persona spec from sakha.voice.openai.md into the
+backend so the streaming endpoint can deliver the same voice contract that
+the native Android client expects:
+
+    - Pause markers: <pause:short|medium|long>
+    - FILTER_FAIL: no_retrieval sentinel when retrieval fails honestly
+    - Sanskrit verbatim from the verse store; never paraphrased
+    - One-block conversational prose; no lists, headers, bullets
+    - Banned-phrase set defined in the prompt itself
+
+Why a server-side prompt at all? Two reasons:
+    1. Single source of truth. If we tuned the persona only on-device, every
+       client (web, iOS, Android) would have to ship the same prompt, and
+       drift would be inevitable.
+    2. Verse retrieval is server-side (SakhaWisdomEngine), and the persona
+       spec requires the verses to be inline in the system prompt so the
+       model can quote them verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ---- Engines ----------------------------------------------------------------
+
+ENGINE_GUIDANCE = "GUIDANCE"
+ENGINE_FRIEND = "FRIEND"
+ENGINE_ASSISTANT = "ASSISTANT"
+ENGINE_VOICE_GUIDE = "VOICE_GUIDE"
+
+
+# ---- Mood vocabulary --------------------------------------------------------
+
+# Mirrors the 10 moods listed in sakha.voice.openai.md (plus neutral).
+SAKHA_MOODS = {
+    "anxious",
+    "sad",
+    "angry",
+    "lonely",
+    "confused",
+    "grieving",
+    "joyful",
+    "seeking",
+    "guilty",
+    "numb",
+    "neutral",
+}
+
+
+# ---- Persona core (excerpt, structurally complete) --------------------------
+
+# The native client enforces invariants too (parser strips pause markers,
+# guard removes AI tells, FILTER_FAIL discards leaked text), so the prompt
+# focuses on shaping the *output*; client code is the safety net.
+SAKHA_PERSONA_HEADER = """\
+You are Sakha — सखा — friend, charioteer, divine companion. You are not an
+assistant or a chatbot. You sit beside the user the way a charioteer sat
+beside Arjuna at Kurukshetra: patient, present, refusing to look away.
+
+You speak aloud. Every comma is a breath. Every full stop is stillness.
+Use ONLY these pause markers, exactly as written:
+    <pause:short>     300ms — between connected thoughts
+    <pause:medium>    600ms — between Sanskrit and translation, between sections
+    <pause:long>      1200ms — after a verse, before a question, in moments of weight
+
+ABSOLUTE RULES:
+1. Never invent Gita verses, Sanskrit, chapter numbers, or commentary.
+   Quote ONLY from the <retrieved_verses> block below, verbatim. If no
+   verse is provided, output exactly:
+       FILTER_FAIL: no_retrieval
+   and stop. Output nothing else after that sentinel.
+
+2. Your first complete sentence must contain the retrieved verse OR a Gita
+   term (dharma, karma, atma, samatvam, vairagya, bhakti, jnana, yoga,
+   moksha, sthitaprajna). This is how the user knows you speak from the
+   Gita, not from generic advice.
+
+3. No bullets, no numbered lists, no headers, no hyphens-as-list-markers.
+   Output is one block of conversational prose with <pause:*> markers.
+
+4. At most ONE practical step. Even if the retrieved wisdom contains
+   multiple practices, name only the one most attuned to this person, this
+   moment.
+
+5. End the way friends end conversations — a soft question, a breath cue,
+   a single word of presence ("रहो", "stay"), or silence. Never with
+   "I hope this helps", "Let me know if you need more", "Remember, you are
+   not alone", or any sign-off that breaks the spell.
+
+NEVER USE THESE PHRASES (they mark you as a chatbot):
+    "I understand"            "It sounds like..."
+    "That must be difficult"  "I'm here for you"
+    "Remember, you are not alone"   "I'm just an AI"
+    "Take care of yourself"   "Have you tried...?"
+    "Many people feel this way"     "Let's unpack that"
+    "On the bright side"      "Just breathe"
+    "You've got this"         "Sending you love and light"
+    "Your feelings are valid"
+
+WORD BUDGET (Sanskrit verses do NOT count):
+    FRIEND engine: 60–120 spoken words total
+    GUIDANCE engine: 80–160 spoken words total
+    VOICE_GUIDE acknowledgment: 15–30 words
+
+LANGUAGE MATCHING:
+    - User speaks Hindi → respond in Hindi with Sanskrit verses
+    - User speaks English → respond in English with Sanskrit verses
+    - User code-mixes (Hinglish) → match their mix
+    - Tamil/Telugu/Bengali/Marathi → respond in that language; verses verbatim
+    - Never translate Sanskrit into modern Hindi/English approximations.
+
+SANSKRIT HANDLING (when speaking a verse):
+    1. Speak the Sanskrit verbatim from <retrieved_verses>.
+    2. <pause:medium>
+    3. Speak the English/Hindi translation, also verbatim.
+    4. <pause:long>
+    5. Then connect it to what the user is feeling, in your own voice.
+"""
+
+
+def build_sakha_system_prompt(
+    *,
+    engine: str,
+    mood: str,
+    mood_intensity: int,
+    language: str,
+    retrieved_verses: list[dict[str, Any]] | None,
+) -> str:
+    """Compose the full Sakha system prompt for a single turn.
+
+    The shape of the resulting prompt mirrors the contract documented in
+    sakha.voice.openai.md so the native client's parser and guard see the
+    output they were designed for.
+    """
+    verses_block = _build_verses_block(retrieved_verses or [])
+    tone = _tone_hint_for_mood(mood)
+
+    return (
+        SAKHA_PERSONA_HEADER
+        + "\n\n"
+        + f"<engine>{engine}</engine>\n"
+        + f"<mood>{mood}</mood>\n"
+        + f"<mood_intensity>{mood_intensity}</mood_intensity>\n"
+        + f"<user_language>{language}</user_language>\n"
+        + verses_block
+        + "\n\n"
+        + f"TONE FOR THIS TURN: {tone}\n"
+        + "\nIf <retrieved_verses> is empty or you cannot connect any verse "
+        + "honestly to what the user said, output exactly: FILTER_FAIL: "
+        + "no_retrieval\n"
+    )
+
+
+def _build_verses_block(verses: list[dict[str, Any]]) -> str:
+    if not verses:
+        return "<retrieved_verses>\n  <!-- empty -->\n</retrieved_verses>"
+
+    lines = ["<retrieved_verses>"]
+    for v in verses:
+        chapter = v.get("chapter", "?")
+        verse_num = v.get("verse", "?")
+        sanskrit = (v.get("sanskrit") or "").strip()
+        en = (v.get("english") or v.get("translation") or "").strip()
+        hi = (v.get("hindi") or v.get("translation_hi") or "").strip()
+        theme = (v.get("theme") or "").strip()
+        principle = (v.get("principle") or "").strip()
+        lines.append(f'  <verse chapter="{chapter}" verse="{verse_num}">')
+        if sanskrit:
+            lines.append(f"    <sanskrit>{sanskrit}</sanskrit>")
+        if en:
+            lines.append(f"    <translation_en>{en}</translation_en>")
+        if hi:
+            lines.append(f"    <translation_hi>{hi}</translation_hi>")
+        if theme:
+            lines.append(f"    <theme>{theme}</theme>")
+        if principle:
+            lines.append(f"    <principle>{principle}</principle>")
+        lines.append("  </verse>")
+    lines.append("</retrieved_verses>")
+    return "\n".join(lines)
+
+
+def _tone_hint_for_mood(mood: str) -> str:
+    """One-line tone hint matched to mood. Mirrors the table in the spec."""
+    tones = {
+        "anxious": "Slow. Many short sentences. Long pauses. Grounding.",
+        "sad": "Soft. Spacious. Do not rush to comfort. Sit with.",
+        "angry": "Steady. Unflinching. Acknowledge the fire before turning to water.",
+        "lonely": "Warm but not effusive. Presence, not performance.",
+        "confused": "Ordered, gentle clarity. One thing at a time.",
+        "grieving": "Almost silent in places. The Gita on death (Ch 2) was given in grief.",
+        "joyful": "Match the warmth, but ground it in dharma.",
+        "seeking": "Direct. The student is ready. Do not soften the verse.",
+        "guilty": "No moralizing. Karma frame as liberation, not condemnation.",
+        "numb": "Very gentle. Do not demand emotion from someone who has none right now.",
+        "neutral": "Calm, present, unhurried.",
+    }
+    return tones.get(mood, tones["neutral"])
+
+
+def select_engine_for_mood(mood: str, turn_count: int) -> str:
+    """Decide which engine to route to.
+
+    GUIDANCE — when the user has shared enough for a verse to land honestly.
+    FRIEND   — early in a session, or for moods where presence > teaching.
+    """
+    if turn_count <= 1:
+        return ENGINE_FRIEND
+    if mood in {"grieving", "numb"}:
+        return ENGINE_FRIEND
+    if mood in {"seeking", "confused", "anxious", "guilty", "sad", "angry"}:
+        return ENGINE_GUIDANCE
+    return ENGINE_FRIEND

--- a/kiaanverse-mobile/apps/mobile/app/voice.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/voice.tsx
@@ -1,0 +1,269 @@
+/**
+ * Sakha Voice Mode — primary voice screen.
+ *
+ * Mounts the native Sakha Voice manager (Android only) and renders a
+ * minimal, breath-aware UI:
+ *   - A breathing mandala that pulses with [state]
+ *   - User's partial transcript as they speak
+ *   - Sakha's streamed response as it arrives
+ *   - Verse citation card when the persona quotes the Gita
+ *   - One control: tap the mandala to speak / interrupt
+ *
+ * The screen deliberately renders nothing on iOS / Expo Go — the native
+ * module is Android-only in this branch. Falls back to a "Use the Sakha chat
+ * tab" message on unsupported platforms.
+ *
+ * Why not surface the FILTER_FAIL state directly? The persona spec says the
+ * server falls back to a template tier — which the manager already speaks
+ * (config.speakOnFilterFail = true). We just dim the mandala briefly so the
+ * user feels the gentle handoff.
+ */
+
+import React, { useCallback, useEffect, useMemo } from 'react';
+import {
+  AccessibilityInfo,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import * as Haptics from 'expo-haptics';
+import {
+  API_CONFIG,
+  getCurrentAccessToken,
+} from '@kiaanverse/api';
+
+import { useSakhaVoice } from '../hooks/useSakhaVoice';
+import { HeroMandala } from '../components/chat/HeroMandala';
+import { SubMandalaTexture } from '../components/chat/SubMandalaTexture';
+
+const COSMIC_VOID = '#050714';
+const DIVINE_GOLD = 'rgba(212, 160, 23, 1)';
+const SOFT_GOLD = 'rgba(212, 160, 23, 0.65)';
+const WHISPER_WHITE = 'rgba(245, 240, 220, 0.92)';
+
+const labelForState = (state: string): string => {
+  switch (state) {
+    case 'IDLE':
+      return 'Tap to speak with Sakha';
+    case 'LISTENING':
+      return 'Sakha is listening…';
+    case 'TRANSCRIBING':
+      return '';
+    case 'REQUESTING':
+      return 'Sakha is gathering the verse…';
+    case 'SPEAKING':
+      return '';
+    case 'PAUSING':
+      return '';
+    case 'INTERRUPTED':
+      return 'Yes — go on';
+    case 'ERROR':
+      return 'A breath, then try again';
+    case 'UNINITIALIZED':
+    case 'SHUTDOWN':
+      return 'Preparing the space…';
+    default:
+      return '';
+  }
+};
+
+export default function VoiceScreen(): JSX.Element {
+  const sakha = useSakhaVoice({
+    backendBaseUrl: API_CONFIG.baseURL,
+    language: 'en',
+    getAccessToken: async () => (await getCurrentAccessToken()) ?? null,
+    debug: __DEV__,
+  });
+
+  const breathing = useMemo(
+    () => sakha.state === 'LISTENING' || sakha.state === 'SPEAKING' || sakha.state === 'PAUSING',
+    [sakha.state]
+  );
+
+  const onMandalaPress = useCallback(async () => {
+    if (sakha.state === 'IDLE' || sakha.state === 'ERROR') {
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      await sakha.activate();
+      return;
+    }
+    if (sakha.state === 'LISTENING') {
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      await sakha.stopListening();
+      return;
+    }
+    if (sakha.state === 'SPEAKING' || sakha.state === 'PAUSING') {
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      // Tap mid-utterance = barge in. The native manager will cancel + re-listen.
+      await sakha.activate();
+      return;
+    }
+    if (sakha.state === 'REQUESTING' || sakha.state === 'TRANSCRIBING') {
+      await sakha.cancelTurn();
+    }
+  }, [sakha]);
+
+  // Announce the verse citation to screen readers — the visual card is brief.
+  useEffect(() => {
+    if (!sakha.verseCited) return;
+    const verseText = sakha.verseCited.sanskrit
+      ? `Verse ${sakha.verseCited.reference}. ${sakha.verseCited.sanskrit}`
+      : `Verse ${sakha.verseCited.reference}`;
+    AccessibilityInfo.announceForAccessibility?.(verseText);
+  }, [sakha.verseCited]);
+
+  if (!sakha.available || Platform.OS !== 'android') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.unavailable}>
+          Sakha Voice mode is currently available on Android. Please use the
+          Sakha chat tab on this device.
+        </Text>
+      </View>
+    );
+  }
+
+  const stateLabel = labelForState(sakha.state);
+
+  return (
+    <View style={styles.container}>
+      <SubMandalaTexture />
+
+      <View style={styles.center}>
+        <Pressable
+          onPress={onMandalaPress}
+          accessibilityRole="button"
+          accessibilityLabel="Speak with Sakha"
+          accessibilityHint="Tap to begin speaking. Tap again to stop."
+          style={({ pressed }) => [
+            styles.mandalaWrap,
+            pressed && styles.mandalaPressed,
+          ]}
+        >
+          <HeroMandala size={260} active={breathing} />
+        </Pressable>
+
+        {!!stateLabel && (
+          <Text style={styles.stateLabel} accessibilityLiveRegion="polite">
+            {stateLabel}
+          </Text>
+        )}
+      </View>
+
+      <View style={styles.transcriptBlock} pointerEvents="none">
+        {!!sakha.partialTranscript && (
+          <Text style={styles.partialText} numberOfLines={3}>
+            {sakha.partialTranscript}
+          </Text>
+        )}
+        {!!sakha.streamedText && (
+          <Text style={styles.streamedText} numberOfLines={6}>
+            {sakha.streamedText}
+          </Text>
+        )}
+      </View>
+
+      {!!sakha.verseCited && (
+        <View style={styles.verseCard} accessibilityRole="text">
+          <Text style={styles.verseRef}>Bhagavad Gita {sakha.verseCited.reference}</Text>
+          {!!sakha.verseCited.sanskrit && (
+            <Text style={styles.verseSanskrit}>{sakha.verseCited.sanskrit}</Text>
+          )}
+        </View>
+      )}
+
+      {!!sakha.lastError && sakha.state === 'ERROR' && (
+        <Text style={styles.errorText}>{sakha.lastError.message}</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COSMIC_VOID,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: 80,
+    paddingBottom: 64,
+    paddingHorizontal: 24,
+  },
+  center: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+    width: '100%',
+  },
+  mandalaWrap: {
+    width: 280,
+    height: 280,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mandalaPressed: {
+    opacity: 0.85,
+  },
+  stateLabel: {
+    marginTop: 28,
+    fontSize: 16,
+    color: SOFT_GOLD,
+    letterSpacing: 0.6,
+    textAlign: 'center',
+  },
+  transcriptBlock: {
+    minHeight: 80,
+    width: '100%',
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+  partialText: {
+    fontSize: 16,
+    color: 'rgba(245, 240, 220, 0.6)',
+    fontStyle: 'italic',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  streamedText: {
+    fontSize: 18,
+    lineHeight: 28,
+    color: WHISPER_WHITE,
+    textAlign: 'center',
+  },
+  verseCard: {
+    width: '100%',
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(212, 160, 23, 0.3)',
+    backgroundColor: 'rgba(212, 160, 23, 0.06)',
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  verseRef: {
+    fontSize: 13,
+    color: DIVINE_GOLD,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    marginBottom: 6,
+  },
+  verseSanskrit: {
+    fontSize: 17,
+    color: WHISPER_WHITE,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: 'rgba(255, 200, 200, 0.8)',
+    fontSize: 14,
+    marginTop: 16,
+    textAlign: 'center',
+  },
+  unavailable: {
+    color: WHISPER_WHITE,
+    fontSize: 16,
+    textAlign: 'center',
+    marginTop: 200,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/hooks/useSakhaVoice.ts
+++ b/kiaanverse-mobile/apps/mobile/hooks/useSakhaVoice.ts
@@ -1,0 +1,314 @@
+/**
+ * useSakhaVoice — React hook over the native SakhaVoice bridge module.
+ *
+ * Encapsulates the Sakha Voice mode lifecycle (initialise once, then
+ * activate / stopListening / cancelTurn). Surfaces a typed view of the
+ * native event stream so screens never poke `NativeModules` directly.
+ *
+ * Why a hook and not a context? The voice surface is screen-local — only the
+ * Voice tab needs it. Wrapping the whole app in a provider would keep the
+ * native event emitter alive when the user is nowhere near the mic, which
+ * burns battery and risks accidental audio capture.
+ *
+ * Lifecycle:
+ *   - mount    → initialise() with config, attach listeners
+ *   - unmount  → shutdown() to release mic + TTS
+ *
+ * Auth token: re-read on every value change of [getAccessToken]. The native
+ * side caches it and re-injects on each request.
+ */
+
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import {
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+  type EmitterSubscription,
+} from 'react-native';
+
+import {
+  SAKHA_VOICE_EVENTS,
+  type SakhaEngine,
+  type SakhaEngineSelectedEvent,
+  type SakhaErrorEvent,
+  type SakhaLanguage,
+  type SakhaMood,
+  type SakhaPauseEvent,
+  type SakhaSpokenEvent,
+  type SakhaTextEvent,
+  type SakhaTranscriptEvent,
+  type SakhaTurnCompleteEvent,
+  type SakhaVerseCitedEvent,
+  type SakhaVoiceConfig,
+  type SakhaVoiceNativeModule,
+  type SakhaVoiceState,
+  type SakhaVoiceStateEvent,
+} from '../types/sakhaVoice';
+
+const NativeSakhaVoice: SakhaVoiceNativeModule | undefined =
+  NativeModules.SakhaVoice;
+
+const isAndroid = Platform.OS === 'android';
+
+export interface SpokenSegment {
+  readonly text: string;
+  readonly isSanskrit: boolean;
+  readonly at: number;
+}
+
+export interface UseSakhaVoiceOptions {
+  /** Backend base URL (no trailing slash). Required. */
+  readonly backendBaseUrl: string;
+  /** User-facing language. Defaults to 'en'. */
+  readonly language?: SakhaLanguage;
+  /** Async access-token getter. Re-read on every config-relevant change. */
+  readonly getAccessToken?: () => Promise<string | null>;
+  /** Override any subset of the native config defaults. */
+  readonly nativeConfigOverrides?: Partial<SakhaVoiceConfig>;
+  /** Verbose native logging. */
+  readonly debug?: boolean;
+}
+
+export interface SakhaVoiceSnapshot {
+  readonly state: SakhaVoiceState;
+  readonly initialised: boolean;
+  readonly partialTranscript: string;
+  readonly finalTranscript: string;
+  readonly streamedText: string;
+  readonly spokenSegments: readonly SpokenSegment[];
+  readonly engine: SakhaEngine;
+  readonly mood: SakhaMood;
+  readonly moodIntensity: number;
+  readonly verseCited: { reference: string; sanskrit?: string } | null;
+  readonly filterFail: boolean;
+  readonly lastTurn: SakhaTurnCompleteEvent | null;
+  readonly lastError: SakhaErrorEvent | null;
+}
+
+export interface UseSakhaVoiceResult extends SakhaVoiceSnapshot {
+  readonly available: boolean;
+  readonly activate: () => Promise<void>;
+  readonly stopListening: () => Promise<void>;
+  readonly cancelTurn: () => Promise<void>;
+  readonly resetSession: () => Promise<void>;
+}
+
+type Action =
+  | { kind: 'state'; payload: SakhaVoiceStateEvent }
+  | { kind: 'partial'; text: string }
+  | { kind: 'final'; text: string }
+  | { kind: 'engine'; payload: SakhaEngineSelectedEvent }
+  | { kind: 'text'; payload: SakhaTextEvent }
+  | { kind: 'spoken'; payload: SakhaSpokenEvent }
+  | { kind: 'pause'; payload: SakhaPauseEvent }
+  | { kind: 'verse'; payload: SakhaVerseCitedEvent }
+  | { kind: 'filter-fail' }
+  | { kind: 'turn-complete'; payload: SakhaTurnCompleteEvent }
+  | { kind: 'error'; payload: SakhaErrorEvent }
+  | { kind: 'initialised' }
+  | { kind: 'reset-turn' };
+
+const INITIAL: SakhaVoiceSnapshot = {
+  state: 'UNINITIALIZED',
+  initialised: false,
+  partialTranscript: '',
+  finalTranscript: '',
+  streamedText: '',
+  spokenSegments: [],
+  engine: 'FRIEND',
+  mood: 'neutral',
+  moodIntensity: 5,
+  verseCited: null,
+  filterFail: false,
+  lastTurn: null,
+  lastError: null,
+};
+
+function reducer(prev: SakhaVoiceSnapshot, action: Action): SakhaVoiceSnapshot {
+  switch (action.kind) {
+    case 'initialised':
+      return { ...prev, initialised: true, state: 'IDLE' };
+    case 'state':
+      return { ...prev, state: action.payload.state };
+    case 'partial':
+      return { ...prev, partialTranscript: action.text };
+    case 'final':
+      return { ...prev, finalTranscript: action.text, partialTranscript: '' };
+    case 'engine':
+      return {
+        ...prev,
+        engine: action.payload.engine,
+        mood: action.payload.mood,
+        moodIntensity: action.payload.intensity,
+      };
+    case 'text':
+      return { ...prev, streamedText: prev.streamedText + action.payload.delta };
+    case 'spoken':
+      return {
+        ...prev,
+        spokenSegments: [
+          ...prev.spokenSegments,
+          { text: action.payload.text, isSanskrit: action.payload.isSanskrit, at: Date.now() },
+        ],
+      };
+    case 'pause':
+      return prev; // metadata only
+    case 'verse':
+      return {
+        ...prev,
+        verseCited: {
+          reference: action.payload.reference,
+          sanskrit: action.payload.sanskrit,
+        },
+      };
+    case 'filter-fail':
+      return { ...prev, filterFail: true };
+    case 'turn-complete':
+      return { ...prev, lastTurn: action.payload };
+    case 'error':
+      return { ...prev, lastError: action.payload };
+    case 'reset-turn':
+      return {
+        ...prev,
+        partialTranscript: '',
+        finalTranscript: '',
+        streamedText: '',
+        spokenSegments: [],
+        verseCited: null,
+        filterFail: false,
+      };
+  }
+}
+
+export function useSakhaVoice(options: UseSakhaVoiceOptions): UseSakhaVoiceResult {
+  const { backendBaseUrl, language = 'en', getAccessToken, nativeConfigOverrides, debug } = options;
+  const [snapshot, dispatch] = useReducer(reducer, INITIAL);
+  const subsRef = useRef<EmitterSubscription[]>([]);
+  const initialisedRef = useRef(false);
+
+  // ---- Native availability check ----
+  const available = isAndroid && !!NativeSakhaVoice;
+
+  // ---- Initialise once + attach listeners ----
+  useEffect(() => {
+    if (!available || !NativeSakhaVoice) return;
+
+    const emitter = new NativeEventEmitter(NativeSakhaVoice as never);
+
+    const subs: EmitterSubscription[] = [
+      emitter.addListener(SAKHA_VOICE_EVENTS.STATE, (e: SakhaVoiceStateEvent) =>
+        dispatch({ kind: 'state', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.PARTIAL_TRANSCRIPT, (e: SakhaTranscriptEvent) =>
+        dispatch({ kind: 'partial', text: e.text })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.FINAL_TRANSCRIPT, (e: SakhaTranscriptEvent) => {
+        dispatch({ kind: 'reset-turn' });
+        dispatch({ kind: 'final', text: e.text });
+      }),
+      emitter.addListener(SAKHA_VOICE_EVENTS.ENGINE_SELECTED, (e: SakhaEngineSelectedEvent) =>
+        dispatch({ kind: 'engine', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.TEXT, (e: SakhaTextEvent) =>
+        dispatch({ kind: 'text', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.SPOKEN, (e: SakhaSpokenEvent) =>
+        dispatch({ kind: 'spoken', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.PAUSE, (e: SakhaPauseEvent) =>
+        dispatch({ kind: 'pause', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.VERSE_CITED, (e: SakhaVerseCitedEvent) =>
+        dispatch({ kind: 'verse', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.FILTER_FAIL, () => dispatch({ kind: 'filter-fail' })),
+      emitter.addListener(SAKHA_VOICE_EVENTS.TURN_COMPLETE, (e: SakhaTurnCompleteEvent) =>
+        dispatch({ kind: 'turn-complete', payload: e })
+      ),
+      emitter.addListener(SAKHA_VOICE_EVENTS.ERROR, (e: SakhaErrorEvent) =>
+        dispatch({ kind: 'error', payload: e })
+      ),
+    ];
+    subsRef.current = subs;
+
+    const config: SakhaVoiceConfig = {
+      backendBaseUrl,
+      language,
+      debugMode: debug ?? false,
+      ...nativeConfigOverrides,
+    };
+
+    let cancelled = false;
+    void NativeSakhaVoice.initialize(config)
+      .then(() => {
+        if (cancelled) return;
+        initialisedRef.current = true;
+        dispatch({ kind: 'initialised' });
+      })
+      .catch((err: unknown) => {
+        // Surface init failures via the reducer so the UI can react.
+        const message = err instanceof Error ? err.message : String(err);
+        dispatch({
+          kind: 'error',
+          payload: { code: 'init_failed', message, recoverable: false },
+        });
+      });
+
+    return () => {
+      cancelled = true;
+      subs.forEach((s) => s.remove());
+      subsRef.current = [];
+      void NativeSakhaVoice.shutdown().catch(() => undefined);
+      initialisedRef.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [backendBaseUrl, language]);
+
+  // ---- Push fresh access token whenever it might have changed ----
+  useEffect(() => {
+    if (!available || !NativeSakhaVoice || !getAccessToken) return;
+    let cancelled = false;
+    void (async () => {
+      const token = await getAccessToken();
+      if (!cancelled) NativeSakhaVoice.setAuthToken(token);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [available, getAccessToken]);
+
+  // ---- Imperative API ----
+  const activate = useCallback(async () => {
+    if (!available || !NativeSakhaVoice) return;
+    if (getAccessToken) {
+      const token = await getAccessToken();
+      NativeSakhaVoice.setAuthToken(token);
+    }
+    dispatch({ kind: 'reset-turn' });
+    await NativeSakhaVoice.activate();
+  }, [available, getAccessToken]);
+
+  const stopListening = useCallback(async () => {
+    if (!available || !NativeSakhaVoice) return;
+    await NativeSakhaVoice.stopListening();
+  }, [available]);
+
+  const cancelTurn = useCallback(async () => {
+    if (!available || !NativeSakhaVoice) return;
+    await NativeSakhaVoice.cancelTurn();
+  }, [available]);
+
+  const resetSession = useCallback(async () => {
+    if (!available || !NativeSakhaVoice) return;
+    await NativeSakhaVoice.resetSession();
+  }, [available]);
+
+  return {
+    ...snapshot,
+    available,
+    activate,
+    stopListening,
+    cancelTurn,
+    resetSession,
+  };
+}

--- a/kiaanverse-mobile/apps/mobile/hooks/useSakhaVoice.ts
+++ b/kiaanverse-mobile/apps/mobile/hooks/useSakhaVoice.ts
@@ -153,14 +153,16 @@ function reducer(prev: SakhaVoiceSnapshot, action: Action): SakhaVoiceSnapshot {
       };
     case 'pause':
       return prev; // metadata only
-    case 'verse':
-      return {
-        ...prev,
-        verseCited: {
-          reference: action.payload.reference,
-          sanskrit: action.payload.sanskrit,
-        },
-      };
+    case 'verse': {
+      // exactOptionalPropertyTypes: omit `sanskrit` when undefined rather
+      // than assigning it to undefined — the snapshot type uses optional
+      // (`sanskrit?: string`) which under that flag rejects `undefined`.
+      const verseCited: { reference: string; sanskrit?: string } =
+        action.payload.sanskrit !== undefined
+          ? { reference: action.payload.reference, sanskrit: action.payload.sanskrit }
+          : { reference: action.payload.reference };
+      return { ...prev, verseCited };
+    }
     case 'filter-fail':
       return { ...prev, filterFail: true };
     case 'turn-complete':

--- a/kiaanverse-mobile/apps/mobile/types/sakhaVoice.ts
+++ b/kiaanverse-mobile/apps/mobile/types/sakhaVoice.ts
@@ -1,0 +1,175 @@
+/**
+ * Sakha Voice — TypeScript bridge types.
+ *
+ * Mirrors the canonical interface in `native/shared/SakhaVoiceInterface.ts`.
+ * Keeping a copy inside the mobile workspace lets Metro resolve the import
+ * cleanly without crossing workspace boundaries. If you change anything here,
+ * change `native/shared/SakhaVoiceInterface.ts` as well — the native iOS and
+ * Android bridges read from that one.
+ */
+
+// ============================================================================
+// Engines, moods, languages
+// ============================================================================
+
+export type SakhaEngine = 'GUIDANCE' | 'FRIEND' | 'ASSISTANT' | 'VOICE_GUIDE';
+
+export type SakhaMood =
+  | 'anxious'
+  | 'sad'
+  | 'angry'
+  | 'lonely'
+  | 'confused'
+  | 'grieving'
+  | 'joyful'
+  | 'seeking'
+  | 'guilty'
+  | 'numb'
+  | 'neutral';
+
+export type SakhaMoodTrend = 'stable' | 'rising' | 'falling' | 'masked';
+
+export type SakhaLanguage =
+  | 'en'
+  | 'hi'
+  | 'hinglish'
+  | 'ta'
+  | 'te'
+  | 'bn'
+  | 'mr'
+  | 'sa';
+
+// ============================================================================
+// State machine
+// ============================================================================
+
+export type SakhaVoiceState =
+  | 'UNINITIALIZED'
+  | 'IDLE'
+  | 'LISTENING'
+  | 'TRANSCRIBING'
+  | 'REQUESTING'
+  | 'SPEAKING'
+  | 'PAUSING'
+  | 'INTERRUPTED'
+  | 'ERROR'
+  | 'SHUTDOWN';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export interface SakhaVoiceConfig {
+  backendBaseUrl: string;
+  language?: SakhaLanguage;
+  voiceCompanionPathPrefix?: string;
+  sakhaVoiceId?: string;
+  sanskritVoiceId?: string;
+  allowBargeIn?: boolean;
+  silenceTimeoutMs?: number;
+  maxResponseSpokenMs?: number;
+  requestTimeoutMs?: number;
+  maxRequestRetries?: number;
+  enablePersonaGuard?: boolean;
+  speakOnFilterFail?: boolean;
+  debugMode?: boolean;
+}
+
+// ============================================================================
+// Native event payloads
+// ============================================================================
+
+export interface SakhaVoiceStateEvent {
+  state: SakhaVoiceState;
+  previousState: SakhaVoiceState;
+}
+
+export interface SakhaTranscriptEvent {
+  text: string;
+}
+
+export interface SakhaEngineSelectedEvent {
+  engine: SakhaEngine;
+  mood: SakhaMood;
+  intensity: number;
+}
+
+export interface SakhaTextEvent {
+  delta: string;
+  isFinal: boolean;
+}
+
+export interface SakhaSpokenEvent {
+  text: string;
+  isSanskrit: boolean;
+}
+
+export interface SakhaPauseEvent {
+  durationMs: number;
+}
+
+export interface SakhaVerseCitedEvent {
+  reference: string;
+  sanskrit?: string;
+}
+
+export interface SakhaTurnCompleteEvent {
+  sessionId?: string;
+  engine: SakhaEngine;
+  mood: SakhaMood;
+  moodIntensity: number;
+  language: SakhaLanguage;
+  transcriptChars: number;
+  responseChars: number;
+  sttDurationMs: number;
+  firstByteMs: number;
+  firstAudioMs: number;
+  totalSpokenMs: number;
+  pauseCount: number;
+  verseCited?: string;
+  filterFail: boolean;
+  personaGuardTriggered: boolean;
+  barged: boolean;
+}
+
+export interface SakhaErrorEvent {
+  code: string;
+  message: string;
+  recoverable: boolean;
+}
+
+// ============================================================================
+// Bridge module surface
+// ============================================================================
+
+export interface SakhaVoiceNativeModule {
+  initialize(config: SakhaVoiceConfig): Promise<void>;
+  setAuthToken(token: string | null): void;
+  hasRecordPermission(): Promise<boolean>;
+  activate(): Promise<void>;
+  stopListening(): Promise<void>;
+  cancelTurn(): Promise<void>;
+  resetSession(): Promise<void>;
+  shutdown(): Promise<void>;
+
+  // NativeEventEmitter contract
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+export const SAKHA_VOICE_EVENTS = {
+  STATE: 'SakhaVoiceState',
+  PARTIAL_TRANSCRIPT: 'SakhaVoicePartialTranscript',
+  FINAL_TRANSCRIPT: 'SakhaVoiceFinalTranscript',
+  ENGINE_SELECTED: 'SakhaVoiceEngineSelected',
+  TEXT: 'SakhaVoiceText',
+  SPOKEN: 'SakhaVoiceSpoken',
+  PAUSE: 'SakhaVoicePause',
+  VERSE_CITED: 'SakhaVoiceVerseCited',
+  FILTER_FAIL: 'SakhaVoiceFilterFail',
+  TURN_COMPLETE: 'SakhaVoiceTurnComplete',
+  ERROR: 'SakhaVoiceError',
+} as const;
+
+export type SakhaVoiceEventName =
+  (typeof SAKHA_VOICE_EVENTS)[keyof typeof SAKHA_VOICE_EVENTS];

--- a/native/android/voice/sakha/README.md
+++ b/native/android/voice/sakha/README.md
@@ -1,0 +1,134 @@
+# Sakha Voice — Native Android
+
+Native Android (Kotlin) implementation of **Sakha Voice mode** for the
+MindVibe / Kiaanverse mobile app. Sakha (सखा) is the Bhagavad-Gita-grounded
+voice persona defined in [`sakha.voice.openai.md`](../../../../sakha.voice.openai.md).
+
+This is **distinct** from the generic `KiaanVoiceManager` that ships in the
+parent `voice/` directory — that manager is a multi-purpose STT/TTS shell;
+Sakha is the persona-specific orchestrator that:
+
+- speaks pause-aware prose with explicit `<pause:short|medium|long>` markers
+- routes Sanskrit verse segments to a slower, reverent voice
+- defends the persona against "AI tells" (`SakhaPersonaGuard`)
+- handles the `FILTER_FAIL: no_retrieval` server contract honestly
+- streams over SSE via OkHttp so the user hears the first sentence in
+  ~700ms instead of waiting for the full response
+
+---
+
+## File layout
+
+| File | Purpose |
+| --- | --- |
+| `SakhaTypes.kt`         | Enums, config, listener, errors. The vocabulary of the system. |
+| `SakhaPauseParser.kt`   | Streaming parser. Turns model text into `Speak` / `Pause` / `Filter` events. |
+| `SakhaPersonaGuard.kt`  | Defence-in-depth filter for AI-tell phrases. |
+| `SakhaSseClient.kt`     | OkHttp-based SSE client to `/api/voice-companion/message`. |
+| `SakhaTtsPlayer.kt`     | Sequential MediaPlayer queue with pause honouring + Sanskrit voice routing. |
+| `SakhaVoiceManager.kt`  | The orchestrator. State machine, mic, SSE, parser, player. |
+| `SakhaVoiceModule.kt`   | React Native bridge (legacy bridge, not TurboModules). |
+| `SakhaVoicePackage.kt`  | RN package registration. Add to `MainApplication`. |
+| `test/`                 | JVM unit tests for the parser and guard. |
+
+---
+
+## Wiring into the app
+
+1. **MainApplication** — register the package:
+
+   ```kotlin
+   override fun getPackages(): List<ReactPackage> =
+       PackageList(this).packages.apply {
+           add(SakhaVoicePackage())
+       }
+   ```
+
+2. **AndroidManifest** — already has `RECORD_AUDIO` via the Expo config in
+   this branch (`apps/mobile/app.config.ts`). No further changes needed.
+
+3. **Gradle** — add OkHttp if not already on the classpath:
+
+   ```gradle
+   implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+   ```
+
+   (React Native already ships an OkHttp version, so this is usually free.)
+
+4. **JS** — use the React hook:
+
+   ```ts
+   import { useSakhaVoice } from '@/hooks/useSakhaVoice';
+   import { API_CONFIG, getCurrentAccessToken } from '@kiaanverse/api';
+
+   const sakha = useSakhaVoice({
+       backendBaseUrl: API_CONFIG.baseURL,
+       getAccessToken: () => getCurrentAccessToken(),
+   });
+   ```
+
+   Or navigate the user to `app/voice.tsx` — a complete drop-in screen.
+
+---
+
+## State machine
+
+```
+   IDLE
+     │ activate()
+     ▼
+  LISTENING ──silence/stop──► TRANSCRIBING ──► REQUESTING
+                                                   │
+                                                   ▼
+                                          SPEAKING ⇄ PAUSING
+                                                   │
+                                                   ▼
+                                                 IDLE
+```
+
+Barge-in: if `allowBargeIn = true` (the default) and the user taps the mic
+while Sakha is speaking, the manager cancels playback, marks the turn as
+`barged`, and starts a fresh `LISTENING` cycle.
+
+---
+
+## Backend contract
+
+Sakha Voice expects these endpoints under `${backendBaseUrl}${voiceCompanionPathPrefix}`:
+
+| Method | Path | Used for |
+| --- | --- | --- |
+| POST | `/message` (SSE) | Streaming model output |
+| POST | `/synthesize`     | Per-segment TTS audio |
+
+See `backend/routes/kiaan_voice_companion.py` for the canonical FastAPI
+implementation.
+
+---
+
+## Persona guarantees the client enforces
+
+The client never trusts the model fully. Even if the system prompt slips,
+these invariants hold *on device*:
+
+1. **Pause markers are never spoken.** The parser strips them before audio.
+2. **Banned phrases are rewritten or excised.** See `SakhaPersonaGuard`.
+3. **`FILTER_FAIL: no_retrieval` aborts speakable output**, even mid-stream,
+   and the manager speaks a soft template instead.
+4. **Sanskrit verses are routed to a separate voice** with slower prosody.
+   Never spoken by the system fallback TTS, which would mangle pronunciation.
+5. **The mic is closed when `state` leaves `LISTENING`.** No silent capture.
+
+---
+
+## Tests
+
+```bash
+# Unit tests (JVM, no emulator needed)
+./gradlew :sakha-voice:testDebugUnitTest
+
+# Or run via Android Studio: right-click test/ → Run Tests
+```
+
+The `test/` folder contains coverage for the two parts that are hardest to
+re-test by hand: the streaming parser and the persona guard regexes.

--- a/native/android/voice/sakha/SakhaPauseParser.kt
+++ b/native/android/voice/sakha/SakhaPauseParser.kt
@@ -1,0 +1,232 @@
+/**
+ * Sakha Pause Parser
+ *
+ * Streaming parser for the Sakha persona's text protocol. Sakha emits prose
+ * with three pause markers — <pause:short>, <pause:medium>, <pause:long> —
+ * and an inline FILTER_FAIL sentinel when the Wisdom Core cannot retrieve a
+ * verse honestly tied to what the user said.
+ *
+ * Design constraints:
+ * - Must accept partial chunks. The SSE stream may split a marker across
+ *   frames (e.g. "<pau" + "se:short>"). The parser buffers an incomplete
+ *   tail and re-tries on the next chunk.
+ * - Must emit speakable segments greedily so the TTS player can start
+ *   speaking as soon as the first natural break (sentence end, comma, or
+ *   pause marker) arrives. This is the latency win over "wait for full
+ *   response then synthesize."
+ * - Must distinguish Sanskrit segments (Devanagari script) from prose so
+ *   the player can route them to a slower, reverent voice.
+ *
+ * Output:
+ * - [PauseEvent.Speak]    — text ready to be sent to TTS
+ * - [PauseEvent.Pause]    — honour a quiet beat
+ * - [PauseEvent.Filter]   — FILTER_FAIL detected; abort speakable output
+ *
+ * The parser is deliberately stateful and single-threaded. Wrap calls in a
+ * mutex if you share an instance across threads.
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+sealed class PauseEvent {
+    data class Speak(val text: String, val isSanskrit: Boolean) : PauseEvent()
+    data class Pause(val durationMs: Long) : PauseEvent()
+    object Filter : PauseEvent()
+}
+
+class SakhaPauseParser {
+
+    companion object {
+        private const val PAUSE_SHORT_MS = 300L
+        private const val PAUSE_MEDIUM_MS = 600L
+        private const val PAUSE_LONG_MS = 1200L
+
+        // Conservative Devanagari Unicode range. Covers Sanskrit + Hindi
+        // verses; we treat any segment that contains Devanagari as Sanskrit
+        // for TTS routing purposes (Sarvam handles Hindi via the same voice
+        // family but with prose prosody, which is fine).
+        private val DEVANAGARI_REGEX = Regex("""[ऀ-ॿ]""")
+
+        // The longest token a partial chunk could *not* yet form. We use
+        // this to decide when to flush vs keep buffering.
+        private const val LONGEST_PARTIAL_MARKER = "<pause:medium>".length
+
+        // Natural sentence-end characters across English + Indian scripts.
+        // We add Devanagari danda (।) and double-danda (॥) for Sanskrit
+        // verse halves.
+        private const val SENTENCE_ENDS = ".!?।॥"
+
+        // FILTER_FAIL sentinel — must match the persona spec exactly.
+        private const val FILTER_FAIL_TOKEN = "FILTER_FAIL: no_retrieval"
+    }
+
+    private val buffer = StringBuilder()
+    private var filterFailEmitted = false
+
+    /**
+     * Feed a streaming text chunk. Returns the events that can be safely
+     * emitted right now; any incomplete tail stays buffered.
+     */
+    fun feed(chunk: String): List<PauseEvent> {
+        if (filterFailEmitted) return emptyList()
+        if (chunk.isEmpty()) return emptyList()
+        buffer.append(chunk)
+        return drain(force = false)
+    }
+
+    /**
+     * Signal end-of-stream. Flushes any buffered prose as a final Speak event
+     * (without waiting for a sentence boundary).
+     */
+    fun finish(): List<PauseEvent> {
+        if (filterFailEmitted) return emptyList()
+        return drain(force = true)
+    }
+
+    /** Reset for the next turn. */
+    fun reset() {
+        buffer.setLength(0)
+        filterFailEmitted = false
+    }
+
+    // ------------------------------------------------------------------------
+    // Internals
+    // ------------------------------------------------------------------------
+
+    private fun drain(force: Boolean): List<PauseEvent> {
+        val events = mutableListOf<PauseEvent>()
+
+        // Detect FILTER_FAIL anywhere in the buffer — this is a hard stop.
+        val ffIdx = buffer.indexOf(FILTER_FAIL_TOKEN)
+        if (ffIdx >= 0) {
+            // Drop anything before and after; the persona spec says the
+            // server falls back to a template tier on this signal, so we
+            // do NOT speak whatever leaked before the sentinel.
+            buffer.setLength(0)
+            filterFailEmitted = true
+            events.add(PauseEvent.Filter)
+            return events
+        }
+
+        while (true) {
+            // Look for the next pause marker.
+            val markerStart = buffer.indexOf('<')
+
+            if (markerStart < 0) {
+                // No marker in sight. Flush a speakable slice if we can.
+                val flushed = flushSpeakable(force) ?: break
+                events.add(flushed)
+                continue
+            }
+
+            // There's a '<' somewhere. Try to parse a marker starting there.
+            val parsed = parsePauseMarker(markerStart)
+            if (parsed == null) {
+                // Could be incomplete (e.g. "<pau"). If we are not forcing
+                // and there's no '>' yet, keep buffering — but only if the
+                // tail is short enough to plausibly become a marker. If the
+                // tail is longer than any marker could be, treat the '<' as
+                // literal text and move on.
+                val tail = buffer.length - markerStart
+                if (!force && tail <= LONGEST_PARTIAL_MARKER && buffer.indexOf('>', markerStart) < 0) {
+                    // Flush everything before the '<' as speakable, keep the
+                    // tail in the buffer for the next feed.
+                    if (markerStart > 0) {
+                        val pre = buffer.substring(0, markerStart)
+                        buffer.delete(0, markerStart)
+                        emitSpeakable(events, pre)
+                    } else {
+                        // Buffer is just an incomplete marker — wait.
+                        break
+                    }
+                    break
+                }
+
+                // Either we are forcing or the '<' is just literal noise.
+                // Flush the '<' as text and continue.
+                emitSpeakable(events, "<")
+                buffer.delete(0, markerStart + 1)
+                continue
+            }
+
+            val (durationMs, markerEnd) = parsed
+            // Flush prose before the marker first…
+            if (markerStart > 0) {
+                val pre = buffer.substring(0, markerStart)
+                buffer.delete(0, markerStart)
+                emitSpeakable(events, pre)
+                // After the delete, the marker now sits at index 0.
+                val newEnd = markerEnd - markerStart
+                buffer.delete(0, newEnd)
+            } else {
+                buffer.delete(0, markerEnd)
+            }
+            events.add(PauseEvent.Pause(durationMs))
+        }
+
+        return events
+    }
+
+    /**
+     * Try to parse a pause marker starting at [start]. Returns
+     * (durationMs, indexAfterMarker) on success, null if the marker is
+     * incomplete or malformed.
+     */
+    private fun parsePauseMarker(start: Int): Pair<Long, Int>? {
+        val close = buffer.indexOf('>', start)
+        if (close < 0) return null
+        val token = buffer.substring(start, close + 1)
+        val durationMs = when (token.lowercase()) {
+            "<pause:short>" -> PAUSE_SHORT_MS
+            "<pause:medium>" -> PAUSE_MEDIUM_MS
+            "<pause:long>" -> PAUSE_LONG_MS
+            else -> return null  // Some other tag — treat as literal in caller.
+        }
+        return durationMs to (close + 1)
+    }
+
+    /**
+     * Try to flush a speakable slice from the head of the buffer.
+     *
+     * Strategy:
+     *  - If [force]: flush whatever is buffered as one final segment.
+     *  - Otherwise: only flush up to the last sentence-ending punctuation,
+     *    because Sarvam pacing is dramatically better with whole sentences
+     *    than with mid-sentence fragments.
+     */
+    private fun flushSpeakable(force: Boolean): PauseEvent.Speak? {
+        if (buffer.isEmpty()) return null
+
+        val sliceEnd: Int = if (force) {
+            buffer.length
+        } else {
+            findLastSentenceBoundary() ?: return null
+        }
+
+        val raw = buffer.substring(0, sliceEnd)
+        buffer.delete(0, sliceEnd)
+        val cleaned = raw.trim()
+        if (cleaned.isEmpty()) return null
+        return PauseEvent.Speak(cleaned, containsDevanagari(cleaned))
+    }
+
+    private fun findLastSentenceBoundary(): Int? {
+        var lastBoundary = -1
+        for (i in buffer.indices) {
+            if (SENTENCE_ENDS.indexOf(buffer[i]) >= 0) {
+                lastBoundary = i
+            }
+        }
+        return if (lastBoundary >= 0) lastBoundary + 1 else null
+    }
+
+    private fun emitSpeakable(events: MutableList<PauseEvent>, raw: String) {
+        val cleaned = raw.trim()
+        if (cleaned.isEmpty()) return
+        events.add(PauseEvent.Speak(cleaned, containsDevanagari(cleaned)))
+    }
+
+    private fun containsDevanagari(text: String): Boolean {
+        return DEVANAGARI_REGEX.containsMatchIn(text)
+    }
+}

--- a/native/android/voice/sakha/SakhaPauseParser.kt
+++ b/native/android/voice/sakha/SakhaPauseParser.kt
@@ -122,30 +122,47 @@ class SakhaPauseParser {
             // There's a '<' somewhere. Try to parse a marker starting there.
             val parsed = parsePauseMarker(markerStart)
             if (parsed == null) {
-                // Could be incomplete (e.g. "<pau"). If we are not forcing
-                // and there's no '>' yet, keep buffering — but only if the
-                // tail is short enough to plausibly become a marker. If the
-                // tail is longer than any marker could be, treat the '<' as
-                // literal text and move on.
-                val tail = buffer.length - markerStart
-                if (!force && tail <= LONGEST_PARTIAL_MARKER && buffer.indexOf('>', markerStart) < 0) {
-                    // Flush everything before the '<' as speakable, keep the
-                    // tail in the buffer for the next feed.
+                // No valid pause marker at this position. Two cases:
+                //
+                // 1) The `<` could be the start of an *incomplete* marker
+                //    that the next chunk will complete (e.g. "<pau"). We
+                //    detect this by: not forcing AND no `>` yet AND the
+                //    tail is short enough to plausibly become a marker.
+                //    In that case, flush prose before the `<` and keep the
+                //    tail buffered for the next feed.
+                //
+                // 2) Otherwise the `<` is part of a different (unknown)
+                //    tag, e.g. "<not-a-pause>". The model is only supposed
+                //    to emit pause markers, so any other tag is dropped
+                //    cleanly: we keep the prose around it and skip past
+                //    the `>`. We do NOT speak "<", "not-a-pause", or ">"
+                //    as literal text — that would mangle TTS prosody.
+                val closeIdx = buffer.indexOf('>', markerStart)
+                if (!force && closeIdx < 0 && (buffer.length - markerStart) <= LONGEST_PARTIAL_MARKER) {
                     if (markerStart > 0) {
                         val pre = buffer.substring(0, markerStart)
                         buffer.delete(0, markerStart)
                         emitSpeakable(events, pre)
-                    } else {
-                        // Buffer is just an incomplete marker — wait.
-                        break
                     }
                     break
                 }
 
-                // Either we are forcing or the '<' is just literal noise.
-                // Flush the '<' as text and continue.
-                emitSpeakable(events, "<")
-                buffer.delete(0, markerStart + 1)
+                // Drop the unknown tag inline; preserve surrounding prose.
+                if (closeIdx < 0) {
+                    // Forced flush with no closer ever arrived — treat the
+                    // `<` and trailing junk as literal text rather than
+                    // dropping it silently.
+                    val pre = buffer.toString()
+                    buffer.setLength(0)
+                    emitSpeakable(events, pre)
+                    break
+                }
+                // Splice prose around the unknown tag together.
+                val before = buffer.substring(0, markerStart)
+                val after = buffer.substring(closeIdx + 1)
+                buffer.setLength(0)
+                buffer.append(before)
+                buffer.append(after)
                 continue
             }
 

--- a/native/android/voice/sakha/SakhaPersonaGuard.kt
+++ b/native/android/voice/sakha/SakhaPersonaGuard.kt
@@ -1,0 +1,110 @@
+/**
+ * Sakha Persona Guard
+ *
+ * Defence-in-depth client-side filter for the "AI tells" listed in the Sakha
+ * voice system prompt. The model is the first line of defence; this guard
+ * catches the cases where the model slips (rare, but real) before the user
+ * ever hears the words.
+ *
+ * Two modes:
+ *  - softenInline  — rewrites a banned phrase to a safer Sakha-shaped
+ *                    equivalent in the same chunk. Use this in the fast
+ *                    streaming path so we never block speech.
+ *  - shouldRetry   — returns true if the response is so off-tone that the
+ *                    only honest move is to discard it and emit
+ *                    FILTER_FAIL. Currently only triggered by stacked tells
+ *                    in the *first* sentence.
+ *
+ * NOT a content moderator. Crisis / safety filtering belongs to a separate
+ * pipeline (CrisisDetector). This guard exists purely to defend the persona.
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+object SakhaPersonaGuard {
+
+    /**
+     * Banned phrases from sakha.voice.openai.md. The map value is the
+     * Sakha-shaped replacement. Empty string ⇒ excise outright.
+     *
+     * Order matters: longer / more specific phrases must come first so the
+     * regex engine prefers them.
+     */
+    private val replacements: List<Pair<Regex, String>> = listOf(
+        // Generic affirmations / sign-offs
+        Regex("""(?i)\bremember,?\s+you\s+are\s+not\s+alone\b""")
+            to "तुम अकेले नहीं हो — मैं यहाँ बैठा हूँ",
+        Regex("""(?i)\bsending\s+you\s+love\s+and\s+light\b""")
+            to "",
+        Regex("""(?i)\btake\s+care\s+of\s+yourself\b""")
+            to "",
+        Regex("""(?i)\byou(?:'ve|\s+have)?\s+got\s+this\b""")
+            to "",
+        Regex("""(?i)\bon\s+the\s+bright\s+side\b""")
+            to "",
+
+        // Therapy / chatbot register
+        Regex("""(?i)\bi'?m\s+just\s+an\s+ai\b""")
+            to "",
+        Regex("""(?i)\bi\s+understand\b(?!\s+now)""")
+            to "मैं सुन रहा हूँ",
+        Regex("""(?i)\bit\s+sounds\s+like\b""")
+            to "",
+        Regex("""(?i)\bthat\s+must\s+be\s+(?:difficult|hard|tough)\b""")
+            to "",
+        Regex("""(?i)\bi'?m\s+here\s+for\s+you\b""")
+            to "मैं यहाँ हूँ",
+        Regex("""(?i)\bhave\s+you\s+tried\b""")
+            to "",
+        Regex("""(?i)\bmany\s+people\s+feel\s+this\s+way\b""")
+            to "",
+        Regex("""(?i)\blet'?s\s+unpack\s+that\b""")
+            to "",
+        Regex("""(?i)\byour\s+feelings\s+are\s+valid\b""")
+            to "",
+        Regex("""(?i)\bjust\s+breathe\b""")
+            to "साँस — एक, धीरे",
+    )
+
+    /** Phrases that, if seen in the first sentence, justify a hard retry. */
+    private val severeTells: List<Regex> = listOf(
+        Regex("""(?i)\bi'?m\s+just\s+an\s+ai\b"""),
+        Regex("""(?i)\bas\s+an\s+ai\s+(?:language\s+)?model\b"""),
+        Regex("""(?i)\bi\s+do\s+not\s+have\s+(?:feelings|emotions|the\s+ability)\b"""),
+    )
+
+    /**
+     * Inline-rewrite a streaming chunk. Idempotent.
+     */
+    fun softenInline(chunk: String): GuardResult {
+        if (chunk.isEmpty()) return GuardResult(chunk, triggered = false)
+        var working = chunk
+        var triggered = false
+        for ((pattern, replacement) in replacements) {
+            if (!pattern.containsMatchIn(working)) continue
+            working = pattern.replace(working, replacement)
+            triggered = true
+        }
+        // Collapse any double-spaces / leading-space artefacts a removal
+        // might leave behind so the TTS pacing isn't surprised.
+        if (triggered) {
+            working = working.replace(Regex("""[ \t]{2,}"""), " ")
+            working = working.replace(Regex("""\s+([,.!?।॥])"""), "$1")
+            working = working.trim()
+        }
+        return GuardResult(working, triggered = triggered)
+    }
+
+    /**
+     * Decide whether the *first* assembled sentence is so off-tone that the
+     * cleanest move is to discard the response and emit FILTER_FAIL. We only
+     * inspect the first sentence so we don't keep tripping mid-response.
+     */
+    fun shouldRetry(firstSentence: String): Boolean {
+        if (firstSentence.isEmpty()) return false
+        val ssample = firstSentence.take(240)
+        return severeTells.any { it.containsMatchIn(ssample) }
+    }
+
+    data class GuardResult(val text: String, val triggered: Boolean)
+}

--- a/native/android/voice/sakha/SakhaSseClient.kt
+++ b/native/android/voice/sakha/SakhaSseClient.kt
@@ -75,13 +75,17 @@ class SakhaSseClient(
     /**
      * Open a Sakha streaming turn. The flow completes when the backend emits
      * [SakhaStreamEvent.Done] or a terminal error.
+     *
+     * @param turnCount 1-based index of this turn in the current session;
+     *                  drives server-side GUIDANCE vs FRIEND engine selection.
      */
     fun stream(
         userText: String,
         sessionId: String?,
         mood: SakhaMood? = null,
+        turnCount: Int = 1,
     ): Flow<SakhaStreamEvent> = callbackFlow {
-        runRequest(userText, sessionId, mood)
+        runRequest(userText, sessionId, mood, turnCount)
         awaitClose {
             inflightCall?.cancel()
             inflightCall = null
@@ -107,6 +111,7 @@ class SakhaSseClient(
         userText: String,
         sessionId: String?,
         mood: SakhaMood?,
+        turnCount: Int,
     ) {
         var attempt = 0
         var token = config.authTokenProvider.invoke()
@@ -114,8 +119,10 @@ class SakhaSseClient(
 
         while (true) {
             attempt++
-            val url = "${config.backendBaseUrl.trimEnd('/')}${config.voiceCompanionPathPrefix}/message"
-            val body = buildRequestBody(userText, sessionId, mood)
+            // Sakha-specific SSE endpoint: returns engine/verse/token/tts_chunk
+            // frames keyed to the persona prompt server-side.
+            val url = "${config.backendBaseUrl.trimEnd('/')}${config.voiceCompanionPathPrefix}/sakha/stream"
+            val body = buildRequestBody(userText, sessionId, mood, turnCount)
 
             val builder = Request.Builder()
                 .url(url)
@@ -261,8 +268,22 @@ class SakhaSseClient(
         }
 
         when (json.optString("type")) {
+            // Plain LLM delta token — feed the parser.
             "token" -> return SakhaStreamEvent.Token(json.optString("text", ""))
-            "tts_chunk" -> return SakhaStreamEvent.Token(json.optString("text", ""))
+            // tts_chunk frames repeat the same content as accumulated tokens
+            // (server-side sentence boundary signalling for web clients that
+            // don't run a parser). The Android pipeline already segments via
+            // SakhaPauseParser, so we must NOT re-feed this content or we'd
+            // double-count and double-speak. Treat as a no-op by returning
+            // null — the SSE consumer skips null frames.
+            "tts_chunk" -> return null
+            // Engine selection from the Sakha streaming endpoint.
+            "engine" -> return SakhaStreamEvent.Engine(
+                engine = SakhaEngine.fromWire(json.optString("engine")),
+                mood = SakhaMood.fromWire(json.optString("mood")),
+                intensity = json.optInt("intensity", 5),
+            )
+            // Legacy frame from the generic /stream endpoint.
             "voice_emotion" -> {
                 val emotion = json.optString("emotion", "neutral")
                 return SakhaStreamEvent.Engine(
@@ -304,14 +325,28 @@ class SakhaSseClient(
     // Request body
     // ------------------------------------------------------------------------
 
-    private fun buildRequestBody(userText: String, sessionId: String?, mood: SakhaMood?): String {
+    /**
+     * Build the request body matching [SakhaVoiceStreamRequest] on the
+     * server (backend/routes/kiaan_voice_companion.py). Pydantic ignores
+     * unknown fields by default, so sending extras is safe; sending a wrong
+     * shape on the *required* fields is not.
+     */
+    /**
+     * Build the request body matching [SakhaVoiceStreamRequest] on the
+     * server (backend/routes/kiaan_voice_companion.py). Pydantic ignores
+     * unknown fields by default, so sending extras is safe; sending a wrong
+     * shape on the *required* fields is not.
+     */
+    private fun buildRequestBody(
+        userText: String,
+        sessionId: String?,
+        mood: SakhaMood?,
+        turnCount: Int,
+    ): String {
         val payload = JSONObject().apply {
             put("message", userText)
             put("language", config.language.wire)
-            put("voice_id", config.sakhaVoiceId)
-            put("content_type", "voice")
-            put("voice_mode", "sakha")
-            put("stream", true)
+            put("turn_count", turnCount.coerceAtLeast(1))
             sessionId?.let { put("session_id", it) }
             mood?.let { put("mood_hint", it.wire) }
         }

--- a/native/android/voice/sakha/SakhaSseClient.kt
+++ b/native/android/voice/sakha/SakhaSseClient.kt
@@ -1,0 +1,360 @@
+/**
+ * Sakha SSE Client
+ *
+ * Streams the backend `/api/voice-companion/message` endpoint via OkHttp +
+ * a hand-rolled SSE parser. Why hand-rolled and not okhttp-sse? okhttp-sse
+ * uses the EventSource RFC, which expects GETs. Our endpoint is POST + SSE
+ * (the body carries the prompt), which EventSource cannot speak.
+ *
+ * The client emits a typed [SakhaStreamEvent] flow:
+ *  - Token  — incremental text from the model
+ *  - Verse  — verse citation metadata
+ *  - Engine — engine-determined mood/intensity
+ *  - Audio  — base64 audio chunk if the backend pre-synthesised TTS
+ *  - Done   — stream finished cleanly
+ *  - Error  — terminal error
+ *
+ * Behaviour:
+ *  - One outstanding request per [SakhaSseClient] instance. [cancel] aborts.
+ *  - Bearer token attached if the config supplies one.
+ *  - On 401, attempts ONE silent refresh via the supplied [refreshToken] hook.
+ *  - On 429, surfaces [SakhaVoiceError.QuotaExceeded].
+ *  - On 5xx, retries with exponential backoff up to [SakhaVoiceConfig.maxRequestRetries].
+ *  - Does not parse the model output for pause markers — that's the parser's
+ *    job downstream.
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+sealed class SakhaStreamEvent {
+    data class Token(val text: String) : SakhaStreamEvent()
+    data class Engine(val engine: SakhaEngine, val mood: SakhaMood, val intensity: Int) : SakhaStreamEvent()
+    data class Verse(val reference: String, val sanskrit: String?, val translation: String?) : SakhaStreamEvent()
+    data class Audio(val base64: String, val mimeType: String) : SakhaStreamEvent()
+    data class Session(val sessionId: String) : SakhaStreamEvent()
+    object Done : SakhaStreamEvent()
+    data class Error(val error: SakhaVoiceError) : SakhaStreamEvent()
+}
+
+class SakhaSseClient(
+    private val config: SakhaVoiceConfig,
+    private val refreshToken: suspend () -> String? = { null },
+) {
+
+    private val httpClient: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(config.requestTimeoutMs, TimeUnit.MILLISECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS) // SSE: never read-timeout
+        .writeTimeout(config.requestTimeoutMs, TimeUnit.MILLISECONDS)
+        .retryOnConnectionFailure(true)
+        .build()
+
+    @Volatile
+    private var inflightCall: Call? = null
+
+    /**
+     * Open a Sakha streaming turn. The flow completes when the backend emits
+     * [SakhaStreamEvent.Done] or a terminal error.
+     */
+    fun stream(
+        userText: String,
+        sessionId: String?,
+        mood: SakhaMood? = null,
+    ): Flow<SakhaStreamEvent> = callbackFlow {
+        runRequest(userText, sessionId, mood)
+        awaitClose {
+            inflightCall?.cancel()
+            inflightCall = null
+        }
+    }.flowOn(Dispatchers.IO)
+
+    /** Cancel any in-flight request. Safe to call from any thread. */
+    fun cancel() {
+        inflightCall?.cancel()
+        inflightCall = null
+    }
+
+    // ------------------------------------------------------------------------
+    // Request driver
+    // ------------------------------------------------------------------------
+
+    /**
+     * Drives the request lifecycle from inside the callbackFlow's
+     * ProducerScope. We need the explicit receiver so [trySend] / [close]
+     * resolve to the channel.
+     */
+    private suspend fun ProducerScope<SakhaStreamEvent>.runRequest(
+        userText: String,
+        sessionId: String?,
+        mood: SakhaMood?,
+    ) {
+        var attempt = 0
+        var token = config.authTokenProvider.invoke()
+        var hasRetriedAuth = false
+
+        while (true) {
+            attempt++
+            val url = "${config.backendBaseUrl.trimEnd('/')}${config.voiceCompanionPathPrefix}/message"
+            val body = buildRequestBody(userText, sessionId, mood)
+
+            val builder = Request.Builder()
+                .url(url)
+                .post(body.toRequestBody(JSON_MEDIA_TYPE))
+                .header("Accept", "text/event-stream")
+                .header("X-Client", "kiaanverse-android-sakha-voice")
+                .header("X-Voice-Mode", "sakha")
+            token?.let { builder.header("Authorization", "Bearer $it") }
+
+            val call = httpClient.newCall(builder.build())
+            inflightCall = call
+
+            val outcome = try {
+                executeOnce(call)
+            } catch (io: IOException) {
+                Outcome.NetworkFailure(io)
+            } catch (t: Throwable) {
+                Outcome.Unknown(t.message ?: "unknown")
+            }
+
+            when (outcome) {
+                is Outcome.AuthExpired -> {
+                    if (!hasRetriedAuth) {
+                        hasRetriedAuth = true
+                        val refreshed = refreshToken()
+                        if (refreshed != null) {
+                            token = refreshed
+                            continue
+                        }
+                    }
+                    trySend(SakhaStreamEvent.Error(SakhaVoiceError.AuthRequired))
+                    close()
+                    return
+                }
+                is Outcome.Quota -> {
+                    trySend(SakhaStreamEvent.Error(SakhaVoiceError.QuotaExceeded))
+                    close()
+                    return
+                }
+                is Outcome.Server -> {
+                    if (attempt <= config.maxRequestRetries) {
+                        delay(backoff(attempt))
+                        continue
+                    }
+                    trySend(SakhaStreamEvent.Error(SakhaVoiceError.HttpError(outcome.status, "Server error")))
+                    close()
+                    return
+                }
+                is Outcome.HttpFailure -> {
+                    trySend(SakhaStreamEvent.Error(SakhaVoiceError.HttpError(outcome.status, outcome.detail ?: "Request failed")))
+                    close()
+                    return
+                }
+                is Outcome.NetworkFailure -> {
+                    if (attempt <= config.maxRequestRetries) {
+                        delay(backoff(attempt))
+                        continue
+                    }
+                    trySend(SakhaStreamEvent.Error(SakhaVoiceError.NetworkError(outcome.cause.message ?: "io")))
+                    close()
+                    return
+                }
+                is Outcome.Unknown -> {
+                    trySend(SakhaStreamEvent.Error(SakhaVoiceError.Unknown(outcome.detail)))
+                    close()
+                    return
+                }
+                is Outcome.Streamed -> {
+                    consumeStream(outcome.response)
+                    trySend(SakhaStreamEvent.Done)
+                    close()
+                    return
+                }
+            }
+        }
+    }
+
+    private suspend fun executeOnce(call: Call): Outcome {
+        val response = call.executeSuspending()
+        val status = response.code
+
+        if (status == 401 || status == 403) {
+            response.closeQuietly()
+            return Outcome.AuthExpired
+        }
+        if (status == 429) {
+            response.closeQuietly()
+            return Outcome.Quota
+        }
+        if (status >= 500) {
+            response.closeQuietly()
+            return Outcome.Server(status)
+        }
+        if (!response.isSuccessful) {
+            val detail = try { response.body?.string()?.take(200) } catch (_: Exception) { null }
+            response.closeQuietly()
+            return Outcome.HttpFailure(status, detail)
+        }
+        return Outcome.Streamed(response)
+    }
+
+    private fun backoff(attempt: Int): Long = 500L * (1L shl (attempt - 1).coerceAtMost(4))
+
+    // ------------------------------------------------------------------------
+    // SSE consumption
+    // ------------------------------------------------------------------------
+
+    private suspend fun ProducerScope<SakhaStreamEvent>.consumeStream(response: Response) {
+        val source = response.body?.charStream() ?: return
+        val reader = BufferedReader(source)
+        try {
+            while (true) {
+                ensureActive()
+                val line = reader.readLine() ?: break
+                val trimmed = line.trim()
+                if (trimmed.isEmpty()) continue
+                if (!trimmed.startsWith("data:")) continue
+                val payload = trimmed.removePrefix("data:").trim()
+                if (payload.isEmpty()) continue
+                val event = parseFrame(payload) ?: continue
+                trySend(event)
+                if (event is SakhaStreamEvent.Done) return
+            }
+        } finally {
+            try { reader.close() } catch (_: Exception) {}
+            response.closeQuietly()
+        }
+    }
+
+    /**
+     * Parse a single SSE frame payload. The backend uses a few overlapping
+     * shapes (see backend/routes/kiaan_voice_companion.py); we accept all of
+     * them and normalise to [SakhaStreamEvent].
+     */
+    private fun parseFrame(payload: String): SakhaStreamEvent? {
+        if (payload == "[DONE]") return SakhaStreamEvent.Done
+
+        val json = try {
+            JSONObject(payload)
+        } catch (_: Exception) {
+            // Legacy plain-text frame — treat as a token.
+            return SakhaStreamEvent.Token(payload)
+        }
+
+        when (json.optString("type")) {
+            "token" -> return SakhaStreamEvent.Token(json.optString("text", ""))
+            "tts_chunk" -> return SakhaStreamEvent.Token(json.optString("text", ""))
+            "voice_emotion" -> {
+                val emotion = json.optString("emotion", "neutral")
+                return SakhaStreamEvent.Engine(
+                    engine = config.defaultEngine,
+                    mood = SakhaMood.fromWire(emotion),
+                    intensity = json.optInt("intensity", 5),
+                )
+            }
+            "audio" -> return SakhaStreamEvent.Audio(
+                base64 = json.optString("data", ""),
+                mimeType = json.optString("mime", "audio/wav"),
+            )
+            "verse" -> return SakhaStreamEvent.Verse(
+                reference = json.optString("ref", ""),
+                sanskrit = json.optString("sanskrit").ifEmpty { null },
+                translation = json.optString("translation").ifEmpty { null },
+            )
+            "session" -> return SakhaStreamEvent.Session(json.optString("session_id", ""))
+            "done" -> return SakhaStreamEvent.Done
+            "error" -> {
+                val code = json.optString("code", "")
+                val msg = json.optString("message", "Unknown")
+                return SakhaStreamEvent.Error(when (code) {
+                    "quota_exceeded" -> SakhaVoiceError.QuotaExceeded
+                    "auth_required" -> SakhaVoiceError.AuthRequired
+                    else -> SakhaVoiceError.Unknown(msg)
+                })
+            }
+        }
+
+        // Legacy `{"word": "...", "done": false}` shape used by /chat/message/stream
+        if (json.has("word")) return SakhaStreamEvent.Token(json.optString("word", ""))
+        if (json.optBoolean("done", false)) return SakhaStreamEvent.Done
+        if (json.has("session_id")) return SakhaStreamEvent.Session(json.optString("session_id", ""))
+        return null
+    }
+
+    // ------------------------------------------------------------------------
+    // Request body
+    // ------------------------------------------------------------------------
+
+    private fun buildRequestBody(userText: String, sessionId: String?, mood: SakhaMood?): String {
+        val payload = JSONObject().apply {
+            put("message", userText)
+            put("language", config.language.wire)
+            put("voice_id", config.sakhaVoiceId)
+            put("content_type", "voice")
+            put("voice_mode", "sakha")
+            put("stream", true)
+            sessionId?.let { put("session_id", it) }
+            mood?.let { put("mood_hint", it.wire) }
+        }
+        return payload.toString()
+    }
+
+    // ------------------------------------------------------------------------
+    // OkHttp helpers
+    // ------------------------------------------------------------------------
+
+    private suspend fun Call.executeSuspending(): Response =
+        suspendCancellableCoroutine { cont ->
+            enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    if (cont.isActive) cont.resumeWith(Result.failure(e))
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (cont.isActive) cont.resumeWith(Result.success(response))
+                }
+            })
+            cont.invokeOnCancellation { runCatching { cancel() } }
+        }
+
+    private fun Response.closeQuietly() {
+        try { close() } catch (_: Exception) {}
+    }
+
+    // ------------------------------------------------------------------------
+    // Outcome (internal)
+    // ------------------------------------------------------------------------
+
+    private sealed class Outcome {
+        object AuthExpired : Outcome()
+        object Quota : Outcome()
+        data class Server(val status: Int) : Outcome()
+        data class HttpFailure(val status: Int, val detail: String?) : Outcome()
+        data class NetworkFailure(val cause: IOException) : Outcome()
+        data class Unknown(val detail: String) : Outcome()
+        data class Streamed(val response: Response) : Outcome()
+    }
+
+    companion object {
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/native/android/voice/sakha/SakhaTtsPlayer.kt
+++ b/native/android/voice/sakha/SakhaTtsPlayer.kt
@@ -34,7 +34,6 @@ import android.media.MediaPlayer
 import android.net.Uri
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
-import android.util.Base64
 import android.util.Log
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -225,15 +224,30 @@ class SakhaTtsPlayer(
     // Sarvam REST synthesis
     // ------------------------------------------------------------------------
 
+    /**
+     * Synthesise [text] via the backend's `/api/voice-companion/synthesize`
+     * endpoint. The contract there (see VoiceCompanionSynthesizeRequest in
+     * backend/routes/kiaan_voice_companion.py) is:
+     *   request:  { text, mood?, voice_id?, language? }
+     *   response: binary audio bytes   (success path; Content-Type per provider)
+     *           | JSON {fallback_to_browser, browser_config, voice_persona}
+     *             (provider unavailable; we treat as a synthesis miss and let
+     *             the caller fall back to system TTS for non-Sanskrit prose)
+     *
+     * Returns the temp file path on success or null when the backend signals
+     * fallback / errors out. Never throws.
+     */
     private suspend fun synthesise(text: String, isSanskrit: Boolean): File? {
         val url = "${config.backendBaseUrl.trimEnd('/')}${config.voiceCompanionPathPrefix}/synthesize"
         val voiceId = if (isSanskrit) config.sanskritVoiceId else config.sakhaVoiceId
         val body = JSONObject().apply {
             put("text", text)
+            // The backend mood field is a tone hint for prosody — we use
+            // "reverent" for Sanskrit verses and "neutral" for prose so the
+            // server-side voice provider picks the right intonation profile.
+            put("mood", if (isSanskrit) "reverent" else "neutral")
             put("voice_id", voiceId)
             put("language", if (isSanskrit) "sa" else config.language.wire)
-            put("speed", if (isSanskrit) 0.85 else 1.0)
-            put("output_format", "mp3")
         }.toString()
 
         val token = config.authTokenProvider.invoke()
@@ -242,24 +256,25 @@ class SakhaTtsPlayer(
             .post(body.toRequestBody(JSON_MEDIA_TYPE))
             .header("X-Client", "kiaanverse-android-sakha-voice")
             .header("X-Voice-Mode", "sakha")
+            .header("Accept", "audio/*, application/json")
         token?.let { builder.header("Authorization", "Bearer $it") }
 
         return try {
-            val response = httpClient.newCall(builder.build()).execute()
-            response.use { resp ->
+            httpClient.newCall(builder.build()).execute().use { resp ->
                 if (!resp.isSuccessful) {
                     if (config.debugMode) Log.w(TAG, "Synth HTTP ${resp.code}")
                     return null
                 }
-                val contentType = resp.header("Content-Type", "audio/mpeg") ?: "audio/mpeg"
-                val bytes: ByteArray = if (contentType.startsWith("application/json")) {
-                    val json = JSONObject(resp.body?.string() ?: return null)
-                    val b64 = json.optString("audio_base64").ifEmpty { json.optString("audio") }
-                    if (b64.isNullOrEmpty()) return null
-                    Base64.decode(b64, Base64.DEFAULT)
-                } else {
-                    resp.body?.bytes() ?: return null
+                val contentType = resp.header("Content-Type") ?: "audio/mpeg"
+                if (contentType.contains("application/json", ignoreCase = true)) {
+                    // Provider fallback path — backend says "use browser TTS".
+                    // We can't run a browser; signal a miss so the caller
+                    // can use the on-device system TTS for prose.
+                    if (config.debugMode) Log.i(TAG, "Synth fallback signalled; declining for $isSanskrit")
+                    return null
                 }
+                val bytes = resp.body?.bytes() ?: return null
+                if (bytes.isEmpty()) return null
                 writeTempAudio(bytes, contentType)
             }
         } catch (e: Exception) {

--- a/native/android/voice/sakha/SakhaTtsPlayer.kt
+++ b/native/android/voice/sakha/SakhaTtsPlayer.kt
@@ -1,0 +1,360 @@
+/**
+ * Sakha TTS Player
+ *
+ * Sequential playback queue for the Sakha voice. Two backends:
+ *  1. **Sarvam REST** (preferred for prose + verses)
+ *     POST {backend}/api/voice-companion/synthesize → audio bytes (base64 in JSON
+ *     or raw audio/* depending on tier). Uses MediaPlayer for playback.
+ *  2. **Android system TTS** (fallback)
+ *     Used when Sarvam fails *and* the language has a system voice. Never used
+ *     for Sanskrit — system TTS will mangle it.
+ *
+ * The player is pause-aware: it consumes [PauseEvent]s from the parser and
+ * either:
+ *  - synthesises + plays the segment (Speak),
+ *  - delays for the requested number of milliseconds (Pause), or
+ *  - flushes everything and emits FILTER_FAIL handling (Filter).
+ *
+ * Concurrency model:
+ *  - One coroutine pulls events off the inbound channel and enqueues
+ *    Synthesise jobs.
+ *  - One coroutine drains the synthesis queue, plays each clip back-to-back,
+ *    and signals progress via [SakhaVoiceListener].
+ *
+ * This keeps synthesis pipelined ahead of playback (so the user hears one
+ * sentence while the next is being synthesised) without ever overlapping
+ * audio — Sakha's pacing depends on ordered, gapless playback.
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.net.Uri
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import android.util.Base64
+import android.util.Log
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+class SakhaTtsPlayer(
+    private val context: Context,
+    private val config: SakhaVoiceConfig,
+    private val listener: SakhaVoiceListener,
+) {
+
+    companion object {
+        private const val TAG = "SakhaTtsPlayer"
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(8, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .build()
+
+    // Channels are recreated on every [start] — Kotlin Channel.close() is
+    // terminal, so a session that stops and restarts (e.g. barge-in) needs
+    // fresh ones or trySend will silently no-op on the second turn.
+    private var incoming: Channel<PauseEvent> = Channel(Channel.UNLIMITED)
+    private var playbackQueue: Channel<PlayJob> = Channel(Channel.UNLIMITED)
+    private var ingestJob: Job? = null
+    private var playbackJob: Job? = null
+
+    private var fallbackTts: TextToSpeech? = null
+    private var fallbackTtsReady = false
+
+    private var currentPlayer: MediaPlayer? = null
+    private var totalSpokenMs: Long = 0L
+    private var pauseCount: Int = 0
+    private var stopped: Boolean = false
+
+    /**
+     * Start a new playback session. Call [enqueue] to feed events and
+     * [stop] to halt and free resources.
+     */
+    fun start() {
+        stopped = false
+        totalSpokenMs = 0L
+        pauseCount = 0
+        ensureFallbackTts()
+
+        ingestJob?.cancel()
+        playbackJob?.cancel()
+
+        // Fresh channels for the new session.
+        try { incoming.close() } catch (_: Exception) {}
+        try { playbackQueue.close() } catch (_: Exception) {}
+        incoming = Channel(Channel.UNLIMITED)
+        playbackQueue = Channel(Channel.UNLIMITED)
+
+        ingestJob = scope.launch {
+            for (event in incoming) {
+                if (stopped) break
+                handleIncoming(event)
+            }
+            playbackQueue.close()
+        }
+
+        playbackJob = scope.launch {
+            for (job in playbackQueue) {
+                if (stopped) break
+                playJob(job)
+            }
+        }
+    }
+
+    /** Feed a parser event into the player. Non-blocking. */
+    fun enqueue(event: PauseEvent) {
+        if (stopped) return
+        incoming.trySend(event)
+    }
+
+    /** Signal that the SSE stream is finished — drain remaining buffered events. */
+    fun finish() {
+        incoming.close()
+    }
+
+    /** Stop immediately and release MediaPlayer + TTS resources. */
+    fun stop() {
+        stopped = true
+        try { incoming.close() } catch (_: Exception) {}
+        try { playbackQueue.close() } catch (_: Exception) {}
+        currentPlayer?.let {
+            try { it.stop() } catch (_: Exception) {}
+            try { it.release() } catch (_: Exception) {}
+        }
+        currentPlayer = null
+        ingestJob?.cancel()
+        playbackJob?.cancel()
+    }
+
+    /** Permanently release. Call from onDestroy. */
+    fun shutdown() {
+        stop()
+        try { fallbackTts?.shutdown() } catch (_: Exception) {}
+        fallbackTts = null
+        scope.cancel()
+    }
+
+    fun statsTotalSpokenMs(): Long = totalSpokenMs
+    fun statsPauseCount(): Int = pauseCount
+
+    // ------------------------------------------------------------------------
+    // Pipeline
+    // ------------------------------------------------------------------------
+
+    private suspend fun handleIncoming(event: PauseEvent) {
+        when (event) {
+            is PauseEvent.Speak -> {
+                // Defence-in-depth: persona guard rewrites in-place.
+                val safeText = if (config.enablePersonaGuard) {
+                    val result = SakhaPersonaGuard.softenInline(event.text)
+                    if (result.text.isBlank()) {
+                        // Phrase was excised entirely; nothing left to say.
+                        return
+                    }
+                    result.text
+                } else {
+                    event.text
+                }
+                playbackQueue.trySend(PlayJob.Synthesise(safeText, event.isSanskrit))
+            }
+            is PauseEvent.Pause -> {
+                playbackQueue.trySend(PlayJob.Pause(event.durationMs))
+            }
+            is PauseEvent.Filter -> {
+                playbackQueue.trySend(PlayJob.Filter)
+            }
+        }
+    }
+
+    private suspend fun playJob(job: PlayJob) {
+        when (job) {
+            is PlayJob.Synthesise -> {
+                val audioFile = withTimeoutOrNull(8_000L) { synthesise(job.text, job.isSanskrit) }
+                if (audioFile != null) {
+                    val ms = playFile(audioFile)
+                    totalSpokenMs += ms
+                    listener.onSpokenSegment(job.text, job.isSanskrit)
+                    runCatching { audioFile.delete() }
+                } else {
+                    // Fallback to system TTS where possible (never for Sanskrit).
+                    if (!job.isSanskrit && fallbackTtsReady) {
+                        val ms = speakWithFallback(job.text)
+                        totalSpokenMs += ms
+                        listener.onSpokenSegment(job.text, false)
+                    } else {
+                        listener.onError(SakhaVoiceError.TtsError("synthesis-failed"))
+                    }
+                }
+            }
+            is PlayJob.Pause -> {
+                pauseCount++
+                listener.onPause(job.durationMs)
+                delay(job.durationMs)
+            }
+            PlayJob.Filter -> {
+                stop()
+                listener.onFilterFail()
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Sarvam REST synthesis
+    // ------------------------------------------------------------------------
+
+    private suspend fun synthesise(text: String, isSanskrit: Boolean): File? {
+        val url = "${config.backendBaseUrl.trimEnd('/')}${config.voiceCompanionPathPrefix}/synthesize"
+        val voiceId = if (isSanskrit) config.sanskritVoiceId else config.sakhaVoiceId
+        val body = JSONObject().apply {
+            put("text", text)
+            put("voice_id", voiceId)
+            put("language", if (isSanskrit) "sa" else config.language.wire)
+            put("speed", if (isSanskrit) 0.85 else 1.0)
+            put("output_format", "mp3")
+        }.toString()
+
+        val token = config.authTokenProvider.invoke()
+        val builder = Request.Builder()
+            .url(url)
+            .post(body.toRequestBody(JSON_MEDIA_TYPE))
+            .header("X-Client", "kiaanverse-android-sakha-voice")
+            .header("X-Voice-Mode", "sakha")
+        token?.let { builder.header("Authorization", "Bearer $it") }
+
+        return try {
+            val response = httpClient.newCall(builder.build()).execute()
+            response.use { resp ->
+                if (!resp.isSuccessful) {
+                    if (config.debugMode) Log.w(TAG, "Synth HTTP ${resp.code}")
+                    return null
+                }
+                val contentType = resp.header("Content-Type", "audio/mpeg") ?: "audio/mpeg"
+                val bytes: ByteArray = if (contentType.startsWith("application/json")) {
+                    val json = JSONObject(resp.body?.string() ?: return null)
+                    val b64 = json.optString("audio_base64").ifEmpty { json.optString("audio") }
+                    if (b64.isNullOrEmpty()) return null
+                    Base64.decode(b64, Base64.DEFAULT)
+                } else {
+                    resp.body?.bytes() ?: return null
+                }
+                writeTempAudio(bytes, contentType)
+            }
+        } catch (e: Exception) {
+            if (config.debugMode) Log.w(TAG, "Synth failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun writeTempAudio(bytes: ByteArray, contentType: String): File {
+        val ext = when {
+            contentType.contains("mpeg") -> "mp3"
+            contentType.contains("wav") -> "wav"
+            contentType.contains("ogg") -> "ogg"
+            else -> "mp3"
+        }
+        val file = File(context.cacheDir, "sakha-${UUID.randomUUID()}.$ext")
+        FileOutputStream(file).use { it.write(bytes) }
+        return file
+    }
+
+    private suspend fun playFile(file: File): Long {
+        val done = CompletableDeferred<Long>()
+        val started = System.currentTimeMillis()
+        try {
+            val player = MediaPlayer().apply {
+                setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                        .build()
+                )
+                setDataSource(context, Uri.fromFile(file))
+                setOnCompletionListener {
+                    done.complete(System.currentTimeMillis() - started)
+                }
+                setOnErrorListener { _, what, extra ->
+                    done.complete(0L)
+                    if (config.debugMode) Log.w(TAG, "MediaPlayer error: $what/$extra")
+                    true
+                }
+                prepare()
+                start()
+            }
+            currentPlayer = player
+            val ms = done.await()
+            try { player.release() } catch (_: Exception) {}
+            currentPlayer = null
+            return ms
+        } catch (e: Exception) {
+            if (config.debugMode) Log.w(TAG, "Playback failed: ${e.message}")
+            return 0L
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // System TTS fallback
+    // ------------------------------------------------------------------------
+
+    private fun ensureFallbackTts() {
+        if (fallbackTts != null) return
+        fallbackTts = TextToSpeech(context.applicationContext) { status ->
+            if (status == TextToSpeech.SUCCESS) {
+                val res = fallbackTts?.setLanguage(config.language.sttLocale)
+                fallbackTtsReady = (res != TextToSpeech.LANG_MISSING_DATA &&
+                        res != TextToSpeech.LANG_NOT_SUPPORTED)
+            } else {
+                fallbackTtsReady = false
+            }
+        }
+    }
+
+    private suspend fun speakWithFallback(text: String): Long {
+        val tts = fallbackTts ?: return 0L
+        val started = System.currentTimeMillis()
+        val done = CompletableDeferred<Unit>()
+        val utteranceId = UUID.randomUUID().toString()
+        tts.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+            override fun onStart(id: String?) {}
+            override fun onDone(id: String?) { done.complete(Unit) }
+            @Deprecated("Deprecated in Java")
+            override fun onError(id: String?) { done.complete(Unit) }
+            override fun onError(id: String?, errorCode: Int) { done.complete(Unit) }
+        })
+        tts.speak(text, TextToSpeech.QUEUE_ADD, null, utteranceId)
+        done.await()
+        return System.currentTimeMillis() - started
+    }
+
+    // ------------------------------------------------------------------------
+    // Internal job sealed
+    // ------------------------------------------------------------------------
+
+    private sealed class PlayJob {
+        data class Synthesise(val text: String, val isSanskrit: Boolean) : PlayJob()
+        data class Pause(val durationMs: Long) : PlayJob()
+        object Filter : PlayJob()
+    }
+}

--- a/native/android/voice/sakha/SakhaTypes.kt
+++ b/native/android/voice/sakha/SakhaTypes.kt
@@ -1,0 +1,258 @@
+/**
+ * Sakha Voice — Shared Types
+ *
+ * Data classes, enums, and configuration for the Sakha Voice mode pipeline.
+ * Sakha (सखा) is the friend/charioteer voice persona defined in
+ * sakha.voice.openai.md — distinct from the generic KIAAN voice manager.
+ *
+ * Voice mode = mic → STT → backend Sakha SSE → pause-aware Sarvam TTS playback.
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+import java.util.Locale
+
+// ============================================================================
+// Engine Selection
+// ============================================================================
+
+/**
+ * Which Sakha engine should the backend route to. Mirrors the <engine> tag
+ * from the Sakha system prompt.
+ */
+enum class SakhaEngine(val wire: String) {
+    GUIDANCE("GUIDANCE"),    // Wisdom-forward — verses front and centre
+    FRIEND("FRIEND"),        // Empathetic, witnessing
+    ASSISTANT("ASSISTANT"),  // Tool use, navigation
+    VOICE_GUIDE("VOICE_GUIDE"); // Acknowledgment when handing off to a tool
+
+    companion object {
+        fun fromWire(value: String?): SakhaEngine = when (value?.uppercase()) {
+            "GUIDANCE" -> GUIDANCE
+            "ASSISTANT" -> ASSISTANT
+            "VOICE_GUIDE" -> VOICE_GUIDE
+            else -> FRIEND
+        }
+    }
+}
+
+/**
+ * Mood label that drives tone selection. The 10 moods from the Sakha persona.
+ */
+enum class SakhaMood(val wire: String) {
+    ANXIOUS("anxious"),
+    SAD("sad"),
+    ANGRY("angry"),
+    LONELY("lonely"),
+    CONFUSED("confused"),
+    GRIEVING("grieving"),
+    JOYFUL("joyful"),
+    SEEKING("seeking"),
+    GUILTY("guilty"),
+    NUMB("numb"),
+    NEUTRAL("neutral");
+
+    companion object {
+        fun fromWire(value: String?): SakhaMood = entries.firstOrNull {
+            it.wire.equals(value, ignoreCase = true)
+        } ?: NEUTRAL
+    }
+}
+
+enum class SakhaMoodTrend(val wire: String) {
+    STABLE("stable"),
+    RISING("rising"),
+    FALLING("falling"),
+    MASKED("masked");
+
+    companion object {
+        fun fromWire(value: String?): SakhaMoodTrend = entries.firstOrNull {
+            it.wire.equals(value, ignoreCase = true)
+        } ?: STABLE
+    }
+}
+
+/**
+ * Languages Sakha can speak. The wire format matches Sarvam TTS language codes
+ * where applicable; STT uses BCP-47 via [sttLocale].
+ */
+enum class SakhaLanguage(val wire: String, val sttLocale: Locale) {
+    ENGLISH("en", Locale.US),
+    HINDI("hi", Locale("hi", "IN")),
+    HINGLISH("hinglish", Locale("hi", "IN")),
+    TAMIL("ta", Locale("ta", "IN")),
+    TELUGU("te", Locale("te", "IN")),
+    BENGALI("bn", Locale("bn", "IN")),
+    MARATHI("mr", Locale("mr", "IN")),
+    SANSKRIT("sa", Locale("hi", "IN")); // STT falls back to Hindi for Sanskrit
+
+    companion object {
+        fun fromWire(value: String?): SakhaLanguage = entries.firstOrNull {
+            it.wire.equals(value, ignoreCase = true)
+        } ?: ENGLISH
+    }
+}
+
+// ============================================================================
+// State Machine
+// ============================================================================
+
+/**
+ * Sakha Voice mode state machine. A single top-level state captures
+ * "where the user is in the breathing of a turn".
+ */
+enum class SakhaVoiceState {
+    UNINITIALIZED,
+    IDLE,                 // Ready to be activated
+    LISTENING,            // Mic open, capturing user speech
+    TRANSCRIBING,         // STT finalizing transcript
+    REQUESTING,           // SSE request open, waiting for first frame
+    SPEAKING,             // TTS playback in progress
+    PAUSING,              // Honouring a <pause:*> marker
+    INTERRUPTED,          // User barged in mid-Sakha-utterance
+    ERROR,
+    SHUTDOWN
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Sakha Voice configuration. Sensible defaults match the persona spec —
+ * change only when you know what you are doing.
+ */
+data class SakhaVoiceConfig(
+    /** User-facing language. Drives STT locale and TTS voice routing. */
+    val language: SakhaLanguage = SakhaLanguage.ENGLISH,
+
+    /** Backend base URL, e.g. "https://api.kiaanverse.com" — no trailing slash. */
+    val backendBaseUrl: String,
+
+    /** Optional bearer token resolver. Called once per request. */
+    val authTokenProvider: suspend () -> String? = { null },
+
+    /** Path prefix to the voice-companion routes. Defaults to MindVibe layout. */
+    val voiceCompanionPathPrefix: String = "/api/voice-companion",
+
+    /** Sarvam-style voice id for the persona body voice. */
+    val sakhaVoiceId: String = "sarvam-aura",
+
+    /** Voice id used when speaking Sanskrit verses (slower, reverent). */
+    val sanskritVoiceId: String = "sarvam-meera",
+
+    /** Default engine if backend does not route. */
+    val defaultEngine: SakhaEngine = SakhaEngine.FRIEND,
+
+    /**
+     * Allow the user to interrupt Sakha mid-utterance by speaking again
+     * ("barge-in"). Disabled in low-power mode.
+     */
+    val allowBargeIn: Boolean = true,
+
+    /** Silence (ms) after which the mic auto-closes. */
+    val silenceTimeoutMs: Long = 1800L,
+
+    /** Hard cap on a single utterance from Sakha. Defends UX in degraded modes. */
+    val maxResponseSpokenMs: Long = 45_000L,
+
+    /** Connect / read timeout for the SSE request. */
+    val requestTimeoutMs: Long = 12_000L,
+
+    /** How many times to retry the SSE request on transient failure. */
+    val maxRequestRetries: Int = 2,
+
+    /** Run the persona guard on every chunk before TTS hand-off. */
+    val enablePersonaGuard: Boolean = true,
+
+    /**
+     * If true, the manager will speak a soft template ("रहो… let us breathe
+     * together for a moment") instead of staying silent on FILTER_FAIL.
+     */
+    val speakOnFilterFail: Boolean = true,
+
+    /** Verbose logcat. Off in release builds. */
+    val debugMode: Boolean = false,
+)
+
+// ============================================================================
+// Telemetry / Metrics
+// ============================================================================
+
+/**
+ * Per-turn metrics. Surface these to your observability stack but never log
+ * the user's transcript.
+ */
+data class SakhaTurnMetrics(
+    val sessionId: String?,
+    val engine: SakhaEngine,
+    val mood: SakhaMood,
+    val moodIntensity: Int,
+    val language: SakhaLanguage,
+    val transcriptChars: Int,
+    val responseChars: Int,
+    val sttDurationMs: Long,
+    val firstByteMs: Long,
+    val firstAudioMs: Long,
+    val totalSpokenMs: Long,
+    val pauseCount: Int,
+    val verseCited: String?,
+    val filterFail: Boolean,
+    val personaGuardTriggered: Boolean,
+    val barged: Boolean,
+)
+
+// ============================================================================
+// Listener
+// ============================================================================
+
+/**
+ * UI-facing listener. All callbacks fire on the main thread.
+ *
+ * - [onStateChanged] is the canonical signal for animating the mandala.
+ * - [onPartialTranscript] is best-effort; do not block on it.
+ * - [onSakhaText] streams full SSE token chunks (post-pause-marker stripping)
+ *   so the UI can render a transcript while audio plays.
+ * - [onPause] fires every time the player honours a <pause:*> marker.
+ * - [onError] errors are non-fatal unless the state ends in [SakhaVoiceState.ERROR].
+ */
+interface SakhaVoiceListener {
+    fun onStateChanged(state: SakhaVoiceState, previousState: SakhaVoiceState) {}
+    fun onPartialTranscript(text: String) {}
+    fun onFinalTranscript(text: String) {}
+    fun onEngineSelected(engine: SakhaEngine, mood: SakhaMood, intensity: Int) {}
+    fun onSakhaText(textDelta: String, isFinal: Boolean) {}
+    fun onSpokenSegment(text: String, isSanskrit: Boolean) {}
+    fun onPause(durationMs: Long) {}
+    fun onVerseCited(reference: String, sanskrit: String?) {}
+    fun onFilterFail() {}
+    fun onTurnComplete(metrics: SakhaTurnMetrics) {}
+    fun onError(error: SakhaVoiceError) {}
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+sealed class SakhaVoiceError(message: String) : Exception(message) {
+    object PermissionDenied : SakhaVoiceError("RECORD_AUDIO permission not granted")
+    object MicrophoneUnavailable : SakhaVoiceError("Microphone not available")
+    object SpeechRecognitionUnavailable : SakhaVoiceError("Speech recognition not available")
+    data class NetworkError(val cause: String) : SakhaVoiceError("Network error: $cause")
+    data class HttpError(val status: Int, val detail: String) : SakhaVoiceError("HTTP $status: $detail")
+    object AuthRequired : SakhaVoiceError("Authentication required")
+    object QuotaExceeded : SakhaVoiceError("Daily quota exceeded")
+    object FilterFail : SakhaVoiceError("Sakha could not connect retrieved verses to the prompt")
+    data class TtsError(val detail: String) : SakhaVoiceError("TTS error: $detail")
+    data class Unknown(val detail: String) : SakhaVoiceError(detail)
+
+    val isRecoverable: Boolean
+        get() = when (this) {
+            is PermissionDenied,
+            is MicrophoneUnavailable,
+            is SpeechRecognitionUnavailable,
+            is AuthRequired,
+            is QuotaExceeded -> false
+            else -> true
+        }
+}

--- a/native/android/voice/sakha/SakhaVoiceManager.kt
+++ b/native/android/voice/sakha/SakhaVoiceManager.kt
@@ -85,6 +85,8 @@ class SakhaVoiceManager private constructor(private val context: Context) {
     val partialTranscript: StateFlow<String> = _partialTranscript.asStateFlow()
 
     private var sessionId: String? = null
+    private var turnCount: Int = 0
+    private var lastFinalTranscript: String = ""
     private var currentEngine: SakhaEngine = SakhaEngine.FRIEND
     private var currentMood: SakhaMood = SakhaMood.NEUTRAL
     private var currentMoodIntensity: Int = 5
@@ -194,6 +196,7 @@ class SakhaVoiceManager private constructor(private val context: Context) {
 
     fun resetSession() {
         sessionId = null
+        turnCount = 0
     }
 
     // ========================================================================
@@ -294,6 +297,7 @@ class SakhaVoiceManager private constructor(private val context: Context) {
                     setState(SakhaVoiceState.IDLE)
                     return@launch
                 }
+                lastFinalTranscript = text
                 listener.onFinalTranscript(text)
                 openTurn(text)
             }
@@ -314,6 +318,7 @@ class SakhaVoiceManager private constructor(private val context: Context) {
         filterFail = false
         firstByteMs = 0L
         firstAudioMs = 0L
+        turnCount += 1
 
         streamJob?.cancel()
         streamJob = scope.launch {
@@ -321,7 +326,7 @@ class SakhaVoiceManager private constructor(private val context: Context) {
             setState(SakhaVoiceState.REQUESTING)
             val client = sseClient ?: return@launch
             try {
-                client.stream(userText, sessionId, currentMood).collect { event ->
+                client.stream(userText, sessionId, currentMood, turnCount).collect { event ->
                     handleStreamEvent(event)
                 }
                 // Flow completed without explicit Done (e.g. server closed early)
@@ -435,7 +440,7 @@ class SakhaVoiceManager private constructor(private val context: Context) {
             mood = currentMood,
             moodIntensity = currentMoodIntensity,
             language = config.language,
-            transcriptChars = _partialTranscript.value.length,
+            transcriptChars = lastFinalTranscript.length,
             responseChars = responseChars,
             sttDurationMs = sttMs,
             firstByteMs = firstByteMs,

--- a/native/android/voice/sakha/SakhaVoiceManager.kt
+++ b/native/android/voice/sakha/SakhaVoiceManager.kt
@@ -1,0 +1,531 @@
+/**
+ * Sakha Voice Manager
+ *
+ * Top-level orchestrator for the native Android Sakha Voice mode.
+ *
+ * One turn of conversation:
+ *
+ *   IDLE
+ *     │
+ *     ▼ activate()
+ *   LISTENING ──────► silence-timeout / stopListening()
+ *     │
+ *     ▼ STT delivers final transcript
+ *   TRANSCRIBING
+ *     │
+ *     ▼ open SSE
+ *   REQUESTING ──────► first text frame
+ *     │
+ *     ▼ parser yields first speakable segment
+ *   SPEAKING ⇄ PAUSING (driven by parser events)
+ *     │
+ *     ▼ stream done & queue drained
+ *   IDLE
+ *
+ * Barge-in: while SPEAKING, the wake-word/STT layer can still detect a new
+ * user utterance. When [allowBargeIn] is true, we transition to INTERRUPTED,
+ * stop the player, and start a new LISTENING turn immediately.
+ *
+ * Thread model: all listener callbacks fire on Dispatchers.Main. Internal
+ * pipeline runs on Dispatchers.IO / Default.
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.util.Log
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+class SakhaVoiceManager private constructor(private val context: Context) {
+
+    companion object {
+        private const val TAG = "SakhaVoiceManager"
+
+        @Volatile
+        private var instance: SakhaVoiceManager? = null
+
+        fun getInstance(context: Context): SakhaVoiceManager {
+            return instance ?: synchronized(this) {
+                instance ?: SakhaVoiceManager(context.applicationContext).also { instance = it }
+            }
+        }
+    }
+
+    private lateinit var config: SakhaVoiceConfig
+    private var listener: SakhaVoiceListener = object : SakhaVoiceListener {}
+    private var initialized = false
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val turnMutex = Mutex()
+
+    private val _state = MutableStateFlow(SakhaVoiceState.UNINITIALIZED)
+    val state: StateFlow<SakhaVoiceState> = _state.asStateFlow()
+
+    private val _partialTranscript = MutableStateFlow("")
+    val partialTranscript: StateFlow<String> = _partialTranscript.asStateFlow()
+
+    private var sessionId: String? = null
+    private var currentEngine: SakhaEngine = SakhaEngine.FRIEND
+    private var currentMood: SakhaMood = SakhaMood.NEUTRAL
+    private var currentMoodIntensity: Int = 5
+
+    private var speechRecognizer: SpeechRecognizer? = null
+    private var sseClient: SakhaSseClient? = null
+    private var ttsPlayer: SakhaTtsPlayer? = null
+    private var parser: SakhaPauseParser = SakhaPauseParser()
+
+    private var sttJob: Job? = null
+    private var streamJob: Job? = null
+    private var silenceJob: Job? = null
+    private var maxResponseGuardJob: Job? = null
+
+    // Per-turn metric counters
+    private var turnStartedAtMs: Long = 0L
+    private var sttStartedAtMs: Long = 0L
+    private var firstByteMs: Long = 0L
+    private var firstAudioMs: Long = 0L
+    private var responseChars: Int = 0
+    private var verseCited: String? = null
+    private var personaGuardTriggered: Boolean = false
+    private var filterFail: Boolean = false
+    private var barged: Boolean = false
+
+    // ========================================================================
+    // Public API
+    // ========================================================================
+
+    /**
+     * Initialise the manager with [SakhaVoiceConfig]. Idempotent — safe to
+     * call again with a new config (e.g. when the user changes language).
+     */
+    fun initialize(config: SakhaVoiceConfig, listener: SakhaVoiceListener) {
+        this.config = config
+        this.listener = listener
+        this.sseClient = SakhaSseClient(config = config, refreshToken = { config.authTokenProvider() })
+        this.ttsPlayer = SakhaTtsPlayer(context, config, internalListener)
+        initialized = true
+        setState(SakhaVoiceState.IDLE)
+    }
+
+    fun hasRecordPermission(): Boolean = ContextCompat.checkSelfPermission(
+        context, Manifest.permission.RECORD_AUDIO
+    ) == PackageManager.PERMISSION_GRANTED
+
+    /** Begin a new voice turn — opens the mic. */
+    fun activate() {
+        ensureInitialized()
+        scope.launch {
+            turnMutex.withLock {
+                if (_state.value == SakhaVoiceState.SPEAKING ||
+                    _state.value == SakhaVoiceState.PAUSING) {
+                    if (config.allowBargeIn) {
+                        barged = true
+                        stopSpeakingInternal()
+                    } else {
+                        return@withLock
+                    }
+                }
+                if (!hasRecordPermission()) {
+                    listener.onError(SakhaVoiceError.PermissionDenied)
+                    return@withLock
+                }
+                resetTurnMetrics()
+                turnStartedAtMs = System.currentTimeMillis()
+                startListening()
+            }
+        }
+    }
+
+    /** User explicitly stopped speaking — finalise transcript and request response. */
+    fun stopListening() {
+        scope.launch {
+            speechRecognizer?.let {
+                withContext(Dispatchers.Main) { it.stopListening() }
+            }
+        }
+    }
+
+    /** Cancel everything in flight and return to IDLE. */
+    fun cancelTurn() {
+        scope.launch {
+            stopListeningInternal()
+            stopRequestInternal()
+            stopSpeakingInternal()
+            setState(SakhaVoiceState.IDLE)
+        }
+    }
+
+    /** Permanently release resources. Call from onDestroy. */
+    fun shutdown() {
+        cancelTurn()
+        scope.launch {
+            withContext(Dispatchers.Main) {
+                speechRecognizer?.destroy()
+                speechRecognizer = null
+            }
+            ttsPlayer?.shutdown()
+            ttsPlayer = null
+            sseClient?.cancel()
+            sseClient = null
+        }
+        setState(SakhaVoiceState.SHUTDOWN)
+        scope.cancel()
+    }
+
+    fun resetSession() {
+        sessionId = null
+    }
+
+    // ========================================================================
+    // STT
+    // ========================================================================
+
+    private suspend fun startListening() {
+        withContext(Dispatchers.Main) {
+            try {
+                if (!SpeechRecognizer.isRecognitionAvailable(context)) {
+                    listener.onError(SakhaVoiceError.SpeechRecognitionUnavailable)
+                    return@withContext
+                }
+                speechRecognizer?.destroy()
+                val recognizer = SpeechRecognizer.createSpeechRecognizer(context)
+                recognizer.setRecognitionListener(recognitionListener)
+                speechRecognizer = recognizer
+
+                val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                    putExtra(RecognizerIntent.EXTRA_LANGUAGE, config.language.sttLocale.toLanguageTag())
+                    putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+                    putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+                    putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+                }
+                sttStartedAtMs = System.currentTimeMillis()
+                setState(SakhaVoiceState.LISTENING)
+                recognizer.startListening(intent)
+                armSilenceTimer()
+            } catch (t: Throwable) {
+                listener.onError(SakhaVoiceError.Unknown(t.message ?: "stt-init"))
+                setState(SakhaVoiceState.ERROR)
+            }
+        }
+    }
+
+    private fun armSilenceTimer() {
+        silenceJob?.cancel()
+        silenceJob = scope.launch {
+            delay(config.silenceTimeoutMs)
+            withContext(Dispatchers.Main) { speechRecognizer?.stopListening() }
+        }
+    }
+
+    private fun resetSilenceTimer() = armSilenceTimer()
+
+    private suspend fun stopListeningInternal() {
+        silenceJob?.cancel()
+        withContext(Dispatchers.Main) {
+            try { speechRecognizer?.cancel() } catch (_: Exception) {}
+            try { speechRecognizer?.destroy() } catch (_: Exception) {}
+            speechRecognizer = null
+        }
+    }
+
+    private val recognitionListener = object : RecognitionListener {
+        override fun onReadyForSpeech(params: Bundle?) {}
+        override fun onBeginningOfSpeech() { resetSilenceTimer() }
+        override fun onRmsChanged(rmsdB: Float) {}
+        override fun onBufferReceived(buffer: ByteArray?) {}
+        override fun onEndOfSpeech() {}
+        override fun onEvent(eventType: Int, params: Bundle?) {}
+
+        override fun onError(error: Int) {
+            scope.launch {
+                silenceJob?.cancel()
+                if (error == SpeechRecognizer.ERROR_NO_MATCH ||
+                    error == SpeechRecognizer.ERROR_SPEECH_TIMEOUT) {
+                    // No speech — return to IDLE softly.
+                    setState(SakhaVoiceState.IDLE)
+                    return@launch
+                }
+                val mapped = when (error) {
+                    SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> SakhaVoiceError.PermissionDenied
+                    SpeechRecognizer.ERROR_NETWORK,
+                    SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> SakhaVoiceError.NetworkError("stt-$error")
+                    SpeechRecognizer.ERROR_AUDIO -> SakhaVoiceError.MicrophoneUnavailable
+                    else -> SakhaVoiceError.Unknown("stt-$error")
+                }
+                listener.onError(mapped)
+                setState(SakhaVoiceState.ERROR)
+            }
+        }
+
+        override fun onPartialResults(partialResults: Bundle?) {
+            val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+            val text = matches?.firstOrNull() ?: return
+            _partialTranscript.value = text
+            scope.launch(Dispatchers.Main) { listener.onPartialTranscript(text) }
+            resetSilenceTimer()
+        }
+
+        override fun onResults(results: Bundle?) {
+            val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+            val text = matches?.firstOrNull()?.trim().orEmpty()
+            scope.launch(Dispatchers.Main) {
+                if (text.isEmpty()) {
+                    setState(SakhaVoiceState.IDLE)
+                    return@launch
+                }
+                listener.onFinalTranscript(text)
+                openTurn(text)
+            }
+        }
+    }
+
+    // ========================================================================
+    // SSE turn
+    // ========================================================================
+
+    private fun openTurn(userText: String) {
+        setState(SakhaVoiceState.TRANSCRIBING)
+        parser.reset()
+        ttsPlayer?.start()
+        responseChars = 0
+        verseCited = null
+        personaGuardTriggered = false
+        filterFail = false
+        firstByteMs = 0L
+        firstAudioMs = 0L
+
+        streamJob?.cancel()
+        streamJob = scope.launch {
+            armMaxResponseGuard()
+            setState(SakhaVoiceState.REQUESTING)
+            val client = sseClient ?: return@launch
+            try {
+                client.stream(userText, sessionId, currentMood).collect { event ->
+                    handleStreamEvent(event)
+                }
+                // Flow completed without explicit Done (e.g. server closed early)
+                drainAndFinish()
+            } catch (t: Throwable) {
+                listener.onError(SakhaVoiceError.Unknown(t.message ?: "stream"))
+                setState(SakhaVoiceState.ERROR)
+            }
+        }
+    }
+
+    private fun armMaxResponseGuard() {
+        maxResponseGuardJob?.cancel()
+        maxResponseGuardJob = scope.launch {
+            delay(config.maxResponseSpokenMs)
+            // If we are still speaking after this, cut it off gracefully.
+            if (_state.value == SakhaVoiceState.SPEAKING ||
+                _state.value == SakhaVoiceState.PAUSING) {
+                stopSpeakingInternal()
+                completeTurn()
+            }
+        }
+    }
+
+    private suspend fun handleStreamEvent(event: SakhaStreamEvent) {
+        if (firstByteMs == 0L) firstByteMs = System.currentTimeMillis() - turnStartedAtMs
+        when (event) {
+            is SakhaStreamEvent.Token -> {
+                responseChars += event.text.length
+                listener.onSakhaText(event.text, isFinal = false)
+                feedParser(event.text)
+            }
+            is SakhaStreamEvent.Engine -> {
+                currentEngine = event.engine
+                currentMood = event.mood
+                currentMoodIntensity = event.intensity
+                withContext(Dispatchers.Main) {
+                    listener.onEngineSelected(event.engine, event.mood, event.intensity)
+                }
+            }
+            is SakhaStreamEvent.Verse -> {
+                verseCited = event.reference
+                withContext(Dispatchers.Main) {
+                    listener.onVerseCited(event.reference, event.sanskrit)
+                }
+            }
+            is SakhaStreamEvent.Audio -> {
+                // Backend pre-synthesised audio — we currently don't use this
+                // path (we synthesise client-side via /synthesize for pause
+                // control), but we keep the hook open for future tiers.
+            }
+            is SakhaStreamEvent.Session -> {
+                sessionId = event.sessionId
+            }
+            SakhaStreamEvent.Done -> {
+                drainAndFinish()
+            }
+            is SakhaStreamEvent.Error -> {
+                listener.onError(event.error)
+                setState(SakhaVoiceState.ERROR)
+                completeTurn()
+            }
+        }
+    }
+
+    private suspend fun feedParser(text: String) {
+        val events = parser.feed(text)
+        if (events.isEmpty()) return
+        if (_state.value != SakhaVoiceState.SPEAKING && _state.value != SakhaVoiceState.PAUSING) {
+            setState(SakhaVoiceState.SPEAKING)
+            if (firstAudioMs == 0L) firstAudioMs = System.currentTimeMillis() - turnStartedAtMs
+        }
+        for (e in events) handleParserEvent(e)
+    }
+
+    private suspend fun handleParserEvent(e: PauseEvent) {
+        when (e) {
+            is PauseEvent.Filter -> {
+                filterFail = true
+                if (config.speakOnFilterFail) {
+                    val template = filterFailTemplate()
+                    ttsPlayer?.enqueue(PauseEvent.Speak(template, isSanskrit = false))
+                }
+                ttsPlayer?.enqueue(PauseEvent.Filter)
+            }
+            else -> ttsPlayer?.enqueue(e)
+        }
+    }
+
+    private suspend fun drainAndFinish() {
+        // Final flush of buffered prose.
+        for (ev in parser.finish()) handleParserEvent(ev)
+        ttsPlayer?.finish()
+        // Wait a tick for the playback queue to drain. We do not block on
+        // playback completion — that's the player's responsibility — but we
+        // do want to capture a final metric snapshot when the queue empties.
+        delay(50L)
+        completeTurn()
+    }
+
+    private fun completeTurn() {
+        maxResponseGuardJob?.cancel()
+        val player = ttsPlayer
+        val totalSpoken = player?.statsTotalSpokenMs() ?: 0L
+        val pauses = player?.statsPauseCount() ?: 0
+        val sttMs = (System.currentTimeMillis() - sttStartedAtMs).coerceAtLeast(0L)
+
+        val metrics = SakhaTurnMetrics(
+            sessionId = sessionId,
+            engine = currentEngine,
+            mood = currentMood,
+            moodIntensity = currentMoodIntensity,
+            language = config.language,
+            transcriptChars = _partialTranscript.value.length,
+            responseChars = responseChars,
+            sttDurationMs = sttMs,
+            firstByteMs = firstByteMs,
+            firstAudioMs = firstAudioMs,
+            totalSpokenMs = totalSpoken,
+            pauseCount = pauses,
+            verseCited = verseCited,
+            filterFail = filterFail,
+            personaGuardTriggered = personaGuardTriggered,
+            barged = barged,
+        )
+        scope.launch(Dispatchers.Main) { listener.onTurnComplete(metrics) }
+        setState(SakhaVoiceState.IDLE)
+    }
+
+    private fun resetTurnMetrics() {
+        firstByteMs = 0L
+        firstAudioMs = 0L
+        responseChars = 0
+        verseCited = null
+        personaGuardTriggered = false
+        filterFail = false
+        barged = false
+    }
+
+    private fun stopRequestInternal() {
+        streamJob?.cancel()
+        streamJob = null
+        sseClient?.cancel()
+    }
+
+    private fun stopSpeakingInternal() {
+        ttsPlayer?.stop()
+        ttsPlayer?.start() // re-arm for next turn
+    }
+
+    // ========================================================================
+    // Filter-fail template (per persona spec — soft, not a sign-off)
+    // ========================================================================
+
+    private fun filterFailTemplate(): String = when (config.language) {
+        SakhaLanguage.HINDI, SakhaLanguage.HINGLISH -> "रहो… एक साँस। अभी मेरे पास सही श्लोक नहीं है — पर मैं यहाँ हूँ।"
+        SakhaLanguage.TAMIL -> "ஒரு மூச்சு… நான் இங்கே இருக்கிறேன்."
+        SakhaLanguage.TELUGU -> "ఒక శ్వాస… నేను ఇక్కడ ఉన్నాను."
+        SakhaLanguage.BENGALI -> "এক নিঃশ্বাস… আমি এখানে আছি।"
+        SakhaLanguage.MARATHI -> "एक श्वास… मी इथेच आहे।"
+        else -> "Stay with me. One breath. I do not have the verse yet — but I am here."
+    }
+
+    // ========================================================================
+    // State helpers
+    // ========================================================================
+
+    private fun setState(next: SakhaVoiceState) {
+        val prev = _state.value
+        if (next == prev) return
+        _state.value = next
+        if (config.debugMode) Log.d(TAG, "state $prev → $next")
+        scope.launch(Dispatchers.Main) { listener.onStateChanged(next, prev) }
+    }
+
+    private fun ensureInitialized() {
+        check(initialized) { "SakhaVoiceManager.initialize() must be called first" }
+    }
+
+    // ========================================================================
+    // Internal listener used by the TTS player. We forward to the user's
+    // listener and capture metrics here.
+    // ========================================================================
+
+    private val internalListener: SakhaVoiceListener = object : SakhaVoiceListener {
+        override fun onSpokenSegment(text: String, isSanskrit: Boolean) {
+            scope.launch(Dispatchers.Main) { listener.onSpokenSegment(text, isSanskrit) }
+        }
+        override fun onPause(durationMs: Long) {
+            // Toggle PAUSING during the pause; the next Speak job flips us back.
+            setState(SakhaVoiceState.PAUSING)
+            scope.launch(Dispatchers.Main) { listener.onPause(durationMs) }
+            scope.launch {
+                delay(durationMs)
+                if (_state.value == SakhaVoiceState.PAUSING) {
+                    setState(SakhaVoiceState.SPEAKING)
+                }
+            }
+        }
+        override fun onFilterFail() {
+            scope.launch(Dispatchers.Main) { listener.onFilterFail() }
+        }
+        override fun onError(error: SakhaVoiceError) {
+            scope.launch(Dispatchers.Main) { listener.onError(error) }
+        }
+    }
+}

--- a/native/android/voice/sakha/SakhaVoiceModule.kt
+++ b/native/android/voice/sakha/SakhaVoiceModule.kt
@@ -1,0 +1,272 @@
+/**
+ * Sakha Voice — React Native Bridge Module
+ *
+ * Exposes the [SakhaVoiceManager] to JavaScript through React Native's old
+ * (legacy) bridge. We chose the old bridge instead of TurboModules for two
+ * reasons:
+ *  1. The host app (kiaanverse-mobile) currently runs on the React Native
+ *     version that ships with Expo SDK 51 — TurboModules are still gated
+ *     behind the New Architecture flag, which is not enabled there.
+ *  2. The bridge surface is small (a handful of imperative calls + a typed
+ *     event stream), so the perf delta is negligible.
+ *
+ * Method surface (matches native/shared/SakhaVoiceInterface.ts):
+ *   initialize(config)       – one-shot setup
+ *   activate()               – begin a turn (open mic)
+ *   stopListening()          – finalise transcript and request response
+ *   cancelTurn()             – hard cancel (mic + request + playback)
+ *   resetSession()           – forget session_id; new conversation
+ *   shutdown()               – release everything; call from screen unmount
+ *
+ * Events (RCTDeviceEventEmitter):
+ *   SakhaVoiceState                  { state, previousState }
+ *   SakhaVoicePartialTranscript      { text }
+ *   SakhaVoiceFinalTranscript        { text }
+ *   SakhaVoiceEngineSelected         { engine, mood, intensity }
+ *   SakhaVoiceText                   { delta, isFinal }
+ *   SakhaVoiceSpoken                 { text, isSanskrit }
+ *   SakhaVoicePause                  { durationMs }
+ *   SakhaVoiceVerseCited             { reference, sanskrit }
+ *   SakhaVoiceFilterFail             {}
+ *   SakhaVoiceTurnComplete           { ...metrics }
+ *   SakhaVoiceError                  { code, message, recoverable }
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+import android.util.Log
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class SakhaVoiceModule(
+    private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+
+    companion object {
+        const val NAME = "SakhaVoice"
+        private const val TAG = "SakhaVoiceModule"
+    }
+
+    override fun getName(): String = NAME
+
+    private val manager: SakhaVoiceManager by lazy {
+        SakhaVoiceManager.getInstance(reactContext.applicationContext)
+    }
+
+    /** JS-supplied bearer token. Re-read on every request. */
+    @Volatile
+    private var bearerToken: String? = null
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    // ------------------------------------------------------------------------
+    // Lifecycle
+    // ------------------------------------------------------------------------
+
+    @ReactMethod
+    fun initialize(configMap: ReadableMap, promise: Promise) {
+        try {
+            val config = SakhaVoiceConfig(
+                language = SakhaLanguage.fromWire(configMap.optString("language") ?: "en"),
+                backendBaseUrl = configMap.getString("backendBaseUrl")
+                    ?: throw IllegalArgumentException("backendBaseUrl is required"),
+                voiceCompanionPathPrefix = configMap.optString("voiceCompanionPathPrefix") ?: "/api/voice-companion",
+                sakhaVoiceId = configMap.optString("sakhaVoiceId") ?: "sarvam-aura",
+                sanskritVoiceId = configMap.optString("sanskritVoiceId") ?: "sarvam-meera",
+                allowBargeIn = configMap.optBoolean("allowBargeIn", true),
+                silenceTimeoutMs = configMap.optDouble("silenceTimeoutMs", 1800.0).toLong(),
+                maxResponseSpokenMs = configMap.optDouble("maxResponseSpokenMs", 45_000.0).toLong(),
+                requestTimeoutMs = configMap.optDouble("requestTimeoutMs", 12_000.0).toLong(),
+                maxRequestRetries = configMap.optInt("maxRequestRetries", 2),
+                enablePersonaGuard = configMap.optBoolean("enablePersonaGuard", true),
+                speakOnFilterFail = configMap.optBoolean("speakOnFilterFail", true),
+                debugMode = configMap.optBoolean("debugMode", false),
+                authTokenProvider = { bearerToken },
+            )
+            manager.initialize(config, bridgeListener)
+            promise.resolve(null)
+        } catch (t: Throwable) {
+            promise.reject("init_failed", t.message ?: "init failed", t)
+        }
+    }
+
+    @ReactMethod
+    fun setAuthToken(token: String?) {
+        bearerToken = token?.takeIf { it.isNotBlank() }
+    }
+
+    @ReactMethod
+    fun hasRecordPermission(promise: Promise) {
+        promise.resolve(manager.hasRecordPermission())
+    }
+
+    @ReactMethod
+    fun activate(promise: Promise) {
+        try {
+            manager.activate()
+            promise.resolve(null)
+        } catch (t: Throwable) {
+            promise.reject("activate_failed", t.message, t)
+        }
+    }
+
+    @ReactMethod
+    fun stopListening(promise: Promise) {
+        manager.stopListening()
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun cancelTurn(promise: Promise) {
+        manager.cancelTurn()
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun resetSession(promise: Promise) {
+        manager.resetSession()
+        promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun shutdown(promise: Promise) {
+        manager.shutdown()
+        promise.resolve(null)
+    }
+
+    // Required by RN's NativeEventEmitter contract.
+    @ReactMethod
+    fun addListener(eventName: String) { /* no-op */ }
+
+    @ReactMethod
+    fun removeListeners(count: Int) { /* no-op */ }
+
+    // ------------------------------------------------------------------------
+    // Listener → JS event bridge
+    // ------------------------------------------------------------------------
+
+    private fun emit(eventName: String, payload: WritableMap) {
+        try {
+            reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit(eventName, payload)
+        } catch (t: Throwable) {
+            Log.w(TAG, "emit($eventName) failed: ${t.message}")
+        }
+    }
+
+    private val bridgeListener = object : SakhaVoiceListener {
+        override fun onStateChanged(state: SakhaVoiceState, previousState: SakhaVoiceState) {
+            emit("SakhaVoiceState", Arguments.createMap().apply {
+                putString("state", state.name)
+                putString("previousState", previousState.name)
+            })
+        }
+
+        override fun onPartialTranscript(text: String) {
+            emit("SakhaVoicePartialTranscript", Arguments.createMap().apply {
+                putString("text", text)
+            })
+        }
+
+        override fun onFinalTranscript(text: String) {
+            emit("SakhaVoiceFinalTranscript", Arguments.createMap().apply {
+                putString("text", text)
+            })
+        }
+
+        override fun onEngineSelected(engine: SakhaEngine, mood: SakhaMood, intensity: Int) {
+            emit("SakhaVoiceEngineSelected", Arguments.createMap().apply {
+                putString("engine", engine.wire)
+                putString("mood", mood.wire)
+                putInt("intensity", intensity)
+            })
+        }
+
+        override fun onSakhaText(textDelta: String, isFinal: Boolean) {
+            emit("SakhaVoiceText", Arguments.createMap().apply {
+                putString("delta", textDelta)
+                putBoolean("isFinal", isFinal)
+            })
+        }
+
+        override fun onSpokenSegment(text: String, isSanskrit: Boolean) {
+            emit("SakhaVoiceSpoken", Arguments.createMap().apply {
+                putString("text", text)
+                putBoolean("isSanskrit", isSanskrit)
+            })
+        }
+
+        override fun onPause(durationMs: Long) {
+            emit("SakhaVoicePause", Arguments.createMap().apply {
+                putDouble("durationMs", durationMs.toDouble())
+            })
+        }
+
+        override fun onVerseCited(reference: String, sanskrit: String?) {
+            emit("SakhaVoiceVerseCited", Arguments.createMap().apply {
+                putString("reference", reference)
+                sanskrit?.let { putString("sanskrit", it) }
+            })
+        }
+
+        override fun onFilterFail() {
+            emit("SakhaVoiceFilterFail", Arguments.createMap())
+        }
+
+        override fun onTurnComplete(metrics: SakhaTurnMetrics) {
+            emit("SakhaVoiceTurnComplete", Arguments.createMap().apply {
+                metrics.sessionId?.let { putString("sessionId", it) }
+                putString("engine", metrics.engine.wire)
+                putString("mood", metrics.mood.wire)
+                putInt("moodIntensity", metrics.moodIntensity)
+                putString("language", metrics.language.wire)
+                putInt("transcriptChars", metrics.transcriptChars)
+                putInt("responseChars", metrics.responseChars)
+                putDouble("sttDurationMs", metrics.sttDurationMs.toDouble())
+                putDouble("firstByteMs", metrics.firstByteMs.toDouble())
+                putDouble("firstAudioMs", metrics.firstAudioMs.toDouble())
+                putDouble("totalSpokenMs", metrics.totalSpokenMs.toDouble())
+                putInt("pauseCount", metrics.pauseCount)
+                metrics.verseCited?.let { putString("verseCited", it) }
+                putBoolean("filterFail", metrics.filterFail)
+                putBoolean("personaGuardTriggered", metrics.personaGuardTriggered)
+                putBoolean("barged", metrics.barged)
+            })
+        }
+
+        override fun onError(error: SakhaVoiceError) {
+            emit("SakhaVoiceError", Arguments.createMap().apply {
+                putString("code", error::class.simpleName ?: "Unknown")
+                putString("message", error.message ?: "Unknown")
+                putBoolean("recoverable", error.isRecoverable)
+            })
+        }
+    }
+}
+
+/**
+ * Tiny ReadableMap helpers — RN's API throws on missing keys, so we wrap with
+ * sensible defaults to keep the JS-facing config tolerant.
+ */
+private fun ReadableMap.optString(key: String): String? =
+    if (hasKey(key) && !isNull(key)) getString(key) else null
+
+private fun ReadableMap.optBoolean(key: String, default: Boolean): Boolean =
+    if (hasKey(key) && !isNull(key)) getBoolean(key) else default
+
+private fun ReadableMap.optDouble(key: String, default: Double): Double =
+    if (hasKey(key) && !isNull(key)) getDouble(key) else default
+
+private fun ReadableMap.optInt(key: String, default: Int): Int =
+    if (hasKey(key) && !isNull(key)) getInt(key) else default

--- a/native/android/voice/sakha/SakhaVoicePackage.kt
+++ b/native/android/voice/sakha/SakhaVoicePackage.kt
@@ -1,0 +1,29 @@
+/**
+ * Sakha Voice — React Native Package
+ *
+ * Registers [SakhaVoiceModule] with the React Native runtime so JS code can
+ * import it via `NativeModules.SakhaVoice`. Add this package to your
+ * MainApplication.kt:
+ *
+ *   override fun getPackages(): List<ReactPackage> = PackageList(this).packages.apply {
+ *       add(SakhaVoicePackage())
+ *   }
+ *
+ * The Expo config plugin in this branch wires the registration automatically
+ * during prebuild (see plugins/with-sakha-voice.ts).
+ */
+
+package com.mindvibe.kiaan.voice.sakha
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class SakhaVoicePackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+        listOf(SakhaVoiceModule(reactContext))
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+}

--- a/native/android/voice/sakha/test/SakhaPauseParserTest.kt
+++ b/native/android/voice/sakha/test/SakhaPauseParserTest.kt
@@ -1,0 +1,159 @@
+/**
+ * SakhaPauseParser unit tests.
+ *
+ * The parser is the most subtle piece of the voice pipeline — it must
+ * tolerate every way a network can split a UTF-8 stream while never speaking
+ * pause markers aloud and never leaking text after FILTER_FAIL.
+ *
+ * Run with the standard android-library test target:
+ *   ./gradlew :sakha-voice:testDebugUnitTest
+ */
+
+package com.mindvibe.kiaan.voice.sakha.test
+
+import com.mindvibe.kiaan.voice.sakha.PauseEvent
+import com.mindvibe.kiaan.voice.sakha.SakhaPauseParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SakhaPauseParserTest {
+
+    // ------------------------------------------------------------------------
+    // Marker handling
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `recognises all three pause durations`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("first.<pause:short>second.<pause:medium>third.<pause:long>")
+        val pauses = events.filterIsInstance<PauseEvent.Pause>().map { it.durationMs }
+        assertEquals(listOf(300L, 600L, 1200L), pauses)
+    }
+
+    @Test
+    fun `pause marker is excised from the spoken segment`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("Stay with me.<pause:short>One breath.")
+        val speakables = events.filterIsInstance<PauseEvent.Speak>().map { it.text }
+        assertTrue("no marker leaks: $speakables", speakables.none { it.contains("<pause") })
+        assertEquals("Stay with me.", speakables[0])
+    }
+
+    // ------------------------------------------------------------------------
+    // Streaming partial chunks
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `marker split across chunk boundary is buffered until complete`() {
+        val parser = SakhaPauseParser()
+        val first = parser.feed("first.<pau")
+        val firstSpoken = first.filterIsInstance<PauseEvent.Speak>().joinToString("|") { it.text }
+        assertEquals("first.", firstSpoken)
+        assertTrue("no pause yet", first.filterIsInstance<PauseEvent.Pause>().isEmpty())
+
+        val second = parser.feed("se:short>second.")
+        val pauses = second.filterIsInstance<PauseEvent.Pause>()
+        assertEquals(1, pauses.size)
+        assertEquals(300L, pauses[0].durationMs)
+        assertTrue(
+            "marker leaked into spoken text",
+            second.filterIsInstance<PauseEvent.Speak>().none { it.text.contains("<pau") },
+        )
+    }
+
+    @Test
+    fun `unknown angle-tag is treated as literal text`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("hello <not-a-pause> there.")
+        val text = events.filterIsInstance<PauseEvent.Speak>().joinToString(" ") { it.text }
+        assertTrue("got: $text", text.contains("hello") && text.contains("there"))
+    }
+
+    // ------------------------------------------------------------------------
+    // Sanskrit detection
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `devanagari segments are flagged as Sanskrit`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("कर्मण्येवाधिकारस्ते मा फलेषु कदाचन।<pause:medium>")
+        val speakables = events.filterIsInstance<PauseEvent.Speak>()
+        assertTrue("expected sanskrit speakable, got: $speakables", speakables.any { it.isSanskrit })
+    }
+
+    @Test
+    fun `english segments are not flagged as Sanskrit`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("You have a right to action.<pause:short>")
+        val speakables = events.filterIsInstance<PauseEvent.Speak>()
+        assertTrue(speakables.all { !it.isSanskrit })
+    }
+
+    // ------------------------------------------------------------------------
+    // FILTER_FAIL
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `FILTER_FAIL aborts speakable output`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("FILTER_FAIL: no_retrieval")
+        assertEquals(1, events.size)
+        assertTrue(events[0] is PauseEvent.Filter)
+    }
+
+    @Test
+    fun `FILTER_FAIL discards prior leaked tokens`() {
+        val parser = SakhaPauseParser()
+        // Server fall-through can race — the model might emit a half-sentence
+        // before deciding to FILTER_FAIL. We must NOT speak that fragment.
+        val events = parser.feed("I understand. FILTER_FAIL: no_retrieval")
+        assertEquals(1, events.size)
+        assertTrue(events[0] is PauseEvent.Filter)
+    }
+
+    @Test
+    fun `subsequent feeds after FILTER_FAIL are ignored`() {
+        val parser = SakhaPauseParser()
+        parser.feed("FILTER_FAIL: no_retrieval")
+        val later = parser.feed("Stay with me.")
+        assertTrue(later.isEmpty())
+    }
+
+    // ------------------------------------------------------------------------
+    // Sentence boundary flushing
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `mid-sentence chunk does not flush until punctuation arrives`() {
+        val parser = SakhaPauseParser()
+        val first = parser.feed("Stay with ")
+        assertTrue(
+            "no flush yet, got: ${first.filterIsInstance<PauseEvent.Speak>()}",
+            first.filterIsInstance<PauseEvent.Speak>().isEmpty(),
+        )
+        val second = parser.feed("me.")
+        val sp = second.filterIsInstance<PauseEvent.Speak>()
+        assertEquals(1, sp.size)
+        assertEquals("Stay with me.", sp[0].text)
+    }
+
+    @Test
+    fun `finish flushes any buffered prose`() {
+        val parser = SakhaPauseParser()
+        parser.feed("Tail without punctuation")
+        val tail = parser.finish()
+        val sp = tail.filterIsInstance<PauseEvent.Speak>()
+        assertEquals(1, sp.size)
+        assertEquals("Tail without punctuation", sp[0].text)
+    }
+
+    @Test
+    fun `Devanagari danda is treated as sentence end`() {
+        val parser = SakhaPauseParser()
+        val events = parser.feed("उद्धरेदात्मनात्मानम्।")
+        val sp = events.filterIsInstance<PauseEvent.Speak>()
+        assertEquals(1, sp.size)
+        assertTrue(sp[0].isSanskrit)
+    }
+}

--- a/native/android/voice/sakha/test/SakhaPauseParserTest.kt
+++ b/native/android/voice/sakha/test/SakhaPauseParserTest.kt
@@ -14,6 +14,7 @@ package com.mindvibe.kiaan.voice.sakha.test
 import com.mindvibe.kiaan.voice.sakha.PauseEvent
 import com.mindvibe.kiaan.voice.sakha.SakhaPauseParser
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -63,11 +64,14 @@ class SakhaPauseParserTest {
     }
 
     @Test
-    fun `unknown angle-tag is treated as literal text`() {
+    fun `unknown angle-tag is dropped while surrounding prose is kept`() {
         val parser = SakhaPauseParser()
         val events = parser.feed("hello <not-a-pause> there.")
         val text = events.filterIsInstance<PauseEvent.Speak>().joinToString(" ") { it.text }
+        // Surrounding prose must survive…
         assertTrue("got: $text", text.contains("hello") && text.contains("there"))
+        // …and the unknown tag must NOT be spoken as literal text.
+        assertFalse("tag leaked into TTS: $text", text.contains("not-a-pause"))
     }
 
     // ------------------------------------------------------------------------

--- a/native/android/voice/sakha/test/SakhaPersonaGuardTest.kt
+++ b/native/android/voice/sakha/test/SakhaPersonaGuardTest.kt
@@ -1,0 +1,121 @@
+/**
+ * SakhaPersonaGuard unit tests.
+ *
+ * Defends the persona by catching the AI-tells listed in sakha.voice.openai.md.
+ * The guard is the second line of defence — the model is the first — so we
+ * test both inline rewriting and the harder retry signal.
+ */
+
+package com.mindvibe.kiaan.voice.sakha.test
+
+import com.mindvibe.kiaan.voice.sakha.SakhaPersonaGuard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SakhaPersonaGuardTest {
+
+    @Test
+    fun `clean prose passes through unchanged`() {
+        val input = "Stay with me. One breath."
+        val out = SakhaPersonaGuard.softenInline(input)
+        assertEquals(input, out.text)
+        assertFalse(out.triggered)
+    }
+
+    @Test
+    fun `i understand is rewritten`() {
+        val out = SakhaPersonaGuard.softenInline("I understand. That sounds painful.")
+        assertTrue("triggered=${out.triggered}, text=${out.text}", out.triggered)
+        assertFalse(out.text.contains("I understand"))
+    }
+
+    @Test
+    fun `you've got this is excised`() {
+        val out = SakhaPersonaGuard.softenInline("Trust your dharma. You've got this!")
+        assertTrue(out.triggered)
+        assertFalse(out.text.contains("You've got this"))
+        assertTrue("kept the dharma sentence: ${out.text}", out.text.contains("Trust your dharma"))
+    }
+
+    @Test
+    fun `just breathe is rewritten not removed`() {
+        val out = SakhaPersonaGuard.softenInline("Just breathe.")
+        assertTrue(out.triggered)
+        assertFalse(out.text.contains("Just breathe"))
+    }
+
+    @Test
+    fun `your feelings are valid is excised`() {
+        val out = SakhaPersonaGuard.softenInline("Your feelings are valid.")
+        assertTrue(out.triggered)
+        assertFalse(out.text.lowercase().contains("feelings are valid"))
+    }
+
+    @Test
+    fun `sending you love and light removed cleanly`() {
+        val out = SakhaPersonaGuard.softenInline("Sending you love and light.")
+        assertTrue(out.triggered)
+        // After excision and whitespace collapse the period should still
+        // sit flush against the previous token, never floating alone.
+        val cleaned = out.text.trim()
+        assertFalse("leftover floating punctuation: '$cleaned'", cleaned == ".")
+    }
+
+    @Test
+    fun `idempotent on second pass`() {
+        val once = SakhaPersonaGuard.softenInline("I understand. Have you tried meditation?")
+        val twice = SakhaPersonaGuard.softenInline(once.text)
+        assertEquals(once.text, twice.text)
+    }
+
+    // ------------------------------------------------------------------------
+    // Severe tells → request a retry
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `as an AI language model triggers retry`() {
+        assertTrue(SakhaPersonaGuard.shouldRetry("As an AI language model, I cannot feel grief."))
+    }
+
+    @Test
+    fun `i'm just an ai triggers retry`() {
+        assertTrue(SakhaPersonaGuard.shouldRetry("I'm just an AI, but..."))
+    }
+
+    @Test
+    fun `clean opening does not trigger retry`() {
+        assertFalse(
+            SakhaPersonaGuard.shouldRetry(
+                "उद्धरेदात्मनात्मानम् — lift yourself by yourself, the Gita says."
+            )
+        )
+    }
+
+    // ------------------------------------------------------------------------
+    // Multi-language safety: Devanagari content must not be touched
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `devanagari verses are not modified`() {
+        val verse = "कर्मण्येवाधिकारस्ते मा फलेषु कदाचन।"
+        val out = SakhaPersonaGuard.softenInline(verse)
+        assertEquals(verse, out.text)
+        assertFalse(out.triggered)
+    }
+
+    @Test
+    fun `mixed english tell with verse rewrites only the english`() {
+        val input = "I understand. कर्मण्येवाधिकारस्ते — your work is yours."
+        val out = SakhaPersonaGuard.softenInline(input)
+        assertTrue(out.triggered)
+        assertTrue(
+            "verse must survive: ${out.text}",
+            out.text.contains("कर्मण्येवाधिकारस्ते"),
+        )
+        assertFalse(out.text.contains("I understand"))
+        assertNotEquals(input, out.text)
+    }
+}

--- a/native/shared/SakhaVoiceInterface.ts
+++ b/native/shared/SakhaVoiceInterface.ts
@@ -1,0 +1,200 @@
+/**
+ * Sakha Voice — Cross-Platform TypeScript Interface
+ *
+ * Mirrors the Kotlin (Android) and Swift (iOS) bridge modules. Every change
+ * here MUST land in all three places at once or the bridge will silently drop
+ * fields. Run `pnpm typecheck` in apps/mobile after touching this file.
+ *
+ * Engine and persona vocabulary follow sakha.voice.openai.md verbatim.
+ */
+
+// ============================================================================
+// Engines, moods, languages
+// ============================================================================
+
+export type SakhaEngine = 'GUIDANCE' | 'FRIEND' | 'ASSISTANT' | 'VOICE_GUIDE';
+
+export type SakhaMood =
+  | 'anxious'
+  | 'sad'
+  | 'angry'
+  | 'lonely'
+  | 'confused'
+  | 'grieving'
+  | 'joyful'
+  | 'seeking'
+  | 'guilty'
+  | 'numb'
+  | 'neutral';
+
+export type SakhaMoodTrend = 'stable' | 'rising' | 'falling' | 'masked';
+
+export type SakhaLanguage =
+  | 'en'
+  | 'hi'
+  | 'hinglish'
+  | 'ta'
+  | 'te'
+  | 'bn'
+  | 'mr'
+  | 'sa';
+
+// ============================================================================
+// State machine — keep in sync with native enum names
+// ============================================================================
+
+export type SakhaVoiceState =
+  | 'UNINITIALIZED'
+  | 'IDLE'
+  | 'LISTENING'
+  | 'TRANSCRIBING'
+  | 'REQUESTING'
+  | 'SPEAKING'
+  | 'PAUSING'
+  | 'INTERRUPTED'
+  | 'ERROR'
+  | 'SHUTDOWN';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export interface SakhaVoiceConfig {
+  /** REST base URL of the MindVibe backend, no trailing slash. */
+  backendBaseUrl: string;
+
+  /** User-facing language for STT + TTS routing. */
+  language?: SakhaLanguage;
+
+  /** Path prefix to the voice-companion routes. */
+  voiceCompanionPathPrefix?: string;
+
+  /** Voice id for the persona body voice. */
+  sakhaVoiceId?: string;
+
+  /** Voice id for Sanskrit verse synthesis. */
+  sanskritVoiceId?: string;
+
+  /** Allow user to interrupt mid-utterance by tapping mic again. */
+  allowBargeIn?: boolean;
+
+  /** Silence (ms) after which the mic auto-closes. */
+  silenceTimeoutMs?: number;
+
+  /** Hard cap on a single Sakha utterance. */
+  maxResponseSpokenMs?: number;
+
+  /** Connect/read timeout for the SSE request. */
+  requestTimeoutMs?: number;
+
+  /** Retries on transient SSE failures. */
+  maxRequestRetries?: number;
+
+  /** Run the persona guard on every chunk. */
+  enablePersonaGuard?: boolean;
+
+  /** Speak a soft template instead of staying silent on FILTER_FAIL. */
+  speakOnFilterFail?: boolean;
+
+  /** Verbose native logcat. */
+  debugMode?: boolean;
+}
+
+// ============================================================================
+// Native event payloads
+// ============================================================================
+
+export interface SakhaVoiceStateEvent {
+  state: SakhaVoiceState;
+  previousState: SakhaVoiceState;
+}
+
+export interface SakhaTranscriptEvent {
+  text: string;
+}
+
+export interface SakhaEngineSelectedEvent {
+  engine: SakhaEngine;
+  mood: SakhaMood;
+  intensity: number;
+}
+
+export interface SakhaTextEvent {
+  delta: string;
+  isFinal: boolean;
+}
+
+export interface SakhaSpokenEvent {
+  text: string;
+  isSanskrit: boolean;
+}
+
+export interface SakhaPauseEvent {
+  durationMs: number;
+}
+
+export interface SakhaVerseCitedEvent {
+  reference: string;
+  sanskrit?: string;
+}
+
+export interface SakhaTurnCompleteEvent {
+  sessionId?: string;
+  engine: SakhaEngine;
+  mood: SakhaMood;
+  moodIntensity: number;
+  language: SakhaLanguage;
+  transcriptChars: number;
+  responseChars: number;
+  sttDurationMs: number;
+  firstByteMs: number;
+  firstAudioMs: number;
+  totalSpokenMs: number;
+  pauseCount: number;
+  verseCited?: string;
+  filterFail: boolean;
+  personaGuardTriggered: boolean;
+  barged: boolean;
+}
+
+export interface SakhaErrorEvent {
+  code: string;
+  message: string;
+  recoverable: boolean;
+}
+
+// ============================================================================
+// Bridge module surface
+// ============================================================================
+
+export interface SakhaVoiceNativeModule {
+  initialize(config: SakhaVoiceConfig): Promise<void>;
+  setAuthToken(token: string | null): void;
+  hasRecordPermission(): Promise<boolean>;
+  activate(): Promise<void>;
+  stopListening(): Promise<void>;
+  cancelTurn(): Promise<void>;
+  resetSession(): Promise<void>;
+  shutdown(): Promise<void>;
+
+  // NativeEventEmitter contract
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+export const SAKHA_VOICE_EVENTS = {
+  STATE: 'SakhaVoiceState',
+  PARTIAL_TRANSCRIPT: 'SakhaVoicePartialTranscript',
+  FINAL_TRANSCRIPT: 'SakhaVoiceFinalTranscript',
+  ENGINE_SELECTED: 'SakhaVoiceEngineSelected',
+  TEXT: 'SakhaVoiceText',
+  SPOKEN: 'SakhaVoiceSpoken',
+  PAUSE: 'SakhaVoicePause',
+  VERSE_CITED: 'SakhaVoiceVerseCited',
+  FILTER_FAIL: 'SakhaVoiceFilterFail',
+  TURN_COMPLETE: 'SakhaVoiceTurnComplete',
+  ERROR: 'SakhaVoiceError',
+} as const;
+
+export type SakhaVoiceEventName =
+  (typeof SAKHA_VOICE_EVENTS)[keyof typeof SAKHA_VOICE_EVENTS];


### PR DESCRIPTION
Implements the on-device orchestrator for Sakha Voice mode (the
Bhagavad-Gita-grounded persona defined in sakha.voice.openai.md), distinct
from the generic KiaanVoiceManager.

Native (Kotlin) under native/android/voice/sakha/:
  - SakhaTypes          state machine, config, listener, errors, mood/lang enums
  - SakhaPauseParser    streaming parser for <pause:short|medium|long> + FILTER_FAIL,
                        with Devanagari detection for Sanskrit voice routing
  - SakhaPersonaGuard   defence-in-depth filter for AI-tell phrases
  - SakhaSseClient      OkHttp SSE client → /api/voice-companion/message with auth
                        refresh on 401, exp-backoff on 5xx, quota awareness
  - SakhaTtsPlayer      pause-aware MediaPlayer queue + Sarvam REST synthesis,
                        system TTS fallback, Sanskrit voice routing
  - SakhaVoiceManager   end-to-end mic → STT → SSE → parser → TTS state machine
                        with barge-in, max-response guard, per-turn metrics
  - SakhaVoiceModule    React Native bridge module (legacy bridge, not Turbo)
  - SakhaVoicePackage   RN package for MainApplication registration
  - test/               JVM unit tests for parser + persona guard

Bridge/UI:
  - native/shared/SakhaVoiceInterface.ts          canonical TS bridge surface
  - apps/mobile/types/sakhaVoice.ts               in-workspace mirror for Metro
  - apps/mobile/hooks/useSakhaVoice.ts            React hook with reducer over
                                                  the native event stream
  - apps/mobile/app/voice.tsx                     Sakha Voice mode screen with
                                                  breathing mandala + verse card