### PR TITLE
Fix Android build: append `implementation project(...)` + restore MainApplication.kt patches

### DIFF
--- a/kiaanverse-mobile/apps/mobile/native/android/expo-module.config.json
+++ b/kiaanverse-mobile/apps/mobile/native/android/expo-module.config.json
@@ -1,9 +1,6 @@
 {
   "platforms": ["android"],
   "android": {
-    "modules": [
-      "com.kiaanverse.sakha.audio.KiaanAudioPlayerPackage",
-      "com.kiaanverse.sakha.audio.SakhaForegroundServicePackage"
-    ]
+    "modules": ["com.kiaanverse.sakha.audio.KiaanAudioPlayerPackage"]
   }
 }

--- a/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
@@ -1,35 +1,155 @@
 /**
- * withKiaanSakhaVoicePackages — Expo config plugin (no-op pass-through).
+ * withKiaanSakhaVoicePackages — Expo config plugin.
  *
- * STATUS: Disabled / pass-through.
+ * The two workspace voice modules (@kiaanverse/{kiaan,sakha}-voice-native)
+ * expose old-style RN bridge `ReactPackage` classes, not new-API Expo
+ * `Module` subclasses. That gives us a tight constraint:
  *
- * Originally this plugin patched MainApplication.kt and app/build.gradle
- * to register three ReactPackage classes:
+ *   • `expo-module.config.json` `android.modules` is strictly typed by
+ *     the autolinker as `Class<? extends expo.modules.kotlin.modules.Module>`.
+ *     If we list a ReactPackage there, ExpoModulesPackageList.java fails
+ *     to compile with:
  *
- *   • com.mindvibe.kiaan.voice.KiaanVoicePackage
- *   • com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage
- *   • com.kiaanverse.sakha.audio.SakhaForegroundServicePackage
+ *       error: method asList in class Arrays cannot be applied to given types;
+ *       reason: Class<KiaanVoicePackage> cannot be converted to Class<? extends Module>
  *
- * Both attempts to make :app see the workspace AARs by patching the
- * generated build.gradle failed on EAS — Expo's autolinker re-runs after
- * config plugins and overwrites our injections. We now register the three
- * packages through the supported channel: each module's
- * expo-module.config.json `android.modules` array. The autolinker:
+ *   • If we leave `android.modules: []`, the autolinker DOES still add
+ *     the workspace package to settings.gradle (via the platforms list)
+ *     but does NOT add an `implementation project(...)` line to the
+ *     host app's build.gradle. The workspace AAR is built but not on
+ *     :app's compile classpath, and `import com.mindvibe.kiaan.voice.*`
+ *     fails inside MainApplication.kt with "Unresolved reference: sakha".
  *
- *   1. Adds `implementation project(':kiaanverse-{kiaan,sakha}-voice-native')`
- *      to apps/mobile/android/app/build.gradle, so :app sees the AARs at
- *      compile time (this is the bit that was missing before).
- *   2. Generates ExpoModulesPackageList.kt with the three class names, so
- *      `PackageList(this).packages` inside MainApplication.kt's getPackages()
- *      returns instances of all three at runtime — no manual packages.add(...)
- *      call needed (KiaanAudioPlayerPackage already proves this works).
+ * Neither auto-pathway works on its own. This plugin bridges the gap:
  *
- * This file is kept as a pass-through so app.config.ts's `plugins:` array
- * doesn't need changing and so we have a place to land a future patch if
- * we ever need to inject something the autolinker can't.
+ *   1. withMainApplication — injects the three imports and the matching
+ *      `packages.add(...)` calls into MainApplication.kt, so the
+ *      registration plumbing exists at runtime.
+ *
+ *   2. withAppBuildGradle — APPENDS a fresh `dependencies { }` block at
+ *      the end of apps/mobile/android/app/build.gradle. Gradle allows
+ *      multiple dependencies blocks (they're additive), so this is
+ *      bulletproof and doesn't rely on any regex matching the exact
+ *      shape of the autolinker's generated block.
+ *
+ * Three packages are registered:
+ *
+ *   • com.mindvibe.kiaan.voice.KiaanVoicePackage         (workspace)
+ *   • com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage   (workspace)
+ *   • com.kiaanverse.sakha.audio.SakhaForegroundServicePackage (local)
+ *
+ * The third one lives in the local `apps/mobile/native/android/` gradle
+ * module, which IS already on :app's classpath via the host app's
+ * implicit project dependency (the local module ships
+ * KiaanAudioPlayerPackage too and that build phase is green). So we
+ * only need to inject `implementation project(...)` for the two
+ * workspace modules.
+ *
+ * Idempotent — re-running prebuild does not duplicate any line.
  */
 
-const withKiaanSakhaVoicePackages = (config) => config;
+const { withMainApplication, withAppBuildGradle } = require('@expo/config-plugins');
+
+const KIAAN_IMPORT = 'import com.mindvibe.kiaan.voice.KiaanVoicePackage';
+const SAKHA_IMPORT = 'import com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage';
+const FG_IMPORT =
+  'import com.kiaanverse.sakha.audio.SakhaForegroundServicePackage';
+const KIAAN_ADD = 'packages.add(KiaanVoicePackage())';
+const SAKHA_ADD = 'packages.add(SakhaVoicePackage())';
+const FG_ADD = 'packages.add(SakhaForegroundServicePackage())';
+
+const APP_GRADLE_DEPS = [
+  "implementation project(':kiaanverse-kiaan-voice-native')",
+  "implementation project(':kiaanverse-sakha-voice-native')",
+];
+
+/** Idempotent marker the appended dependencies block is wrapped in.
+ *  Detecting it lets us skip re-appending on subsequent prebuilds. */
+const APP_GRADLE_MARKER = '// kiaanverse-voice-native-deps:start';
+const APP_GRADLE_MARKER_END = '// kiaanverse-voice-native-deps:end';
+
+function addImport(contents, importLine) {
+  if (contents.includes(importLine)) return contents;
+  // Insert after the package declaration. Kotlin: `package com.foo`.
+  // We append after the first import block to avoid the package line.
+  const lastImportMatch = [...contents.matchAll(/^import\s+\S+/gm)].pop();
+  if (lastImportMatch) {
+    const insertAt = lastImportMatch.index + lastImportMatch[0].length;
+    return contents.slice(0, insertAt) + '\n' + importLine + contents.slice(insertAt);
+  }
+  // Fallback: insert after the package declaration.
+  return contents.replace(/^(package\s+\S+)/m, `$1\n\n${importLine}`);
+}
+
+function addPackageRegistration(contents, addLine) {
+  if (contents.includes(addLine)) return contents;
+  // The Expo / RN MainApplication.kt template has:
+  //   val packages = PackageList(this).packages
+  //   // Packages that cannot be autolinked yet can be added manually here, for example:
+  //   // packages.add(MyReactNativePackage())
+  //   return packages
+  //
+  // We insert our add() lines right after `val packages = PackageList(this).packages`.
+  return contents.replace(
+    /(val\s+packages\s*=\s*PackageList\(this\)\.packages)/,
+    `$1\n          ${addLine}`,
+  );
+}
+
+/**
+ * Append a fresh `dependencies { ... }` block to the end of
+ * apps/mobile/android/app/build.gradle. Gradle merges all dependencies
+ * blocks in a single build.gradle, so this safely adds the workspace
+ * project deps without touching whatever block(s) the autolinker /
+ * Expo template wrote earlier in the file.
+ *
+ * Idempotent via APP_GRADLE_MARKER. If the block is already there we
+ * return contents unchanged.
+ */
+function appendGradleDependencies(contents) {
+  if (contents.includes(APP_GRADLE_MARKER)) return contents;
+  const block = [
+    '',
+    APP_GRADLE_MARKER,
+    '// Workspace voice modules expose ReactPackage (not Module) classes,',
+    "// so they can't be auto-added via expo-module.config.json's",
+    '// android.modules without breaking ExpoModulesPackageList.java',
+    '// compilation. Instead we register the gradle project deps here so',
+    "// :app's compile classpath sees the workspace AARs at compile time.",
+    '// Generated by withKiaanSakhaVoicePackages.js.',
+    'dependencies {',
+    ...APP_GRADLE_DEPS.map((dep) => `    ${dep}`),
+    '}',
+    APP_GRADLE_MARKER_END,
+    '',
+  ].join('\n');
+  return contents.replace(/\s*$/, '\n') + block + '\n';
+}
+
+const withKiaanSakhaVoicePackages = (config) => {
+  // 1. Patch MainApplication.kt with imports + packages.add() calls.
+  config = withMainApplication(config, (cfg) => {
+    if (cfg.modResults.language !== 'kt') return cfg;
+    let contents = cfg.modResults.contents;
+    contents = addImport(contents, KIAAN_IMPORT);
+    contents = addImport(contents, SAKHA_IMPORT);
+    contents = addImport(contents, FG_IMPORT);
+    contents = addPackageRegistration(contents, KIAAN_ADD);
+    contents = addPackageRegistration(contents, SAKHA_ADD);
+    contents = addPackageRegistration(contents, FG_ADD);
+    cfg.modResults.contents = contents;
+    return cfg;
+  });
+
+  // 2. Append `implementation project(...)` to app/build.gradle.
+  config = withAppBuildGradle(config, (cfg) => {
+    if (cfg.modResults.language !== 'groovy') return cfg;
+    cfg.modResults.contents = appendGradleDependencies(cfg.modResults.contents);
+    return cfg;
+  });
+
+  return config;
+};
 
 module.exports = withKiaanSakhaVoicePackages;
 module.exports.default = withKiaanSakhaVoicePackages;

--- a/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "platforms": ["android"],
   "android": {
-    "modules": ["com.mindvibe.kiaan.voice.KiaanVoicePackage"]
+    "modules": []
   }
 }

--- a/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "platforms": ["android"],
   "android": {
-    "modules": ["com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage"]
+    "modules": []
   }
 }


### PR DESCRIPTION
## The error

Build #5 (from `main @ c6082e2`) hit the EXACT failure the original `withKiaanSakhaVoicePackages` plugin author warned about — listing `ReactPackage` classes in `expo-module.config.json`'s `android.modules` makes Expo's autolinker generate a strictly-typed `ExpoModulesPackageList.java` that fails `:expo:compileReleaseJavaWithJavac`:

```
error: method asList in class Arrays cannot be applied to given types;
reason: Class<KiaanVoicePackage> cannot be converted to Class<? extends Module>
```

## Why my last "fix" was wrong

Commit `7d3b220` assumed `KiaanAudioPlayerPackage` (also a `ReactPackage`) worked through the same `android.modules` path because it ships in `apps/mobile/native/android/expo-module.config.json`. But the EAS build log's `Using expo modules` header lists ONLY the two workspace voice modules — the local audio module is NOT autolinked at all, its `android.modules` array is silently ignored, and `KiaanAudioPlayerPackage` gets on `:app`'s classpath through a different mechanism (gradle module included via the workspace's settings.gradle).

So neither auto-pathway works for the workspace voice packages on its own:

| | Outcome |
|---|---|
| `modules: []` | Autolinker skips ExpoModulesPackageList ✓ but also skips `implementation project(...)` ✗ → "Unresolved reference: sakha" at `:app:compileReleaseKotlin` |
| `modules: [<ReactPackage>]` | Autolinker adds `implementation project(...)` ✓ but also adds it to ExpoModulesPackageList ✗ → "Class<X> cannot be converted to Class<? extends Module>" at `:expo:compileReleaseJavaWithJavac` |

## What this PR does

The plugin now bridges the gap explicitly:

1. **Reverts `android.modules` to empty** for both workspace voice modules (so the autolinker stops generating the bad ExpoModulesPackageList entry).
2. **Reverts** the local audio module to the single `KiaanAudioPlayerPackage` entry it had before. `SakhaForegroundServicePackage` would have hit the same ExpoModulesPackageList cast error if listed there — registered manually in MainApplication.kt instead.
3. **Patches `MainApplication.kt`** with three imports and three `packages.add(...)` calls (existing behaviour, restored).
4. **Appends a fresh `dependencies { }` block** at the end of `apps/mobile/android/app/build.gradle` containing
   ```groovy
   implementation project(':kiaanverse-kiaan-voice-native')
   implementation project(':kiaanverse-sakha-voice-native')
   ```
   Gradle merges multiple `dependencies` blocks in a single build.gradle additively — this is bulletproof and does **not** rely on regex finding the autolinker-generated block. Wrapped in a `// kiaanverse-voice-native-deps:start/end` marker so re-running prebuild is idempotent.

## Test plan

- [ ] `eas build --profile preview --platform android` from this branch's tip clears `:expo:compileReleaseJavaWithJavac` (the new failure point) AND `:app:compileReleaseKotlin` (the previous failure point)
- [ ] AAB / APK installs on an Android device
- [ ] Bottom nav shows 6 tabs · Sacred Tools → Bhagavad Gita opens · Terms / Data-Privacy render · Voice Companion taps work

## What's NOT in this PR

`KiaanAudioPlayerPackage` registration is unchanged — whatever pathway is delivering it on `:app`'s classpath today (via the local audio gradle module's own settings.gradle inclusion) keeps working. We only add gradle deps for the two workspace voice modules where the autolinker refuses to.

Branch: `claude/fix-app-issues-gDzAa-build-fix` · Commit `cb26c68`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9YoG5EKB5GBz84hgTAhdg)_