### PR TITLE
fix(voice): explicit android.modules:[] to stop autolinker registerin…

### DIFF
--- a/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
@@ -1,3 +1,6 @@
 {
-  "platforms": ["android"]
+  "platforms": ["android"],
+  "android": {
+    "modules": []
+  }
 }

--- a/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
@@ -1,3 +1,6 @@
 {
-  "platforms": ["android"]
+  "platforms": ["android"],
+  "android": {
+    "modules": []
+  }
 }


### PR DESCRIPTION
…g ReactPackages (Step 55)

EAS production .aab build (28b0a1e7-330c-487e-af79-c7011e3b5cbb) failed at :expo:compileReleaseJavaWithJavac with the same type-mismatch error from Step 53:

  ExpoModulesPackageList.java:24: error: method asList in class Arrays
  cannot be applied to given types;
    static final List<Class<? extends Module>> modulesList =
        Arrays.<Class<? extends Module>>asList(
    found:  Class<KiaanVoicePackage>, Class<SakhaVoicePackage>, ...
    reason: Class<KiaanVoicePackage> cannot be converted to
            Class<? extends Module>

Step 53 had attempted to fix this by removing `android.modules` from both expo-module.config.json files, leaving just `{ "platforms": ["android"] }`. That worked once (the .aab built and produced installable split APKs from build 31a62c27) — but a subsequent clean rebuild (28b0a1e7) re-triggered the same failure. The autolinker's behavior with bare `platforms` is to *scan the AAR for *Package-suffix classes and add them to modulesList expecting they extend Module*. Our KiaanVoicePackage / SakhaVoicePackage extend ReactPackage (old RN bridge API), not Module (new Expo Module API), so the generated cast fails.

Fix: explicitly declare `android.modules: []` so the autolinker uses the empty list verbatim instead of falling back to AAR scanning.

  // Before
  { "platforms": ["android"] }

  // After
  { "platforms": ["android"], "android": { "modules": [] } }

Registration of the two ReactPackages still happens via the withKiaanSakhaVoicePackages.js config plugin (Step 53), which patches MainApplication.kt's getPackages() to add KiaanVoicePackage() and SakhaVoicePackage() — that path is unchanged and unaffected.

Why this is more robust than the bare-platforms variant: with explicit empty modules array, the autolinker has no reason to scan, no edge case where a previous-state cache vs clean-build affects what it discovers. The .aar files still get built and linked (settings.gradle wires them up via the standard Expo autolinking discovery — that side is independent), only the ExpoModulesPackageList.java generation is constrained to the empty list.

https://claude.ai/code/session_01QGforGwe66ppghLMD4uocV

<!-- Describe the change and why it matters -->
## Summary

<!-- One-sentence summary of the change -->

## Checklist
- [ ] CI passes (tests run successfully)
- [ ] No private keys are committed (only *-pub.json allowed)
- [ ] README and docs updated as needed
- [ ] License and Code of Conduct included

## Testing
Describe how this change was tested locally (commands run).

## Reviewers
Tag any maintainers or teams that should review.
