### PR TITLE
feat(tools): add Sakha Voice Companion to Sacred Tools dashboard (Step 62)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/tools/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/index.tsx
@@ -66,6 +66,33 @@ interface ToolDescriptor {
   readonly route: string;
 }
 
+/**
+ * SACRED VOICE — The KIAAN Voice Companion (Sakha).
+ *
+ * The 3-engine voice companion (Friendly / Guidance / Internal Navigation)
+ * placed at the TOP of Sacred Tools because it is the centerpiece of the
+ * KIAANverse experience per FINAL.2 spec. From here the user enters the
+ * /voice-companion canvas (Shankha + sacred geometry, "Tap to begin"
+ * tap-to-start), where Sakha listens, responds in Sanskrit-anchored
+ * modern-secular wisdom, and can navigate them into any tool below
+ * (Emotional Reset, Karma Reset, etc.) with PII-scrubbed prefill via
+ * the INPUT_TO_TOOL contract.
+ *
+ * Iconography: Shankha (शङ्ख) — Krishna's conch.
+ * Color: DIVINE_GOLD — matches the persona's warm-gold register.
+ */
+const SACRED_VOICE_TOOLS: readonly ToolDescriptor[] = [
+  {
+    id: 'voice-companion',
+    name: 'Sakha — Voice Companion',
+    sanskrit: 'सखा',
+    description: 'Speak with the divine friend',
+    color: DIVINE_GOLD,
+    icon: '🐚',
+    route: '/voice-companion',
+  },
+];
+
 const HEALING_TOOLS: readonly ToolDescriptor[] = [
   {
     id: 'emotional-reset',
@@ -168,6 +195,11 @@ export default function ToolsDashboardScreen(): React.JSX.Element {
   const sections = useMemo(
     () =>
       [
+        // Sacred Voice goes FIRST — Sakha is the centerpiece of the
+        // KIAANverse experience per FINAL.2 spec. From here the user
+        // enters the voice companion canvas; from there Sakha can
+        // navigate them to any other tool below.
+        { title: 'Sacred Voice', tools: SACRED_VOICE_TOOLS },
         { title: 'Healing Tools', tools: HEALING_TOOLS },
         { title: 'Wisdom Tools', tools: WISDOM_TOOLS },
         { title: 'Karma Insights', tools: INSIGHT_TOOLS },


### PR DESCRIPTION
## Why

User requirement: *"please put voice companion in Sacred tools"*

The `/voice-companion` route exists and Shankha-input UI is wired into the 5 ritual tools (Steps 59–60), but there was no entry point from the Sacred Tools dashboard itself. Users had to know the URL or use the bottom tab to reach Sakha. This commit elevates Voice Companion to a first-class Sacred Tool — placed at the **top** of the dashboard because it IS the centerpiece of the KIAANverse experience per the FINAL.2 spec.

## What

A new "Sacred Voice" section is inserted as section index 0 (before Healing Tools), containing a single `ToolCard` for Sakha:

| Field | Value |
|-------|-------|
| name | Sakha — Voice Companion |
| sanskrit | सखा |
| description | Speak with the divine friend |
| icon | 🐚 (Shankha) |
| color | `DIVINE_GOLD` |
| route | `/voice-companion` |

## Why a dedicated section vs. dropping into Wisdom Tools

The 3-brain voice architecture (Friendly / Guidance / Internal Navigation) is structurally different from the ritual tools below. Sakha doesn't fit into Healing, Wisdom, or Karma Insights — she is the conversational entry that can navigate the user **into** any of those three categories via the INPUT_TO_TOOL contract. A dedicated section communicates that hierarchy to the user immediately on the dashboard:

```
Sacred Tools dashboard
   │
   ├── Sacred Voice  ← Sakha (top, golden)
   │     │
   │     ├── speaks → Friend / Guidance / Voice-Guide engine
   │     └── INPUT_TO_TOOL → opens any tool below with prefill
   │
   ├── Healing Tools (Emotional Reset, Karma Reset)
   ├── Wisdom Tools (Ardha, Viyoga, Relationship Compass)
   ├── Karma Insights (KarmaLytix, Karma Footprint, Karma Tree)
   └── Sacred Sound (KIAAN Vibe Player)
```

## Entrance choreography

Existing `useDivineEntrance` lotus-bloom auto-includes the new section. sectionIndex=0 means it enters first (delay=0ms) with the single Sakha card at +60ms. The total stagger chain becomes 0/100/200/300/400ms across the five sections. `vibePlayerDelay` is computed from `sections.length` so it auto-adjusts.

## Diff

```
1 file changed, 32 insertions(+)
kiaanverse-mobile/apps/mobile/app/tools/index.tsx
```

## Verification

- ✅ TypeScript compiles with zero new errors
- ✅ `/voice-companion` route exists (Step 56)
- ✅ `ToolCard` component handles new entry without prop changes
- ✅ `DIVINE_GOLD` already imported from `toolColors`

🤖 https://claude.ai/code/session_01QGforGwe66ppghLMD4uocV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGforGwe66ppghLMD4uocV)_