### PR TITLE
feat(voice): real ElevenLabs + Sarvam providers + Android APK build path

### DIFF
--- a/backend/services/voice/provider_registry.py
+++ b/backend/services/voice/provider_registry.py
@@ -1,0 +1,211 @@
+"""Voice provider registry — extensibility seam for STT/TTS/LLM providers.
+
+The built-in providers (Mock, Sarvam, ElevenLabs, Deepgram, OpenAI) are
+hardwired into their respective routers. This registry lets ops or
+plugins add new providers without touching router code.
+
+Usage — adding a future Google TTS provider:
+
+    # backend/services/voice/providers/google_tts.py
+    from backend.services.voice.tts_router import TTSProvider, TTSChunk
+    from backend.services.voice.provider_registry import register_tts_provider
+
+    class GoogleTTSProvider:
+        name = "google"
+        supported_languages = frozenset({"en", "hi", ...})
+        def is_configured(self): return bool(os.environ.get("GOOGLE_TTS_KEY"))
+        def supports_voice(self, vid): return vid.startswith("google:")
+        async def synthesize_streaming(self, *, text, voice_id, lang_hint): ...
+
+    register_tts_provider("google", GoogleTTSProvider, voice_prefix="google:")
+
+Then import the module once at startup so the registration runs:
+
+    # backend/main.py
+    from backend.services.voice.providers import google_tts  # noqa: F401
+
+The router will pick GoogleTTSProvider when a voice_id starts with
+'google:' and the provider's is_configured() returns True.
+
+Registration is idempotent — re-registering the same name overwrites the
+previous entry (useful for tests).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RegisteredProvider:
+    """Metadata for a registered provider class."""
+
+    name: str
+    factory: Callable[[], Any]
+    voice_prefix: str | None  # for TTS — prefix that this provider claims
+    languages: frozenset[str]
+
+
+class _Registry:
+    """Thread-safe registry per provider kind (stt / tts / llm)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._stt: dict[str, RegisteredProvider] = {}
+        self._tts: dict[str, RegisteredProvider] = {}
+        self._llm: dict[str, RegisteredProvider] = {}
+
+    def _bucket(self, kind: str) -> dict[str, RegisteredProvider]:
+        if kind == "stt":
+            return self._stt
+        if kind == "tts":
+            return self._tts
+        if kind == "llm":
+            return self._llm
+        raise ValueError(f"unknown provider kind {kind!r}")
+
+    def register(
+        self,
+        kind: str,
+        name: str,
+        factory: Callable[[], Any],
+        *,
+        voice_prefix: str | None = None,
+        languages: frozenset[str] | None = None,
+    ) -> None:
+        with self._lock:
+            self._bucket(kind)[name] = RegisteredProvider(
+                name=name,
+                factory=factory,
+                voice_prefix=voice_prefix,
+                languages=languages or frozenset(),
+            )
+        logger.info(
+            "voice.provider.registered kind=%s name=%s prefix=%r langs=%d",
+            kind, name, voice_prefix, len(languages) if languages else 0,
+        )
+
+    def unregister(self, kind: str, name: str) -> None:
+        with self._lock:
+            self._bucket(kind).pop(name, None)
+
+    def get(self, kind: str, name: str) -> RegisteredProvider | None:
+        with self._lock:
+            return self._bucket(kind).get(name)
+
+    def all(self, kind: str) -> list[RegisteredProvider]:
+        with self._lock:
+            return list(self._bucket(kind).values())
+
+    def find_by_voice_prefix(
+        self, kind: str, voice_id: str,
+    ) -> RegisteredProvider | None:
+        """Find a provider whose voice_prefix matches the start of voice_id."""
+        with self._lock:
+            for p in self._bucket(kind).values():
+                if p.voice_prefix and voice_id.startswith(p.voice_prefix):
+                    return p
+        return None
+
+    def find_by_language(
+        self, kind: str, lang_hint: str,
+    ) -> RegisteredProvider | None:
+        """Find the first provider that declares support for lang_hint."""
+        normalized = (lang_hint or "").lower()
+        primary = normalized.split("-")[0]
+        with self._lock:
+            for p in self._bucket(kind).values():
+                if not p.languages:
+                    continue
+                if normalized in p.languages or primary in p.languages:
+                    return p
+        return None
+
+    def reset(self) -> None:
+        """Test-only — clear every registered provider."""
+        with self._lock:
+            self._stt.clear()
+            self._tts.clear()
+            self._llm.clear()
+
+
+_registry = _Registry()
+
+
+# ─── Public API ───────────────────────────────────────────────────────────
+
+
+def register_stt_provider(
+    name: str,
+    factory: Callable[[], Any],
+    *,
+    languages: frozenset[str] | None = None,
+) -> None:
+    """Register an STT provider for use by STTRouter."""
+    _registry.register("stt", name, factory, languages=languages)
+
+
+def register_tts_provider(
+    name: str,
+    factory: Callable[[], Any],
+    *,
+    voice_prefix: str,
+    languages: frozenset[str] | None = None,
+) -> None:
+    """Register a TTS provider for use by TTSRouter.
+
+    voice_prefix is required because TTSRouter dispatches by voice_id
+    (e.g. 'google:standard-en-IN-Wavenet-A').
+    """
+    _registry.register(
+        "tts", name, factory, voice_prefix=voice_prefix, languages=languages,
+    )
+
+
+def register_llm_provider(
+    name: str, factory: Callable[[], Any],
+) -> None:
+    """Register an LLM provider for use by LLMRouter."""
+    _registry.register("llm", name, factory)
+
+
+def get_provider(kind: str, name: str) -> RegisteredProvider | None:
+    return _registry.get(kind, name)
+
+
+def all_providers(kind: str) -> list[RegisteredProvider]:
+    return _registry.all(kind)
+
+
+def find_provider_by_voice_prefix(
+    kind: str, voice_id: str,
+) -> RegisteredProvider | None:
+    return _registry.find_by_voice_prefix(kind, voice_id)
+
+
+def find_provider_by_language(
+    kind: str, lang_hint: str,
+) -> RegisteredProvider | None:
+    return _registry.find_by_language(kind, lang_hint)
+
+
+def _reset_registry_for_tests() -> None:
+    _registry.reset()
+
+
+__all__ = [
+    "RegisteredProvider",
+    "register_stt_provider",
+    "register_tts_provider",
+    "register_llm_provider",
+    "get_provider",
+    "all_providers",
+    "find_provider_by_voice_prefix",
+    "find_provider_by_language",
+    "_reset_registry_for_tests",
+]

--- a/backend/services/voice/stt_router.py
+++ b/backend/services/voice/stt_router.py
@@ -201,22 +201,62 @@ class MockSTTProvider:
 # without an explicit env-var opt-in.
 
 
-class SarvamSTTProvider:
-    """Sarvam Saarika streaming STT for Indic languages.
+_SARVAM_STT_BASE_URL = os.environ.get(
+    "KIAAN_SARVAM_BASE_URL", "https://api.sarvam.ai"
+)
+_SARVAM_STT_MODEL = os.environ.get("KIAAN_SARVAM_STT_MODEL", "saarika:v2")
+_SARVAM_STT_HTTP_TIMEOUT_S = float(
+    os.environ.get("KIAAN_SARVAM_HTTP_TIMEOUT_S", "30.0")
+)
+_SARVAM_STT_LANG_CODE: dict[str, str] = {
+    "hi": "hi-IN",
+    "mr": "mr-IN",
+    "bn": "bn-IN",
+    "ta": "ta-IN",
+    "te": "te-IN",
+    "pa": "pa-IN",
+    "gu": "gu-IN",
+    "kn": "kn-IN",
+    "ml": "ml-IN",
+    "hi-en": "hi-IN",
+}
 
-    Activates when KIAAN_SARVAM_API_KEY is set. Otherwise raises at
-    start_session so the router falls back to Mock.
+
+class SarvamSTTProvider:
+    """Sarvam Saarika STT for Indic languages — batch mode on end_of_speech.
+
+    Lifecycle: start_session() — bookkeeping only. feed_audio_chunk() —
+    accumulates the base64 opus chunks into an internal buffer; yields
+    nothing (no partials in this implementation; see runbook for the
+    deferred streaming-WebSocket variant). end_of_speech() — flushes the
+    buffer to Sarvam's /speech-to-text endpoint and yields exactly one
+    is_final=True STTResult with the transcribed text.
+
+    Tradeoff: crisis-routing latency on Indic transcripts is bounded by
+    sarvam round-trip (typically 600-1500ms) instead of the sub-800ms
+    target the streaming variant would provide. Documented in the runbook.
     """
 
     name = "sarvam-saarika"
-    supported_languages = frozenset({"hi", "mr", "bn", "ta", "te", "pa", "gu", "kn", "ml", "hi-en"})
+    supported_languages = frozenset(_SARVAM_STT_LANG_CODE.keys())
 
     def __init__(self) -> None:
         self._api_key = os.environ.get("KIAAN_SARVAM_API_KEY")
-        self._client: object | None = None
+        self._session_id = ""
+        self._lang_hint = "hi"
+        self._buffer = bytearray()
+        self._seq = 0
 
     def is_configured(self) -> bool:
         return bool(self._api_key)
+
+    @staticmethod
+    def _lang_code(lang_hint: str) -> str:
+        normalized = (lang_hint or "hi").lower()
+        return _SARVAM_STT_LANG_CODE.get(
+            normalized,
+            _SARVAM_STT_LANG_CODE.get(normalized.split("-")[0], "hi-IN"),
+        )
 
     async def start_session(self, *, session_id: str, lang_hint: str) -> None:
         if not self._api_key:
@@ -225,41 +265,75 @@ class SarvamSTTProvider:
                 "Either configure the env var or set "
                 "KIAAN_VOICE_MOCK_PROVIDERS=1 to use the mock provider."
             )
-        # Real impl: open Sarvam Saarika websocket connection here.
-        # Lazy-import the SDK so this module loads without sarvam-ai installed.
-        try:
-            import sarvamai  # noqa: F401  # type: ignore[import-not-found]
-        except ImportError as e:
-            raise RuntimeError(
-                "SarvamSTTProvider: sarvamai SDK not installed. "
-                "pip install sarvamai or use mock providers."
-            ) from e
-        # NOTE: real implementation goes here — websocket open, language
-        # config, etc. Not implemented in this commit because the env
-        # cannot reach Sarvam in CI; the orchestrator has full mock
-        # coverage so the WSS endpoint is exercisable without it.
-        raise NotImplementedError(
-            f"SarvamSTTProvider streaming impl not wired (session_id={session_id!r}, "
-            f"lang_hint={lang_hint!r}). Set KIAAN_VOICE_MOCK_PROVIDERS=1 for mock."
-        )
+        self._session_id = session_id
+        self._lang_hint = lang_hint
+        self._buffer = bytearray()
+        self._seq = 0
 
     async def feed_audio_chunk(
         self, *, seq: int, opus_b64: str
     ) -> AsyncIterator[STTResult]:
-        if False:  # pragma: no cover — placeholder to satisfy AsyncIterator
+        # Accumulate; emit no partials in batch mode.
+        import base64 as _b64
+        try:
+            self._buffer.extend(_b64.b64decode(opus_b64))
+        except Exception as e:
+            raise RuntimeError(
+                f"SarvamSTTProvider: cannot base64-decode chunk seq={seq}: {e}"
+            ) from e
+        self._seq = seq
+        if False:  # pragma: no cover — async iterator must yield from a generator
             yield STTResult(text="", is_final=False, seq=seq)
-        raise NotImplementedError(
-            f"SarvamSTTProvider.feed_audio_chunk not wired "
-            f"(seq={seq}, chunk_len={len(opus_b64)})"
-        )
 
     async def end_of_speech(self) -> AsyncIterator[STTResult]:
-        if False:  # pragma: no cover
-            yield STTResult(text="", is_final=True, seq=0)
-        raise NotImplementedError
+        if not self._api_key:
+            raise RuntimeError("SarvamSTTProvider: KIAAN_SARVAM_API_KEY not set")
+
+        try:
+            import httpx  # type: ignore[import-not-found]
+        except ImportError as e:  # pragma: no cover
+            raise RuntimeError("httpx not installed") from e
+
+        if not self._buffer:
+            yield STTResult(text="", is_final=True, seq=self._seq)
+            return
+
+        url = f"{_SARVAM_STT_BASE_URL.rstrip('/')}/speech-to-text"
+        headers = {"api-subscription-key": self._api_key}
+        # Sarvam expects multipart/form-data with the audio file.
+        files = {
+            "file": ("audio.opus", bytes(self._buffer), "audio/opus"),
+        }
+        data = {
+            "language_code": self._lang_code(self._lang_hint),
+            "model": _SARVAM_STT_MODEL,
+        }
+
+        timeout = httpx.Timeout(
+            connect=10.0,
+            read=_SARVAM_STT_HTTP_TIMEOUT_S,
+            write=10.0,
+            pool=10.0,
+        )
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                url, headers=headers, files=files, data=data,
+            )
+            if resp.status_code != 200:
+                body = resp.text[:500]
+                raise RuntimeError(
+                    f"SarvamSTTProvider: HTTP {resp.status_code} "
+                    f"session={self._session_id!r} body={body!r}"
+                )
+            payload = resp.json()
+
+        transcript = (payload.get("transcript") or "").strip()
+        yield STTResult(
+            text=transcript, is_final=True, seq=self._seq,
+        )
 
     async def close(self) -> None:
-        return None
+        self._buffer = bytearray()
 
 
 class DeepgramSTTProvider:

--- a/backend/services/voice/tts_router.py
+++ b/backend/services/voice/tts_router.py
@@ -175,16 +175,47 @@ class MockTTSProvider:
 # ─── Real provider stubs ──────────────────────────────────────────────────
 
 
+_SARVAM_BASE_URL = os.environ.get(
+    "KIAAN_SARVAM_BASE_URL", "https://api.sarvam.ai"
+)
+_SARVAM_TTS_MODEL = os.environ.get("KIAAN_SARVAM_TTS_MODEL", "bulbul:v2")
+_SARVAM_TTS_HTTP_TIMEOUT_S = float(
+    os.environ.get("KIAAN_SARVAM_HTTP_TIMEOUT_S", "30.0")
+)
+_SARVAM_TTS_CHUNK_BYTES = int(
+    os.environ.get("KIAAN_SARVAM_CHUNK_BYTES", "32768")
+)
+
+# Sarvam expects ISO-639-1 plus a region code. Map our short lang_hints.
+_SARVAM_LANG_CODE: dict[str, str] = {
+    "hi": "hi-IN",
+    "mr": "mr-IN",
+    "bn": "bn-IN",
+    "ta": "ta-IN",
+    "te": "te-IN",
+    "pa": "pa-IN",
+    "gu": "gu-IN",
+    "kn": "kn-IN",
+    "ml": "ml-IN",
+    "sa": "sa-IN",
+    "hi-en": "hi-IN",  # code-mixed English-in-Hindi → Hindi voice
+}
+
+
 class SarvamTTSProvider:
     """Sarvam TTS — Indic + Sanskrit voices.
 
-    Activates when KIAAN_SARVAM_API_KEY is set. Otherwise raises so the
-    router falls back to Mock."""
+    Sarvam's TTS endpoint is a non-streaming REST call: it returns the
+    whole synthesized audio as base64 in a JSON body. We re-chunk that
+    audio into TTSChunks of ~32KB each so downstream consumers (WSS
+    audio.chunk frames) see the same shape they'd see from a true
+    streaming provider.
+
+    voice_id format: 'sarvam:<speaker_name>' (e.g. 'sarvam:meera').
+    """
 
     name = "sarvam"
-    supported_languages = frozenset(
-        {"hi", "mr", "bn", "ta", "te", "pa", "gu", "kn", "ml", "hi-en", "sa"}
-    )
+    supported_languages = frozenset(_SARVAM_LANG_CODE.keys())
 
     def __init__(self) -> None:
         self._api_key = os.environ.get("KIAAN_SARVAM_API_KEY")
@@ -194,6 +225,27 @@ class SarvamTTSProvider:
 
     def supports_voice(self, voice_id: str) -> bool:
         return voice_id.startswith("sarvam:")
+
+    @staticmethod
+    def _parse_voice_id(voice_id: str) -> str:
+        if ":" not in voice_id:
+            raise ValueError(
+                f"SarvamTTSProvider: voice_id missing 'sarvam:' prefix: {voice_id!r}"
+            )
+        prefix, _, raw = voice_id.partition(":")
+        if prefix != "sarvam" or not raw:
+            raise ValueError(
+                f"SarvamTTSProvider: malformed voice_id {voice_id!r} "
+                f"(expected 'sarvam:<speaker>')"
+            )
+        return raw
+
+    @staticmethod
+    def _lang_code(lang_hint: str) -> str:
+        normalized = (lang_hint or "hi").lower()
+        return _SARVAM_LANG_CODE.get(normalized, _SARVAM_LANG_CODE.get(
+            normalized.split("-")[0], "hi-IN"
+        ))
 
     async def synthesize_streaming(
         self,
@@ -207,22 +259,107 @@ class SarvamTTSProvider:
                 f"SarvamTTSProvider: KIAAN_SARVAM_API_KEY not set "
                 f"(text_len={len(text)}, voice_id={voice_id!r}, lang={lang_hint!r})."
             )
+        if not text:
+            return
+
         try:
-            import sarvamai  # noqa: F401  # type: ignore[import-not-found]
-        except ImportError as e:
-            raise RuntimeError("sarvamai SDK not installed") from e
-        # NOTE: real streaming impl deferred — see stt_router.SarvamSTTProvider
-        # for the same rationale.
-        if False:  # pragma: no cover — placeholder to satisfy AsyncIterator
-            yield TTSChunk(seq=0, data=b"")
-        raise NotImplementedError(
-            f"SarvamTTSProvider streaming impl not wired "
-            f"(text_len={len(text)}, voice_id={voice_id!r}, lang={lang_hint!r})."
+            import httpx  # type: ignore[import-not-found]
+        except ImportError as e:  # pragma: no cover
+            raise RuntimeError("httpx not installed") from e
+
+        speaker = self._parse_voice_id(voice_id)
+        url = f"{_SARVAM_BASE_URL.rstrip('/')}/text-to-speech"
+        headers = {
+            "api-subscription-key": self._api_key,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "inputs": [text],
+            "target_language_code": self._lang_code(lang_hint),
+            "speaker": speaker,
+            "model": _SARVAM_TTS_MODEL,
+            "audio_response_format": "wav",
+            "speech_sample_rate": 22050,
+            "enable_preprocessing": True,
+            "pitch": 0,
+            "pace": 1.0,
+            "loudness": 1.0,
+        }
+
+        started = time.monotonic()
+        timeout = httpx.Timeout(
+            connect=10.0,
+            read=_SARVAM_TTS_HTTP_TIMEOUT_S,
+            write=10.0,
+            pool=10.0,
         )
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, headers=headers, json=payload)
+            if resp.status_code != 200:
+                body = resp.text[:500]
+                raise RuntimeError(
+                    f"SarvamTTSProvider: HTTP {resp.status_code} "
+                    f"speaker={speaker!r} body={body!r}"
+                )
+            data = resp.json()
+
+        audios = data.get("audios") or []
+        if not audios:
+            raise RuntimeError(
+                f"SarvamTTSProvider: empty 'audios' in response keys={list(data.keys())}"
+            )
+
+        # Decode + concatenate every clip in audios (typically just one).
+        wav_bytes = bytearray()
+        import base64 as _b64
+        for clip_b64 in audios:
+            wav_bytes.extend(_b64.b64decode(clip_b64))
+
+        # Chunk the WAV into TTSChunks. Mark the final chunk is_final=True.
+        seq = 0
+        view = bytes(wav_bytes)
+        total = len(view)
+        offset = 0
+        while offset < total:
+            end = min(offset + _SARVAM_TTS_CHUNK_BYTES, total)
+            piece = view[offset:end]
+            elapsed = int((time.monotonic() - started) * 1000)
+            yield TTSChunk(
+                seq=seq, data=piece,
+                mime="audio/wav", is_final=(end == total),
+                elapsed_ms=elapsed,
+            )
+            seq += 1
+            offset = end
+
+
+_ELEVENLABS_BASE_URL = os.environ.get(
+    "KIAAN_ELEVENLABS_BASE_URL", "https://api.elevenlabs.io"
+)
+_ELEVENLABS_DEFAULT_MODEL = os.environ.get(
+    "KIAAN_ELEVENLABS_MODEL", "eleven_turbo_v2_5"
+)
+_ELEVENLABS_OUTPUT_FORMAT = os.environ.get(
+    "KIAAN_ELEVENLABS_OUTPUT_FORMAT", "opus_24000_64"
+)
+_ELEVENLABS_HTTP_TIMEOUT_S = float(
+    os.environ.get("KIAAN_ELEVENLABS_HTTP_TIMEOUT_S", "30.0")
+)
+_ELEVENLABS_CHUNK_BYTES = int(
+    os.environ.get("KIAAN_ELEVENLABS_CHUNK_BYTES", "16384")
+)
 
 
 class ElevenLabsTTSProvider:
-    """ElevenLabs TTS — English voice for Sakha."""
+    """ElevenLabs streaming TTS for English Sakha voices.
+
+    Calls /v1/text-to-speech/{voice_id}/stream with audio/opus output and
+    yields TTSChunks as bytes arrive over the HTTP stream. The voice_id
+    is parsed as 'elevenlabs:<elevenlabs_voice_id>' — anything before the
+    colon is the routing prefix; anything after is sent verbatim to
+    ElevenLabs.
+    """
 
     name = "elevenlabs"
     supported_languages = frozenset({"en", "en-US", "en-GB", "en-IN", "en-AU"})
@@ -236,6 +373,21 @@ class ElevenLabsTTSProvider:
     def supports_voice(self, voice_id: str) -> bool:
         return voice_id.startswith("elevenlabs:")
 
+    @staticmethod
+    def _parse_voice_id(voice_id: str) -> str:
+        """Strip the 'elevenlabs:' prefix, return the raw provider voice_id."""
+        if ":" not in voice_id:
+            raise ValueError(
+                f"ElevenLabsTTSProvider: voice_id missing 'elevenlabs:' prefix: {voice_id!r}"
+            )
+        prefix, _, raw = voice_id.partition(":")
+        if prefix != "elevenlabs" or not raw:
+            raise ValueError(
+                f"ElevenLabsTTSProvider: malformed voice_id {voice_id!r} "
+                f"(expected 'elevenlabs:<id>')"
+            )
+        return raw
+
     async def synthesize_streaming(
         self,
         *,
@@ -248,16 +400,77 @@ class ElevenLabsTTSProvider:
                 f"ElevenLabsTTSProvider: KIAAN_ELEVENLABS_API_KEY not set "
                 f"(text_len={len(text)}, voice_id={voice_id!r}, lang={lang_hint!r})."
             )
+        if not text:
+            return
+
         try:
-            import elevenlabs  # noqa: F401  # type: ignore[import-not-found]
-        except ImportError as e:
-            raise RuntimeError("elevenlabs SDK not installed") from e
-        if False:  # pragma: no cover
-            yield TTSChunk(seq=0, data=b"")
-        raise NotImplementedError(
-            f"ElevenLabsTTSProvider streaming impl not wired "
-            f"(text_len={len(text)}, voice_id={voice_id!r}, lang={lang_hint!r})."
+            import httpx  # type: ignore[import-not-found]
+        except ImportError as e:  # pragma: no cover — httpx is in requirements.txt
+            raise RuntimeError("httpx not installed") from e
+
+        eleven_voice_id = self._parse_voice_id(voice_id)
+        url = (
+            f"{_ELEVENLABS_BASE_URL.rstrip('/')}/v1/text-to-speech/"
+            f"{eleven_voice_id}/stream"
+            f"?output_format={_ELEVENLABS_OUTPUT_FORMAT}"
         )
+        headers = {
+            "xi-api-key": self._api_key,
+            "Accept": "audio/ogg",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "text": text,
+            "model_id": _ELEVENLABS_DEFAULT_MODEL,
+            "voice_settings": {
+                "stability": 0.55,
+                "similarity_boost": 0.75,
+                "style": 0.20,
+                "use_speaker_boost": True,
+            },
+        }
+
+        started = time.monotonic()
+        seq = 0
+        timeout = httpx.Timeout(
+            connect=10.0,
+            read=_ELEVENLABS_HTTP_TIMEOUT_S,
+            write=10.0,
+            pool=10.0,
+        )
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream(
+                "POST", url, headers=headers, json=payload,
+            ) as resp:
+                if resp.status_code != 200:
+                    body = (await resp.aread()).decode(errors="replace")[:500]
+                    raise RuntimeError(
+                        f"ElevenLabsTTSProvider: HTTP {resp.status_code} "
+                        f"voice_id={eleven_voice_id!r} body={body!r}"
+                    )
+                buffer = bytearray()
+                async for raw in resp.aiter_bytes(_ELEVENLABS_CHUNK_BYTES):
+                    if not raw:
+                        continue
+                    buffer.extend(raw)
+                    while len(buffer) >= _ELEVENLABS_CHUNK_BYTES:
+                        chunk_data = bytes(buffer[:_ELEVENLABS_CHUNK_BYTES])
+                        del buffer[:_ELEVENLABS_CHUNK_BYTES]
+                        elapsed = int((time.monotonic() - started) * 1000)
+                        yield TTSChunk(
+                            seq=seq, data=chunk_data,
+                            mime="audio/opus", is_final=False,
+                            elapsed_ms=elapsed,
+                        )
+                        seq += 1
+                # Flush any remainder as the final chunk
+                elapsed = int((time.monotonic() - started) * 1000)
+                yield TTSChunk(
+                    seq=seq, data=bytes(buffer),
+                    mime="audio/opus", is_final=True,
+                    elapsed_ms=elapsed,
+                )
 
 
 # ─── Audio cache ──────────────────────────────────────────────────────────
@@ -418,6 +631,7 @@ class TTSRouter:
                 fell_back_to_mock=False,
             )
 
+        # Built-in routing: Indic→Sarvam, English→ElevenLabs.
         if normalized in _INDIC_LANGS_TTS:
             sarvam = SarvamTTSProvider()
             if sarvam.is_configured():
@@ -427,25 +641,46 @@ class TTSRouter:
                     reason=f"indic lang {lang_hint!r} → Sarvam",
                     fell_back_to_mock=False,
                 )
-            return TTSRouterDecision(
-                provider_name="mock",
-                voice_id=voice_id,
-                reason="Sarvam not configured → mock fallback",
-                fell_back_to_mock=True,
-            )
+        else:
+            eleven = ElevenLabsTTSProvider()
+            if eleven.is_configured():
+                return TTSRouterDecision(
+                    provider_name=eleven.name,
+                    voice_id=voice_id,
+                    reason=f"english lang {lang_hint!r} → ElevenLabs",
+                    fell_back_to_mock=False,
+                )
 
-        eleven = ElevenLabsTTSProvider()
-        if eleven.is_configured():
-            return TTSRouterDecision(
-                provider_name=eleven.name,
-                voice_id=voice_id,
-                reason=f"english lang {lang_hint!r} → ElevenLabs",
-                fell_back_to_mock=False,
-            )
+        # Registry fallthrough — let plugin providers claim the lang.
+        from backend.services.voice.provider_registry import (
+            find_provider_by_voice_prefix,
+            find_provider_by_language,
+        )
+        registered = find_provider_by_voice_prefix("tts", voice_id) \
+            or find_provider_by_language("tts", lang_hint)
+        if registered is not None:
+            try:
+                inst = registered.factory()
+                if getattr(inst, "is_configured", lambda: True)():
+                    return TTSRouterDecision(
+                        provider_name=registered.name,
+                        voice_id=voice_id,
+                        reason=f"registered provider {registered.name!r}",
+                        fell_back_to_mock=False,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "voice.tts.registered.factory_failed name=%s err=%s",
+                    registered.name, e,
+                )
+
         return TTSRouterDecision(
             provider_name="mock",
             voice_id=voice_id,
-            reason="ElevenLabs not configured → mock fallback",
+            reason=(
+                f"no configured provider for lang {lang_hint!r} "
+                f"→ mock fallback"
+            ),
             fell_back_to_mock=True,
         )
 
@@ -457,6 +692,19 @@ class TTSRouter:
             return SarvamTTSProvider(), decision
         if decision.provider_name == "elevenlabs":
             return ElevenLabsTTSProvider(), decision
+
+        # Registry-backed provider
+        from backend.services.voice.provider_registry import get_provider
+        registered = get_provider("tts", decision.provider_name)
+        if registered is not None:
+            try:
+                return registered.factory(), decision
+            except Exception as e:  # pragma: no cover — defensive
+                logger.error(
+                    "voice.tts.registered.build_failed name=%s err=%s",
+                    decision.provider_name, e,
+                )
+
         logger.error(
             "TTSRouter: unknown provider %r — falling back to mock",
             decision.provider_name,

--- a/docs/voice-companion-runbook.md
+++ b/docs/voice-companion-runbook.md
@@ -72,21 +72,87 @@ pnpm --filter @kiaanverse/sakha-mobile run submit:android
 
 ## 3. Required environment variables
 
-### Backend (production)
+### Backend (production) — core
 
 | Variable | What | Required? |
 |---|---|---|
 | `OPENAI_API_KEY` | gpt-4o-mini streaming | yes for live LLM |
 | `KIAAN_LLM_PROFILE` | "production" / "preview" | optional |
-| `KIAAN_SARVAM_API_KEY` | Sarvam Saarika STT + TTS | yes for live |
-| `KIAAN_DEEPGRAM_API_KEY` | Deepgram Nova-3 STT (English) | yes for live |
-| `KIAAN_ELEVENLABS_API_KEY` | ElevenLabs TTS (English) | yes for live |
-| `KIAAN_VOICE_MOCK_PROVIDERS` | `1` to force mock STT/TTS/LLM | dev/CI only |
+| `KIAAN_SARVAM_API_KEY` | Sarvam Saarika STT + Bulbul TTS | yes for live Indic |
+| `KIAAN_DEEPGRAM_API_KEY` | Deepgram Nova-3 STT (English) | yes for live English STT |
+| `KIAAN_ELEVENLABS_API_KEY` | ElevenLabs TTS (English) | yes for live English TTS |
+| `KIAAN_VOICE_MOCK_PROVIDERS` | `1` to force mock STT/TTS/LLM (overrides every other key) | dev/CI only |
 | `KIAAN_VOICE_ID_EN` / `_HI` / `_MR` / … | per-language voice ID override | optional |
 | `KIAAN_HELPLINE_OVERRIDES_JSON` | per-region helpline number override | optional |
 | `KIAAN_SAFETY_AUDIO_REQUIRED` | `1` to fail builds on placeholder slots | CI gate |
 | `KIAAN_PROMPT_LOADER_TEST` | `1` to allow `reset_cache_for_tests()` | tests only |
 | `KIAAN_VOICE_QUOTA_TEST` | `1` to allow quota counter reset | tests only |
+
+### Backend — provider tuning (all optional)
+
+| Variable | Default | Notes |
+|---|---|---|
+| `KIAAN_ELEVENLABS_BASE_URL` | `https://api.elevenlabs.io` | swap for proxy / EU region |
+| `KIAAN_ELEVENLABS_MODEL` | `eleven_turbo_v2_5` | latency-optimized turbo model |
+| `KIAAN_ELEVENLABS_OUTPUT_FORMAT` | `opus_24000_64` | 24kHz opus, 64kbps |
+| `KIAAN_ELEVENLABS_HTTP_TIMEOUT_S` | `30.0` | per-request read timeout |
+| `KIAAN_ELEVENLABS_CHUNK_BYTES` | `16384` | audio chunk size for WSS |
+| `KIAAN_SARVAM_BASE_URL` | `https://api.sarvam.ai` | shared by Sarvam STT + TTS |
+| `KIAAN_SARVAM_TTS_MODEL` | `bulbul:v2` | Sarvam TTS model |
+| `KIAAN_SARVAM_STT_MODEL` | `saarika:v2` | Sarvam STT model |
+| `KIAAN_SARVAM_HTTP_TIMEOUT_S` | `30.0` | per-request read timeout |
+| `KIAAN_SARVAM_CHUNK_BYTES` | `32768` | local chunk size (Sarvam returns whole WAV) |
+
+### Adding a new provider (extensibility)
+
+The `backend/services/voice/provider_registry.py` module exposes
+`register_stt_provider`, `register_tts_provider`, `register_llm_provider`.
+
+```python
+# backend/services/voice/providers/google_tts.py
+import os
+from collections.abc import AsyncIterator
+from backend.services.voice.tts_router import TTSChunk
+from backend.services.voice.provider_registry import register_tts_provider
+
+
+class GoogleTTSProvider:
+    name = "google"
+    supported_languages = frozenset({"en", "hi", "mr"})
+
+    def __init__(self) -> None:
+        self._key = os.environ.get("GOOGLE_TTS_KEY")
+
+    def is_configured(self) -> bool:
+        return bool(self._key)
+
+    def supports_voice(self, voice_id: str) -> bool:
+        return voice_id.startswith("google:")
+
+    async def synthesize_streaming(
+        self, *, text: str, voice_id: str, lang_hint: str,
+    ) -> AsyncIterator[TTSChunk]:
+        ...
+
+
+register_tts_provider(
+    "google",
+    GoogleTTSProvider,
+    voice_prefix="google:",
+    languages=frozenset({"en", "hi", "mr"}),
+)
+```
+
+Then import the module once at app startup so the registration runs:
+
+```python
+# backend/main.py
+from backend.services.voice.providers import google_tts  # noqa: F401
+```
+
+Now any voice_id that starts with `google:` (e.g.
+`KIAAN_VOICE_ID_EN=google:en-US-Wavenet-D`) will route to the new
+provider. The Sarvam/ElevenLabs built-ins keep working unchanged.
 
 ### Mobile (EAS secrets)
 

--- a/kiaanverse-mobile/apps/sakha-mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/sakha-mobile/app.config.ts
@@ -202,13 +202,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     schemaVersion: SCHEMA_VERSION,
     subprotocol: SUBPROTOCOL,
     sentryDsn: process.env.SENTRY_DSN ?? '',
-    // EAS projectId — set only when EAS_PROJECT_ID is provided (e.g. via
-    // `eas init` writing it back, or via env). Omitting the field
-    // entirely is required when not set; passing a non-UUID placeholder
-    // makes the EAS GraphQL API reject the build with "Invalid UUID appId".
-    ...(process.env.EAS_PROJECT_ID
-      ? { eas: { projectId: process.env.EAS_PROJECT_ID } }
-      : {}),
+    eas: {
+      // Linked to expo.dev/accounts/kiaanverse/projects/sakha-voice-companion.
+      // EAS_PROJECT_ID env var wins so per-environment overrides still work.
+      projectId: process.env.EAS_PROJECT_ID ?? '2ca58471-88ee-43fe-98ab-cbe9ac502ac5',
+    },
     // Picovoice access keys are runtime-only. Set via EAS Secrets:
     //   eas secret:create --scope project --name PICOVOICE_ACCESS_KEY ...
     picovoice: {

--- a/kiaanverse-mobile/apps/sakha-mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/sakha-mobile/app.config.ts
@@ -202,11 +202,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     schemaVersion: SCHEMA_VERSION,
     subprotocol: SUBPROTOCOL,
     sentryDsn: process.env.SENTRY_DSN ?? '',
-    eas: {
-      // Real projectId is injected by `eas init` on first build. Keeping
-      // a placeholder for static-config validation; eas overrides it.
-      projectId: process.env.EAS_PROJECT_ID ?? 'sakha-placeholder',
-    },
+    // EAS projectId — set only when EAS_PROJECT_ID is provided (e.g. via
+    // `eas init` writing it back, or via env). Omitting the field
+    // entirely is required when not set; passing a non-UUID placeholder
+    // makes the EAS GraphQL API reject the build with "Invalid UUID appId".
+    ...(process.env.EAS_PROJECT_ID
+      ? { eas: { projectId: process.env.EAS_PROJECT_ID } }
+      : {}),
     // Picovoice access keys are runtime-only. Set via EAS Secrets:
     //   eas secret:create --scope project --name PICOVOICE_ACCESS_KEY ...
     picovoice: {

--- a/kiaanverse-mobile/apps/sakha-mobile/package.json
+++ b/kiaanverse-mobile/apps/sakha-mobile/package.json
@@ -32,8 +32,6 @@
     "clean": "rm -rf .expo dist node_modules/.cache android ios"
   },
   "dependencies": {
-    "@picovoice/cobra-react-native": "^2.0.2",
-    "@picovoice/porcupine-react-native": "^3.0.4",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@sentry/react-native": "~5.33.0",
     "@shopify/react-native-skia": "^1.3.0",

--- a/tests/unit/test_voice_real_providers.py
+++ b/tests/unit/test_voice_real_providers.py
@@ -1,0 +1,325 @@
+"""Tests for the real (non-mock) voice providers.
+
+Uses httpx.MockTransport to simulate the upstream API — no real network
+calls. Verifies:
+  • ElevenLabsTTSProvider streams chunks correctly + parses voice_id
+  • SarvamTTSProvider chunks the WAV body returned in JSON
+  • SarvamSTTProvider buffers chunks then flushes on end_of_speech
+  • All three providers raise on missing API key
+  • All three reject malformed voice_id / responses
+  • Provider registry round-trips registration + lookup
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import unittest
+
+import httpx
+
+from backend.services.voice.provider_registry import (
+    _reset_registry_for_tests,
+    all_providers,
+    find_provider_by_language,
+    find_provider_by_voice_prefix,
+    register_stt_provider,
+    register_tts_provider,
+)
+from backend.services.voice.stt_router import SarvamSTTProvider
+from backend.services.voice.tts_router import (
+    ElevenLabsTTSProvider,
+    SarvamTTSProvider,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+async def _drain(agen):
+    out = []
+    async for x in agen:
+        out.append(x)
+    return out
+
+
+class _PatchedAsyncClient:
+    """Patches httpx.AsyncClient to use a fixed MockTransport.
+
+    Usage:
+        with _PatchedAsyncClient(handler):
+            # any provider call that does `httpx.AsyncClient(...)` will
+            # now route through `handler` instead of hitting the network.
+    """
+
+    def __init__(self, handler):
+        self._handler = handler
+        self._original_cls = httpx.AsyncClient
+
+    def __enter__(self):
+        original_cls = self._original_cls
+        handler = self._handler
+
+        def _factory(*args, **kwargs):
+            # Drop the user-supplied timeout/transport and inject our mock.
+            kwargs.pop("timeout", None)
+            kwargs.pop("transport", None)
+            return original_cls(transport=httpx.MockTransport(handler), **kwargs)
+
+        httpx.AsyncClient = _factory  # type: ignore[misc]
+        return self
+
+    def __exit__(self, *exc):
+        httpx.AsyncClient = self._original_cls  # type: ignore[misc]
+
+
+# ────────────────────────── ElevenLabs TTS ──────────────────────────
+
+
+class TestElevenLabsTTSProvider(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["KIAAN_ELEVENLABS_API_KEY"] = "test-key-eleven"
+
+    def tearDown(self) -> None:
+        os.environ.pop("KIAAN_ELEVENLABS_API_KEY", None)
+
+    def test_streams_chunks_in_order(self):
+        # Simulate ~70KB of audio across one body; provider chunks it locally.
+        body = b"\x00" * 50_000
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert "/v1/text-to-speech/" in request.url.path
+            assert request.headers["xi-api-key"] == "test-key-eleven"
+            assert b"\"text\":" in request.content
+            return httpx.Response(200, content=body)
+
+        prov = ElevenLabsTTSProvider()
+        with _PatchedAsyncClient(handler):
+            chunks = _run(_drain(prov.synthesize_streaming(
+                text="hello world",
+                voice_id="elevenlabs:sakha-en-v1",
+                lang_hint="en",
+            )))
+
+        self.assertGreater(len(chunks), 1, "expected multiple chunks")
+        seqs = [c.seq for c in chunks]
+        self.assertEqual(seqs, list(range(len(chunks))), "seq must be ordered 0..N")
+        self.assertTrue(chunks[-1].is_final)
+        self.assertFalse(any(c.is_final for c in chunks[:-1]))
+        # Total bytes must round-trip
+        self.assertEqual(b"".join(c.data for c in chunks), body)
+
+    def test_raises_without_api_key(self):
+        os.environ.pop("KIAAN_ELEVENLABS_API_KEY", None)
+        prov = ElevenLabsTTSProvider()
+        with self.assertRaises(RuntimeError) as ctx:
+            _run(_drain(prov.synthesize_streaming(
+                text="x", voice_id="elevenlabs:v", lang_hint="en",
+            )))
+        self.assertIn("KIAAN_ELEVENLABS_API_KEY", str(ctx.exception))
+
+    def test_rejects_malformed_voice_id(self):
+        prov = ElevenLabsTTSProvider()
+        with self.assertRaises(ValueError):
+            _run(_drain(prov.synthesize_streaming(
+                text="x", voice_id="no-prefix", lang_hint="en",
+            )))
+
+    def test_raises_on_non_200(self):
+        def handler(request):
+            return httpx.Response(401, content=b"unauthorized")
+
+        prov = ElevenLabsTTSProvider()
+        with _PatchedAsyncClient(handler):
+            with self.assertRaises(RuntimeError) as ctx:
+                _run(_drain(prov.synthesize_streaming(
+                    text="x", voice_id="elevenlabs:v", lang_hint="en",
+                )))
+        self.assertIn("HTTP 401", str(ctx.exception))
+
+    def test_empty_text_returns_no_chunks(self):
+        prov = ElevenLabsTTSProvider()
+        chunks = _run(_drain(prov.synthesize_streaming(
+            text="", voice_id="elevenlabs:v", lang_hint="en",
+        )))
+        self.assertEqual(chunks, [])
+
+
+# ────────────────────────── Sarvam TTS ──────────────────────────
+
+
+class TestSarvamTTSProvider(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["KIAAN_SARVAM_API_KEY"] = "test-key-sarvam"
+
+    def tearDown(self) -> None:
+        os.environ.pop("KIAAN_SARVAM_API_KEY", None)
+
+    def test_synthesize_returns_chunks_for_hi(self):
+        wav = b"\x52\x49\x46\x46" + b"\x00" * 100_000  # fake WAV header + body
+        body = json.dumps({
+            "request_id": "req-1",
+            "audios": [base64.b64encode(wav).decode()],
+        }).encode()
+
+        def handler(request):
+            assert request.url.path == "/text-to-speech"
+            assert request.headers["api-subscription-key"] == "test-key-sarvam"
+            payload = json.loads(request.content)
+            assert payload["target_language_code"] == "hi-IN"
+            assert payload["speaker"] == "meera"
+            return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+        prov = SarvamTTSProvider()
+        with _PatchedAsyncClient(handler):
+            chunks = _run(_drain(prov.synthesize_streaming(
+                text="नमस्ते", voice_id="sarvam:meera", lang_hint="hi",
+            )))
+
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual([c.seq for c in chunks], list(range(len(chunks))))
+        self.assertTrue(chunks[-1].is_final)
+        self.assertEqual(b"".join(c.data for c in chunks), wav)
+
+    def test_lang_code_mapping(self):
+        self.assertEqual(SarvamTTSProvider._lang_code("ta"), "ta-IN")
+        self.assertEqual(SarvamTTSProvider._lang_code("ta-IN"), "ta-IN")
+        self.assertEqual(SarvamTTSProvider._lang_code("hi-en"), "hi-IN")
+        self.assertEqual(SarvamTTSProvider._lang_code("xx"), "hi-IN")
+
+    def test_raises_on_empty_audios(self):
+        body = json.dumps({"audios": []}).encode()
+
+        def handler(request):
+            return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+        prov = SarvamTTSProvider()
+        with _PatchedAsyncClient(handler):
+            with self.assertRaises(RuntimeError):
+                _run(_drain(prov.synthesize_streaming(
+                    text="x", voice_id="sarvam:meera", lang_hint="hi",
+                )))
+
+
+# ────────────────────────── Sarvam STT ──────────────────────────
+
+
+class TestSarvamSTTProvider(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["KIAAN_SARVAM_API_KEY"] = "test-key-sarvam"
+
+    def tearDown(self) -> None:
+        os.environ.pop("KIAAN_SARVAM_API_KEY", None)
+
+    def test_buffers_then_flushes_on_eos(self):
+        body = json.dumps({
+            "request_id": "req-1",
+            "transcript": "मुझे चिंता है",
+        }).encode()
+
+        captured: dict = {}
+
+        def handler(request):
+            captured["path"] = request.url.path
+            captured["headers"] = dict(request.headers)
+            captured["len"] = len(request.content)
+            return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+        prov = SarvamSTTProvider()
+        _run(prov.start_session(session_id="s-1", lang_hint="hi"))
+        # Feed two chunks (base64 of 1KB each)
+        chunk_b64 = base64.b64encode(b"\x00" * 1024).decode()
+        _run(_drain(prov.feed_audio_chunk(seq=0, opus_b64=chunk_b64)))
+        _run(_drain(prov.feed_audio_chunk(seq=1, opus_b64=chunk_b64)))
+
+        with _PatchedAsyncClient(handler):
+            results = _run(_drain(prov.end_of_speech()))
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "मुझे चिंता है")
+        self.assertTrue(results[0].is_final)
+        self.assertEqual(results[0].seq, 1)
+        self.assertEqual(captured["path"], "/speech-to-text")
+        self.assertEqual(captured["headers"]["api-subscription-key"], "test-key-sarvam")
+
+    def test_empty_buffer_yields_empty_transcript(self):
+        prov = SarvamSTTProvider()
+        _run(prov.start_session(session_id="s-1", lang_hint="hi"))
+        results = _run(_drain(prov.end_of_speech()))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "")
+        self.assertTrue(results[0].is_final)
+
+    def test_close_clears_buffer(self):
+        prov = SarvamSTTProvider()
+        _run(prov.start_session(session_id="s-1", lang_hint="hi"))
+        chunk_b64 = base64.b64encode(b"\x01\x02").decode()
+        _run(_drain(prov.feed_audio_chunk(seq=0, opus_b64=chunk_b64)))
+        _run(prov.close())
+        self.assertEqual(len(prov._buffer), 0)
+
+
+# ────────────────────────── Provider registry ──────────────────────────
+
+
+class TestProviderRegistry(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_registry_for_tests()
+
+    def tearDown(self) -> None:
+        _reset_registry_for_tests()
+
+    def test_register_and_lookup_by_voice_prefix(self):
+        class _Fake:
+            name = "google-tts"
+            supported_languages = frozenset({"en"})
+            def is_configured(self): return True
+            def supports_voice(self, vid): return vid.startswith("google:")
+
+        register_tts_provider(
+            "google-tts",
+            lambda: _Fake(),
+            voice_prefix="google:",
+            languages=frozenset({"en"}),
+        )
+        found = find_provider_by_voice_prefix("tts", "google:standard-en-A")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.name, "google-tts")
+
+    def test_register_and_lookup_by_language(self):
+        class _Fake:
+            pass
+        register_stt_provider(
+            "azure-stt", lambda: _Fake(), languages=frozenset({"en", "de"}),
+        )
+        found = find_provider_by_language("stt", "de-DE")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.name, "azure-stt")
+
+    def test_idempotent_registration(self):
+        class _Fake:
+            pass
+        register_tts_provider(
+            "x", lambda: _Fake(), voice_prefix="x:", languages=frozenset({"en"}),
+        )
+        register_tts_provider(
+            "x", lambda: _Fake(), voice_prefix="x:", languages=frozenset({"hi"}),
+        )
+        # Only one entry survives; languages reflect the latest registration.
+        all_tts = all_providers("tts")
+        self.assertEqual(len([p for p in all_tts if p.name == "x"]), 1)
+        x = next(p for p in all_tts if p.name == "x")
+        self.assertEqual(x.languages, frozenset({"hi"}))
+
+    def test_unknown_kind_raises(self):
+        from backend.services.voice.provider_registry import _registry
+        with self.assertRaises(ValueError):
+            _registry._bucket("xxx")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Path B per spec: replace `NotImplementedError` stubs with real streaming HTTP for the providers the user has keys for, plus an extensibility seam so adding Google/Azure/etc. is a single file. Also threads through the EAS build path for `apps/sakha-mobile` (the native Android app) so the `.apk` workflow runs cleanly on the user's Render-hosted backend.

## What's in this PR

### Real provider implementations (ends the "Mock-only" era)
- **`ElevenLabsTTSProvider`** — POSTs to `/v1/text-to-speech/{voice_id}/stream` with `opus_24000_64`, yields `TTSChunk`s as bytes arrive over `httpx.AsyncClient.stream()`. Parses `voice_id` as `elevenlabs:<id>`. Tunable via `KIAAN_ELEVENLABS_BASE_URL`, `KIAAN_ELEVENLABS_MODEL`, `KIAAN_ELEVENLABS_OUTPUT_FORMAT`, `KIAAN_ELEVENLABS_HTTP_TIMEOUT_S`, `KIAAN_ELEVENLABS_CHUNK_BYTES`.
- **`SarvamTTSProvider`** — POSTs to `/text-to-speech` with `bulbul:v2`, decodes base64 WAV from JSON, re-chunks locally into ~32KB `TTSChunk`s so consumers see streaming-shaped output. All 10 Indic languages + Sanskrit have lang-code mappings.
- **`SarvamSTTProvider`** — batch mode: `feed_audio_chunk` accumulates base64-decoded opus into an internal buffer; `end_of_speech` POSTs as multipart/form-data to `/speech-to-text` and yields one `is_final=True` `STTResult`. Tradeoff documented: crisis routing on Indic transcripts depends on round-trip (~600–1500 ms) instead of sub-800 ms partials. Streaming-WebSocket variant deferred.

### Provider registry — extensibility seam
- New `backend/services/voice/provider_registry.py` — thread-safe (`RLock`) registry per kind (`stt`/`tts`/`llm`).
- Public API: `register_stt_provider`, `register_tts_provider`, `register_llm_provider`.
- `TTSRouter.decide` / `build_provider` now consult the registry as a third tier after the built-in Sarvam/ElevenLabs branches.
- Idempotent — re-registering the same name overwrites (useful for tests).

### Mobile build path fixes (the "old APK" debug)
- `eas.json` — pointed all 3 profiles at `https://mindvibe-api.onrender.com` (single Render service, no separate preview/dev).
- `app.config.ts` — pinned EAS `projectId` to `2ca58471-88ee-43fe-98ab-cbe9ac502ac5` after `eas init` created the project (writes back automatically failed because the config is dynamic `.ts`).
- `package.json` — dropped `@picovoice/cobra-react-native` (returns 404 on npm) and `@picovoice/porcupine-react-native`. `useVAD.ts` already wraps these in a runtime `require()` with a stub fallback, so VAD just stays in stub mode and server-side STT end-of-utterance drives barge-in via the WSS `interrupt` frame. Also unblocks every fresh `pnpm install`, which was blocking `eas build`.

### Crisis audio URL fix
- `useWebSocket.ts` — backend's `CrisisFrame.audio_url` is `/static/voice/safety/...` (relative). expo-av's `Audio.Sound.createAsync` requires absolute. Added `absolutizeAudioUrl` at the dispatch boundary so the mobile prefixes with `httpBaseUrl` before handing to the player. Caught by post-merge integrity scan.

### Documentation
- `docs/voice-companion-runbook.md` — split env-var table into "core" (the 11 you set on Render) + "provider tuning" (10 optional knobs). New "Adding a new provider" section with a worked Google TTS example end-to-end.

## Test plan
- [x] **177/177** voice-branch Python unit tests pass (Parts 2/3/4/5/6/11 — no regressions)
- [x] **15/15** new real-provider tests pass (`tests/unit/test_voice_real_providers.py` — `httpx.MockTransport` based, no real network)
- [x] **100/100** prompt-regression cases (50 voice + 50 text)
- [x] **17/17** WSS frame types match TS↔Python
- [x] **15/15** tool contracts match TS↔Python
- [x] **3/3** Expo plugins load + invoke
- [x] **11** pure helpers green (`computeNavDelay` + `downgradeIfLowConfidence`)
- [x] All Python files parse (33 voice files clean)
- [x] All TS/JS files parse (49 mobile files clean)
- [x] All JSON files valid (6 files including the regression jsonl + manifest)
- [x] **API endpoint cross-check**: `/api/voice/quota`, `/api/voice/persona-version`, `/voice-companion/converse` (subprotocol `kiaan-voice-v1`) all match — caught and fixed the relative `audio_url` mismatch
- [x] **Code cross-references**: `com.kiaanverse.sakha.audio.*` FQNs · meta-data keys · channel ID `sakha_voice_session` · `tier_used` literals · persona-version `1.0.0` — all match
- [ ] Founder's listen — manual, can't be automated

**Total: 292/292 automated checks green.**

## Operational

After merge, on the Render service:

```
KIAAN_SARVAM_API_KEY      = <sarvam key>     # enables Indic STT + TTS
KIAAN_ELEVENLABS_API_KEY  = <elevenlabs key>  # enables English TTS
```

Don't set `KIAAN_VOICE_MOCK_PROVIDERS` (or set it to `0`). Render redeploys in ~1–2 min.

For mobile: `cd kiaanverse-mobile/apps/sakha-mobile && npx eas-cli build --platform android --profile preview` → `.apk` download URL emailed when EAS finishes (~15–25 min).

## What's still stubbed (intentional, deferred)
- **Deepgram English STT** — user doesn't have a key yet; provider class is wired with the same shape as the others, just gated on `KIAAN_DEEPGRAM_API_KEY`.
- **Sarvam streaming WebSocket STT** — would give sub-800 ms partials on Indic transcripts. Batch mode is correct first ship.
- **30 safety audio `.opus` placeholders** — human-asset pipeline drop. Mobile gracefully falls back to live-TTS via `_render_voice` while placeholders persist.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_