### PR TITLE
fix(android): cut workspace voice modules out of Expo autolinker — kill dual-registration

### DIFF
--- a/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
@@ -1,54 +1,70 @@
 /**
  * withKiaanSakhaVoicePackages — Expo config plugin.
  *
- * The two workspace voice modules (@kiaanverse/{kiaan,sakha}-voice-native)
- * expose old-style RN bridge `ReactPackage` classes, not new-API Expo
- * `Module` subclasses. That gives us a tight constraint:
+ * MODEL: pure manual gradle library registration.
  *
- *   • `expo-module.config.json` `android.modules` is strictly typed by
- *     the autolinker as `Class<? extends expo.modules.kotlin.modules.Module>`.
- *     If we list a ReactPackage there, ExpoModulesPackageList.java fails
- *     to compile with:
+ * The two workspace voice modules
+ * (kiaanverse-mobile/native/{kiaan,sakha}-voice/android/) are deliberately
+ * NOT discoverable by Expo's autolinker — there is no
+ * `expo-module.config.json` at either workspace path. This is the
+ * fix for the dual-registration bug:
  *
- *       error: method asList in class Arrays cannot be applied to given types;
- *       reason: Class<KiaanVoicePackage> cannot be converted to Class<? extends Module>
+ *   In a pnpm workspace, the autolinker finds each module twice:
+ *     1. via the workspace path (kiaanverse-mobile/native/{X}-voice/)
+ *     2. via the pnpm symlink (apps/mobile/node_modules/@kiaanverse/{X}-voice-native/)
+ *   Both paths point at the same source tree, but the autolinker mangles
+ *   the gradle project name differently for each (slash→`-` vs slash→`_`),
+ *   so settings.gradle ends up with TWO entries per module:
+ *     :kiaanverse-{X}-voice-native   AND   :kiaanverse_{X}-voice-native
+ *   Both AARs build with the same Android `namespace`, AGP detects the
+ *   namespace collision, and one set of classes gets pruned from :app's
+ *   compile classpath. The result was the persistent
+ *   `Unresolved reference: sakha` failure at :app:compileReleaseKotlin
+ *   across builds #1 through #7.
  *
- *   • If we leave `android.modules: []`, the autolinker DOES still add
- *     the workspace package to settings.gradle (via the platforms list)
- *     but does NOT add an `implementation project(...)` line to the
- *     host app's build.gradle. The workspace AAR is built but not on
- *     :app's compile classpath, and `import com.mindvibe.kiaan.voice.*`
- *     fails inside MainApplication.kt with "Unresolved reference: sakha".
+ * Removing the autolinker hook (deleting `expo-module.config.json` from
+ * both workspace dirs) eliminates double-discovery at the source. This
+ * plugin then takes over the three registration responsibilities the
+ * autolinker would otherwise have done:
  *
- * Neither auto-pathway works on its own. This plugin bridges the gap:
+ *   1. withSettingsGradle — appends
+ *        include ':kiaanverse-kiaan-voice-native', ':kiaanverse-sakha-voice-native'
+ *        project(':kiaanverse-kiaan-voice-native').projectDir = file(...)
+ *        project(':kiaanverse-sakha-voice-native').projectDir = file(...)
+ *      so gradle knows about the two library modules. The relative path
+ *      is resolved from the host android/ folder — which on EAS Build is
+ *      `apps/mobile/android/`, so we go up three levels to the
+ *      kiaanverse-mobile root and then into native/{X}-voice/android/.
  *
- *   1. withMainApplication — injects the three imports and the matching
- *      `packages.add(...)` calls into MainApplication.kt, so the
- *      registration plumbing exists at runtime.
+ *   2. withAppBuildGradle — appends a fresh `dependencies { ... }` block
+ *      with `implementation project(':kiaanverse-{kiaan,sakha}-voice-native')`
+ *      so :app sees the two AARs at compile time. Multiple
+ *      `dependencies { }` blocks in one build.gradle are additive in
+ *      Gradle, so this never collides with the autolinker's block.
  *
- *   2. withAppBuildGradle — APPENDS a fresh `dependencies { }` block at
- *      the end of apps/mobile/android/app/build.gradle. Gradle allows
- *      multiple dependencies blocks (they're additive), so this is
- *      bulletproof and doesn't rely on any regex matching the exact
- *      shape of the autolinker's generated block.
+ *   3. withMainApplication — injects three imports and matching
+ *      `packages.add(...)` calls so the host app instantiates the
+ *      ReactPackage classes at runtime:
+ *        com.mindvibe.kiaan.voice.KiaanVoicePackage         (workspace)
+ *        com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage   (workspace)
+ *        com.kiaanverse.sakha.audio.SakhaForegroundServicePackage (local)
  *
- * Three packages are registered:
- *
- *   • com.mindvibe.kiaan.voice.KiaanVoicePackage         (workspace)
- *   • com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage   (workspace)
- *   • com.kiaanverse.sakha.audio.SakhaForegroundServicePackage (local)
- *
- * The third one lives in the local `apps/mobile/native/android/` gradle
- * module, which IS already on :app's classpath via the host app's
- * implicit project dependency (the local module ships
- * KiaanAudioPlayerPackage too and that build phase is green). So we
- * only need to inject `implementation project(...)` for the two
- * workspace modules.
+ * The third package (SakhaForegroundServicePackage) lives in the local
+ * gradle module at `apps/mobile/native/android/`, which IS still
+ * autolinked through `apps/mobile/native/android/expo-module.config.json`
+ * (that one ships KiaanAudioPlayerPackage as an Expo Module). We only
+ * need the `packages.add(...)` line for the foreground-service package
+ * because it's a ReactPackage, not a Module — the autolinker's
+ * `PackageList(this).packages` doesn't auto-instantiate it.
  *
  * Idempotent — re-running prebuild does not duplicate any line.
  */
 
-const { withMainApplication, withAppBuildGradle } = require('@expo/config-plugins');
+const {
+  withMainApplication,
+  withAppBuildGradle,
+  withSettingsGradle,
+} = require('@expo/config-plugins');
 
 const KIAAN_IMPORT = 'import com.mindvibe.kiaan.voice.KiaanVoicePackage';
 const SAKHA_IMPORT = 'import com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage';
@@ -58,20 +74,32 @@ const KIAAN_ADD = 'packages.add(KiaanVoicePackage())';
 const SAKHA_ADD = 'packages.add(SakhaVoicePackage())';
 const FG_ADD = 'packages.add(SakhaForegroundServicePackage())';
 
-const APP_GRADLE_DEPS = [
-  "implementation project(':kiaanverse-kiaan-voice-native')",
-  "implementation project(':kiaanverse-sakha-voice-native')",
+/** Gradle module entries we register. Each `name` is the gradle project
+ *  name (used in `:<name>` references), `dir` is the relative path from
+ *  the host app's android/ folder (where settings.gradle lives) to the
+ *  workspace module's android/ folder. */
+const WORKSPACE_MODULES = [
+  {
+    name: 'kiaanverse-kiaan-voice-native',
+    dir: '../../../native/kiaan-voice/android',
+  },
+  {
+    name: 'kiaanverse-sakha-voice-native',
+    dir: '../../../native/sakha-voice/android',
+  },
 ];
 
-/** Idempotent marker the appended dependencies block is wrapped in.
- *  Detecting it lets us skip re-appending on subsequent prebuilds. */
+/** Idempotent markers so re-running prebuild doesn't duplicate lines. */
+const SETTINGS_MARKER = '// kiaanverse-voice-native-modules:start';
+const SETTINGS_MARKER_END = '// kiaanverse-voice-native-modules:end';
 const APP_GRADLE_MARKER = '// kiaanverse-voice-native-deps:start';
 const APP_GRADLE_MARKER_END = '// kiaanverse-voice-native-deps:end';
 
 function addImport(contents, importLine) {
   if (contents.includes(importLine)) return contents;
-  // Insert after the package declaration. Kotlin: `package com.foo`.
-  // We append after the first import block to avoid the package line.
+  // Insert after the last existing import. The plugin runs three
+  // addImport calls; each new import becomes the "last", so subsequent
+  // imports are appended in order.
   const lastImportMatch = [...contents.matchAll(/^import\s+\S+/gm)].pop();
   if (lastImportMatch) {
     const insertAt = lastImportMatch.index + lastImportMatch[0].length;
@@ -83,13 +111,11 @@ function addImport(contents, importLine) {
 
 function addPackageRegistration(contents, addLine) {
   if (contents.includes(addLine)) return contents;
-  // The Expo / RN MainApplication.kt template has:
+  // Expo SDK 51's MainApplication.kt template has:
   //   val packages = PackageList(this).packages
-  //   // Packages that cannot be autolinked yet can be added manually here, for example:
-  //   // packages.add(MyReactNativePackage())
+  //   // Packages that cannot be autolinked yet can be added manually here, ...
   //   return packages
-  //
-  // We insert our add() lines right after `val packages = PackageList(this).packages`.
+  // We insert our packages.add(...) call right after the val declaration.
   return contents.replace(
     /(val\s+packages\s*=\s*PackageList\(this\)\.packages)/,
     `$1\n          ${addLine}`,
@@ -97,37 +123,69 @@ function addPackageRegistration(contents, addLine) {
 }
 
 /**
- * Append a fresh `dependencies { ... }` block to the end of
- * apps/mobile/android/app/build.gradle. Gradle merges all dependencies
- * blocks in a single build.gradle, so this safely adds the workspace
- * project deps without touching whatever block(s) the autolinker /
- * Expo template wrote earlier in the file.
- *
- * Idempotent via APP_GRADLE_MARKER. If the block is already there we
- * return contents unchanged.
+ * Append `include ':...'` and `project(':...').projectDir = file('...')`
+ * to settings.gradle. Idempotent via SETTINGS_MARKER.
+ */
+function appendSettingsGradleIncludes(contents) {
+  if (contents.includes(SETTINGS_MARKER)) return contents;
+  const lines = [
+    '',
+    SETTINGS_MARKER,
+    '// Workspace voice modules (kiaanverse-mobile/native/{kiaan,sakha}-voice/)',
+    '// are NOT autolinked — they have no expo-module.config.json. We',
+    '// register them here as pure gradle library modules so the autolinker',
+    '// cannot double-register them via the pnpm symlink path. See',
+    '// withKiaanSakhaVoicePackages.js header for the full failure mode.',
+    `include ${WORKSPACE_MODULES.map((m) => `':${m.name}'`).join(', ')}`,
+    ...WORKSPACE_MODULES.map(
+      (m) => `project(':${m.name}').projectDir = new File(rootProject.projectDir, '${m.dir}')`,
+    ),
+    SETTINGS_MARKER_END,
+    '',
+  ];
+  return contents.replace(/\s*$/, '\n') + lines.join('\n') + '\n';
+}
+
+/**
+ * Append a fresh `dependencies { ... }` block with the workspace
+ * project deps. Gradle merges multiple dependencies blocks additively,
+ * so this is safe alongside whatever the autolinker / Expo template
+ * wrote earlier in the file. Idempotent via APP_GRADLE_MARKER.
  */
 function appendGradleDependencies(contents) {
   if (contents.includes(APP_GRADLE_MARKER)) return contents;
-  const block = [
+  const lines = [
     '',
     APP_GRADLE_MARKER,
-    '// Workspace voice modules expose ReactPackage (not Module) classes,',
-    "// so they can't be auto-added via expo-module.config.json's",
-    '// android.modules without breaking ExpoModulesPackageList.java',
-    '// compilation. Instead we register the gradle project deps here so',
-    "// :app's compile classpath sees the workspace AARs at compile time.",
-    '// Generated by withKiaanSakhaVoicePackages.js.',
+    '// Workspace voice ReactPackage modules registered manually (see',
+    '// settings.gradle injection above and withKiaanSakhaVoicePackages.js',
+    '// header for why autolinker is bypassed).',
     'dependencies {',
-    ...APP_GRADLE_DEPS.map((dep) => `    ${dep}`),
+    ...WORKSPACE_MODULES.map((m) => `    implementation project(':${m.name}')`),
     '}',
     APP_GRADLE_MARKER_END,
     '',
-  ].join('\n');
-  return contents.replace(/\s*$/, '\n') + block + '\n';
+  ];
+  return contents.replace(/\s*$/, '\n') + lines.join('\n') + '\n';
 }
 
 const withKiaanSakhaVoicePackages = (config) => {
-  // 1. Patch MainApplication.kt with imports + packages.add() calls.
+  // 1. settings.gradle — add the two workspace modules as gradle subprojects.
+  config = withSettingsGradle(config, (cfg) => {
+    if (cfg.modResults.language !== 'groovy') return cfg;
+    cfg.modResults.contents = appendSettingsGradleIncludes(cfg.modResults.contents);
+    return cfg;
+  });
+
+  // 2. app/build.gradle — add `implementation project(...)` deps.
+  config = withAppBuildGradle(config, (cfg) => {
+    if (cfg.modResults.language !== 'groovy') return cfg;
+    cfg.modResults.contents = appendGradleDependencies(cfg.modResults.contents);
+    return cfg;
+  });
+
+  // 3. MainApplication.kt — inject imports + packages.add() calls so the
+  //    three ReactPackage classes get registered at runtime.
   config = withMainApplication(config, (cfg) => {
     if (cfg.modResults.language !== 'kt') return cfg;
     let contents = cfg.modResults.contents;
@@ -138,13 +196,6 @@ const withKiaanSakhaVoicePackages = (config) => {
     contents = addPackageRegistration(contents, SAKHA_ADD);
     contents = addPackageRegistration(contents, FG_ADD);
     cfg.modResults.contents = contents;
-    return cfg;
-  });
-
-  // 2. Append `implementation project(...)` to app/build.gradle.
-  config = withAppBuildGradle(config, (cfg) => {
-    if (cfg.modResults.language !== 'groovy') return cfg;
-    cfg.modResults.contents = appendGradleDependencies(cfg.modResults.contents);
     return cfg;
   });
 

--- a/kiaanverse-mobile/native/kiaan-voice/android/build.gradle
+++ b/kiaanverse-mobile/native/kiaan-voice/android/build.gradle
@@ -1,4 +1,17 @@
-// KIAAN Voice Native — Expo-autolinked Android library.
+// KIAAN Voice Native — manually-registered Android library.
+//
+// REGISTRATION MODEL: this module is NOT autolinked. There is
+// deliberately no expo-module.config.json at the workspace root.
+// Instead, the `withKiaanSakhaVoicePackages` config plugin
+// (apps/mobile/plugins/withKiaanSakhaVoicePackages.js) injects the
+// `include ':kiaanverse-kiaan-voice-native'` line + projectDir mapping
+// into apps/mobile/android/settings.gradle, plus the matching
+// `implementation project(...)` dep into app/build.gradle and the
+// runtime `packages.add(KiaanVoicePackage())` line into
+// MainApplication.kt. See that plugin's header for why autolinker is
+// bypassed (pnpm symlink causing dual-discovery → AGP namespace
+// collision → the long-running `Unresolved reference: sakha` build
+// failure).
 //
 // The KIAAN tier-1 voice Kotlin lives in this module's standard
 // `src/main/java/com/mindvibe/kiaan/voice/` tree:
@@ -9,33 +22,14 @@
 //   • KiaanEngineOrchestrator     — Friend/Guidance/Navigation engines
 //   • KiaanVoicePackage           — ReactPackage registration target
 //
-// The sources are intentionally co-located with the gradle module that
-// builds them. An earlier layout pulled them in via a relative
-// `java.srcDirs += '../../../../native/android/voice/kiaan'` reaching
-// out of the kiaanverse-mobile workspace tree — that worked locally
-// (whole repo on disk) but on EAS Build the relative path resolved to
-// a non-existent directory, kotlinc happily produced an empty AAR, and
-// :app:compileReleaseKotlin then failed resolving
-// `com.mindvibe.kiaan.voice.*` because the AAR shipped with zero
-// classes. Co-locating the sources eliminates that whole class of
-// "silent empty AAR" failures.
-//
 // The Sakha persona-specific Kotlin lives in the sibling
-// `kiaanverse-mobile/native/sakha-voice/android/` module and is owned
-// by @kiaanverse/sakha-voice-native. The two source trees are
-// physically disjoint so kotlinc cannot accidentally compile Sakha
-// sources into this .aar — Step 54 fix for the R8 duplicate-class
-// error where `java.exclude '**/sakha/**'` was honored by javac but
-// ignored by kotlinc, producing PauseEvent$Filter / VerseSegment /
-// etc. in BOTH .aar files and triggering R8 dex-merge collisions.
-//
-// Built as part of `eas build --profile production --platform android`
-// (signed .aab) when apps/mobile depends on @kiaanverse/kiaan-voice-native.
-// The Expo autolinker discovers this via the sibling
-// expo-module.config.json and registers it in settings.gradle. The
-// `withKiaanSakhaVoicePackages` config plugin then injects the matching
-// `implementation project(...)` dep into apps/mobile/android/app/build.gradle
-// and patches MainApplication.kt to register KiaanVoicePackage at runtime.
+// `kiaanverse-mobile/native/sakha-voice/android/` module. The two
+// source trees are physically disjoint so kotlinc cannot accidentally
+// compile Sakha sources into this .aar — Step 54 fix for the R8
+// duplicate-class error where `java.exclude '**/sakha/**'` was honored
+// by javac but ignored by kotlinc, producing PauseEvent$Filter /
+// VerseSegment / etc. in BOTH .aar files and triggering R8 dex-merge
+// collisions.
 //
 // Pattern mirrors kiaanverse-mobile/native/sakha-voice/android/build.gradle
 // so AGP / Kotlin / JVM versions stay consistent.

--- a/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/kiaan-voice/expo-module.config.json
@@ -1,6 +1,0 @@
-{
-  "platforms": ["android"],
-  "android": {
-    "modules": []
-  }
-}

--- a/kiaanverse-mobile/native/sakha-voice/android/build.gradle
+++ b/kiaanverse-mobile/native/sakha-voice/android/build.gradle
@@ -1,4 +1,17 @@
-// Sakha Voice Native — Expo-autolinked Android library.
+// Sakha Voice Native — manually-registered Android library.
+//
+// REGISTRATION MODEL: this module is NOT autolinked. There is
+// deliberately no expo-module.config.json at the workspace root.
+// Instead, the `withKiaanSakhaVoicePackages` config plugin
+// (apps/mobile/plugins/withKiaanSakhaVoicePackages.js) injects the
+// `include ':kiaanverse-sakha-voice-native'` line + projectDir mapping
+// into apps/mobile/android/settings.gradle, plus the matching
+// `implementation project(...)` dep into app/build.gradle and the
+// runtime `packages.add(SakhaVoicePackage())` line into
+// MainApplication.kt. See that plugin's header for why autolinker is
+// bypassed (pnpm symlink causing dual-discovery → AGP namespace
+// collision → the long-running `Unresolved reference: sakha` build
+// failure).
 //
 // The Sakha persona Kotlin lives in this module's standard
 // `src/main/java/com/mindvibe/kiaan/voice/sakha/` tree:
@@ -12,25 +25,6 @@
 //   • SakhaPersonaGuard           — guardrail filter
 //   • SakhaTypes / SakhaDictation / SakhaVerseReader / SakhaWakeWordDetector
 //   • WakeWordMatcher
-//
-// The sources are intentionally co-located with the gradle module that
-// builds them. An earlier layout pulled them in via a relative
-// `java.srcDirs += '../../../../native/android/voice/sakha'` reaching
-// out of the kiaanverse-mobile workspace tree — that worked locally but
-// on EAS Build the relative path resolved to a non-existent directory,
-// kotlinc happily produced an empty AAR, and :app:compileReleaseKotlin
-// then failed with "Unresolved reference: sakha" because the AAR
-// shipped with zero classes. Co-locating the sources eliminates that
-// whole class of "silent empty AAR" failures.
-//
-// Built as part of `eas build --profile production --platform android`
-// (signed .aab). The Expo autolinker discovers this via the sibling
-// expo-module.config.json and includes it in the generated
-// settings.gradle automatically once the host app declares
-// @kiaanverse/sakha-voice-native as a workspace dep. The
-// `withKiaanSakhaVoicePackages` config plugin then injects the matching
-// `implementation project(...)` dep into apps/mobile/android/app/build.gradle
-// and patches MainApplication.kt to register SakhaVoicePackage at runtime.
 //
 // Pattern mirrors kiaanverse-mobile/native/kiaan-voice/android/build.gradle
 // so AGP / Kotlin / JVM versions stay consistent across the workspace's

--- a/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
+++ b/kiaanverse-mobile/native/sakha-voice/expo-module.config.json
@@ -1,6 +1,0 @@
-{
-  "platforms": ["android"],
-  "android": {
-    "modules": []
-  }
-}


### PR DESCRIPTION
## Summary

Definitive fix for the persistent `MainApplication.kt:19:23 Unresolved reference: sakha` Android build failure that survived **seven** prior fix attempts (PRs #1670–#1675 + commit `cb26c688`).

## Root cause (build #7 surfaced it)

In a pnpm monorepo, Expo's autolinker discovers each workspace voice module via **two paths**:
1. workspace path → `kiaanverse-mobile/native/{X}-voice/`
2. pnpm symlink → `apps/mobile/node_modules/@kiaanverse/{X}-voice-native/` (same dir)

Both have `expo-module.config.json` (the symlink mirrors the workspace). The autolinker emits two `settings.gradle` entries per module with **different name-mangling** (slash→`-` vs slash→`_`):

```
:kiaanverse-kiaan-voice-native     :kiaanverse_kiaan-voice-native
:kiaanverse-sakha-voice-native     :kiaanverse_sakha-voice-native
```

Build #7 log confirmed it explicitly:

```
Namespace 'com.mindvibe.kiaan.voice.sakha' is used in multiple modules and/or libraries:
  :kiaanverse_sakha-voice-native, :kiaanverse-sakha-voice-native.
```

AGP detects the namespace collision and prunes one set of classes from `:app`'s compile classpath. The pruned classes are exactly the ones `MainApplication.kt` imports → `Unresolved reference: sakha`.

## The fix — cut these modules out of the autolinker entirely

1. **Delete** `expo-module.config.json` from `kiaanverse-mobile/native/{kiaan,sakha}-voice/`. The autolinker now ignores these dirs at BOTH the workspace path AND the pnpm-symlink path. No double-discovery is possible.

2. **Extend** `withKiaanSakhaVoicePackages` config plugin with a new `withSettingsGradle` pass:
   ```groovy
   include ':kiaanverse-kiaan-voice-native', ':kiaanverse-sakha-voice-native'
   project(':kiaanverse-kiaan-voice-native').projectDir = file('../../../native/kiaan-voice/android')
   project(':kiaanverse-sakha-voice-native').projectDir = file('../../../native/sakha-voice/android')
   ```

3. Existing plugin behaviors preserved:
   - `withAppBuildGradle` → `implementation project(':...')` deps
   - `withMainApplication` → imports + `packages.add(...)` calls

## Why this prevents recurrence

The dual-discovery was a structural property of mixing Expo autolinker with a pnpm workspace where the same dir is reachable via two paths. The only definitive cure is to remove the modules from the autolinker's reach entirely. Without `expo-module.config.json`, there's no autolinker registration at all — one discovery path (the plugin), one gradle project, one AAR, one set of classes on `:app`'s classpath.

`build.gradle` headers in both workspace modules updated to document the manual-registration model.

## Test plan

- [ ] Build #8 (preview profile, --clear-cache) clears `:app:compileReleaseKotlin`
- [ ] Build log no longer shows `Namespace ... is used in multiple modules` warning for `com.mindvibe.kiaan.voice` / `com.mindvibe.kiaan.voice.sakha`
- [ ] Build log shows only ONE Kotlin compile per voice module (`:kiaanverse-{X}-voice-native:compileReleaseKotlin`, not the underscore-suffixed twin)
- [ ] Resulting `.apk` / `.aab` ships KiaanVoicePackage + SakhaVoicePackage + SakhaForegroundServicePackage
- [ ] App launches; SakhaVoiceModule registers without R8 stripping (proguard keeps already in place)

https://claude.ai/code/session_01H9YoG5EKB5GBz84hgTAhdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9YoG5EKB5GBz84hgTAhdg)_