### PR TITLE
chore(mobile): point all EAS profiles at single Render backend

### DIFF
--- a/kiaanverse-mobile/apps/sakha-mobile/eas.json
+++ b/kiaanverse-mobile/apps/sakha-mobile/eas.json
@@ -12,7 +12,7 @@
         "buildType": "apk"
       },
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://mindvibe-api-dev.onrender.com",
+        "EXPO_PUBLIC_API_BASE_URL": "https://mindvibe-api.onrender.com",
         "KIAAN_VOICE_MOCK_PROVIDERS": "1"
       }
     },
@@ -23,7 +23,7 @@
       },
       "channel": "preview",
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://mindvibe-api-preview.onrender.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://mindvibe-api.onrender.com"
       }
     },
     "production": {


### PR DESCRIPTION
User has one Render service at https://mindvibe-api.onrender.com. The previously-templated mindvibe-api-dev.* and mindvibe-api-preview.* hostnames don't exist, which would have left preview/dev APK builds unable to reach the backend.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

<!-- Describe the change and why it matters -->
## Summary

<!-- One-sentence summary of the change -->

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing
Describe how this change was tested locally (commands run).

## Reviewers
Tag any maintainers or teams that should review.
