### PR TITLE
fix(voice): register ReactPackages via plugin, not Expo autolinker codegen (Step 53 / follow-up to #1660)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -151,6 +151,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // ("Hey Sakha"). ABI splits + BuildConfig.KIAAN_PICOVOICE_ACCESS_KEY
     // injection. Reads extras.picovoice.accessKey at prebuild.
     './plugins/withPicovoice',
+    // Sakha + KIAAN voice — register the two ReactPackage classes
+    // (KiaanVoicePackage, SakhaVoicePackage) in MainApplication.kt.
+    // These are old-style RN bridge packages, NOT new-API Expo Modules,
+    // so they can't ride the expo-module.config.json `android.modules`
+    // codegen path (which expects `Class<? extends Module>`).
+    './plugins/withKiaanSakhaVoicePackages',
     'expo-router',
     'expo-splash-screen',
     [

--- a/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
@@ -1,0 +1,91 @@
+/**
+ * withKiaanSakhaVoicePackages — Expo config plugin.
+ *
+ * Registers the two ReactPackage classes from
+ *   @kiaanverse/kiaan-voice-native  (com.mindvibe.kiaan.voice.KiaanVoicePackage)
+ *   @kiaanverse/sakha-voice-native  (com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage)
+ *
+ * by patching MainApplication.kt during prebuild to call:
+ *   packages.add(KiaanVoicePackage())
+ *   packages.add(SakhaVoicePackage())
+ *
+ * Why a plugin instead of expo-module.config.json `android.modules`:
+ * The `android.modules` field is for the *new* Expo Module API
+ * (classes extending `expo.modules.kotlin.modules.Module`). Our two
+ * packages are old-style RN bridge `ReactPackage` subclasses. When
+ * registered via `android.modules`, the autolinker generates
+ * `ExpoModulesPackageList.java` with a strict `Class<? extends Module>`
+ * cast that fails at javac time:
+ *
+ *   error: method asList in class Arrays cannot be applied to given types;
+ *   reason: Class<KiaanVoicePackage> cannot be converted to Class<? extends Module>
+ *
+ * The fix is to register them through MainApplication.kt's `getPackages()`
+ * method like any other RN bridge package, which is what this plugin does.
+ *
+ * The Gradle modules `:kiaanverse-kiaan-voice-native` and
+ * `:kiaanverse-sakha-voice-native` are still discovered by the
+ * autolinker (because the workspace package has `expo-module.config.json`
+ * with `platforms: ["android"]`), so the .aar files still get linked.
+ * Only the runtime registration mechanism changes.
+ *
+ * Idempotent — re-running prebuild does not duplicate imports or
+ * package additions.
+ */
+
+const { withMainApplication } = require('@expo/config-plugins');
+
+const KIAAN_IMPORT = 'import com.mindvibe.kiaan.voice.KiaanVoicePackage';
+const SAKHA_IMPORT = 'import com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage';
+const KIAAN_ADD = 'packages.add(KiaanVoicePackage())';
+const SAKHA_ADD = 'packages.add(SakhaVoicePackage())';
+
+function addImport(contents, importLine) {
+  if (contents.includes(importLine)) return contents;
+  // Insert after the package declaration. Kotlin: `package com.foo`.
+  // We append after the first import block to avoid the package line.
+  const lastImportMatch = [...contents.matchAll(/^import\s+\S+/gm)].pop();
+  if (lastImportMatch) {
+    const insertAt = lastImportMatch.index + lastImportMatch[0].length;
+    return contents.slice(0, insertAt) + '\n' + importLine + contents.slice(insertAt);
+  }
+  // Fallback: insert after the package declaration.
+  return contents.replace(/^(package\s+\S+)/m, `$1\n\n${importLine}`);
+}
+
+function addPackageRegistration(contents, addLine) {
+  if (contents.includes(addLine)) return contents;
+  // The Expo / RN MainApplication.kt template has:
+  //   val packages = PackageList(this).packages
+  //   // Packages that cannot be autolinked yet can be added manually here, for example:
+  //   // packages.add(MyReactNativePackage())
+  //   return packages
+  //
+  // We insert our add() lines right after `val packages = PackageList(this).packages`.
+  return contents.replace(
+    /(val\s+packages\s*=\s*PackageList\(this\)\.packages)/,
+    `$1\n          ${addLine}`,
+  );
+}
+
+const withKiaanSakhaVoicePackages = (config) => {
+  return withMainApplication(config, (config) => {
+    if (config.modResults.language !== 'kt') {
+      // Java MainApplication is not what Expo SDK 51 generates by default,
+      // so we don't bother handling it. If a future template change reverts
+      // to Java, this plugin would no-op and the build would compile but
+      // the packages wouldn't be registered.
+      return config;
+    }
+    let contents = config.modResults.contents;
+    contents = addImport(contents, KIAAN_IMPORT);
+    contents = addImport(contents, SAKHA_IMPORT);
+    contents = addPackageRegistration(contents, KIAAN_ADD);
+    contents = addPackageRegistration(contents, SAKHA_ADD);
+    config.modResults.contents = contents;
+    return config;
+  });
+};
+
+module.exports = withKiaanSakhaVoicePackages;
+module.exports.default = withKiaanSakhaVoicePackages;

--- a/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
@@ -1,6 +1,3 @@
 {
-  "platforms": ["android"],
-  "android": {
-    "modules": ["com.mindvibe.kiaan.voice.KiaanVoicePackage"]
-  }
+  "platforms": ["android"]
 }

--- a/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
@@ -1,6 +1,3 @@
 {
-  "platforms": ["android"],
-  "android": {
-    "modules": ["com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage"]
-  }
+  "platforms": ["android"]
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1660. After that PR unblocked Kotlin compile,
the build moved one step further and hit a real javac error in the
Expo-generated `ExpoModulesPackageList.java`:

```
ExpoModulesPackageList.java:24: error: method asList in class Arrays
  cannot be applied to given types;
  reason: varargs mismatch;
  Class<KiaanVoicePackage> cannot be converted to Class<? extends Module>
```

Single-commit fix: `bac5a179`.

## Root cause

The autolinker generates this list:

```java
static final List<Class<? extends Module>> modulesList = Arrays.<Class<? extends Module>>asList(
    KiaanVoicePackage.class,        // ← ReactPackage, NOT Module
    SakhaVoicePackage.class,        // ← ReactPackage, NOT Module
    ApplicationModule.class,        // ✓ Module
    AssetModule.class,              // ✓ Module
    ...
);
```

The `android.modules` field in `expo-module.config.json` is for **new
Expo Module API** classes (extending `expo.modules.kotlin.modules.Module`).
Our two packages are **old-style React Native bridge** `ReactPackage`
subclasses, so the strict typed cast fails at javac time.

## What's fixed

### 1. Drop `android.modules` from both expo-module.config.json files

```diff
-{
-  "platforms": ["android"],
-  "android": {
-    "modules": ["com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage"]
-  }
-}
+{
+  "platforms": ["android"]
+}
```

Same change for `kiaan-voice/expo-module.config.json`.

The autolinker still discovers the workspace package (because
`platforms: ["android"]` is enough), still generates
`include ':kiaanverse-sakha-voice-native'` in `settings.gradle`,
still adds `implementation project(':kiaanverse-sakha-voice-native')`
to `:app/build.gradle`. The `.aar` files still ship in the `.aab`.
Only the generated registration in `ExpoModulesPackageList.java` is
suppressed.

### 2. New config plugin: `apps/mobile/plugins/withKiaanSakhaVoicePackages.js`

Patches `MainApplication.kt` during prebuild to add:

```kotlin
import com.mindvibe.kiaan.voice.KiaanVoicePackage
import com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage

// ...
override fun getPackages(): List<ReactPackage> {
    val packages = PackageList(this).packages
    packages.add(KiaanVoicePackage())
    packages.add(SakhaVoicePackage())
    return packages
}
```

This is the canonical RN bridge way to register a `ReactPackage` —
same pattern documented in the Expo prebuild template's "Packages
that cannot be autolinked yet can be added manually here" comment.

The plugin is **idempotent**: re-running `expo prebuild` does NOT
duplicate imports or add() calls.

### 3. Wire the plugin into `apps/mobile/app.config.ts`

Added after the three existing Sakha plugins
(`withKiaanForegroundService`, `withKiaanAudioFocus`, `withPicovoice`).

## Build progression

Each PR has narrowed the failure window:

| Stage | PR | Status |
|---|---|---|
| Gradle configure (module path) | #1659 (Step 35) | ✅ |
| Maven resolution (`expomodulescore`) | #1659 (Step 51) | ✅ |
| Kotlin compile (sakha + kiaan native) | #1660 (Step 52) | ✅ |
| `expo:compileReleaseJavaWithJavac` | **this PR (Step 53)** | ✅ (after merge) |
| R8 / dexer | next | ❓ |
| Bundler / signed `.aab` | next | ❓ |

If the build fails again post-merge, it'll be at R8/dexer or later —
narrower than every prior failure.

## Test plan

- [ ] Merge this PR
- [ ] `git pull origin main` locally
- [ ] `cd kiaanverse-mobile/apps/mobile`
- [ ] `eas build --profile preview --platform android`
- [ ] Build advances past `:expo:compileReleaseJavaWithJavac` (was
      failing on this task in the previous build)
- [ ] Either succeeds (sideloadable `.apk` URL) or fails on a narrower
      task (R8 / dexer / packager) — actionable next PR

## Confidentiality

Per the FINAL.2 spec: this architecture, the system prompts, the
Wisdom Core internals, and the integration details are Kiaanverse IP.
Reviewers, please do not summarize or share outside the team.

🪔 शङ्ख · सखा

https://claude.ai/code/session_01QGforGwe66ppghLMD4uocV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGforGwe66ppghLMD4uocV)_