### PR TITLE
fix(android): opt out of RN autolinker too — kill the second source of dual-registration

### DIFF
--- a/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
@@ -5,27 +5,36 @@
  *
  * The two workspace voice modules
  * (kiaanverse-mobile/native/{kiaan,sakha}-voice/android/) are deliberately
- * NOT discoverable by Expo's autolinker — there is no
- * `expo-module.config.json` at either workspace path. This is the
- * fix for the dual-registration bug:
+ * NOT discoverable by Expo's autolinker NOR React Native's autolinker.
+ * Both opt-out files are co-located with each workspace module:
  *
- *   In a pnpm workspace, the autolinker finds each module twice:
- *     1. via the workspace path (kiaanverse-mobile/native/{X}-voice/)
- *     2. via the pnpm symlink (apps/mobile/node_modules/@kiaanverse/{X}-voice-native/)
- *   Both paths point at the same source tree, but the autolinker mangles
- *   the gradle project name differently for each (slash→`-` vs slash→`_`),
- *   so settings.gradle ends up with TWO entries per module:
- *     :kiaanverse-{X}-voice-native   AND   :kiaanverse_{X}-voice-native
- *   Both AARs build with the same Android `namespace`, AGP detects the
- *   namespace collision, and one set of classes gets pruned from :app's
- *   compile classpath. The result was the persistent
- *   `Unresolved reference: sakha` failure at :app:compileReleaseKotlin
- *   across builds #1 through #7.
+ *   • Expo autolinker — opt-out via the absence of `expo-module.config.json`
+ *   • RN autolinker   — opt-out via `react-native.config.js` declaring
+ *                       `dependency.platforms.{android,ios}: null`
  *
- * Removing the autolinker hook (deleting `expo-module.config.json` from
- * both workspace dirs) eliminates double-discovery at the source. This
- * plugin then takes over the three registration responsibilities the
- * autolinker would otherwise have done:
+ * This is the fix for the dual-registration bug that produced builds
+ * #1 through #8's persistent `Unresolved reference: sakha` failure:
+ *
+ *   In a pnpm workspace, each voice module is reachable via TWO paths:
+ *     1. workspace path: kiaanverse-mobile/native/{X}-voice/
+ *     2. pnpm symlink:   apps/mobile/node_modules/@kiaanverse/{X}-voice-native/
+ *   Both autolinkers (Expo via expo-module.config.json, RN via
+ *   android/build.gradle detection in node_modules) would each register
+ *   the SAME source dir as TWO gradle projects with different name-
+ *   mangling — `:kiaanverse-{X}-voice-native` (slash→`-`) and
+ *   `:kiaanverse_{X}-voice-native` (slash→`_`). Both AARs build with
+ *   the same Android `namespace`, AGP detects the namespace collision,
+ *   prunes one set of classes from :app's compile classpath, and
+ *   :app:compileReleaseKotlin fails because MainApplication.kt's
+ *   imports point at the pruned classes.
+ *
+ *   Build #7 confirmed Expo autolinker as one source.
+ *   Build #8 confirmed RN autolinker as the OTHER source — even after
+ *   the Expo opt-out landed, the duplicate `:kiaanverse_*` projects
+ *   were still being added by RN autolinker through the pnpm symlink.
+ *
+ * With BOTH autolinkers opted out, this plugin takes over the three
+ * registration responsibilities:
  *
  *   1. withSettingsGradle — appends
  *        include ':kiaanverse-kiaan-voice-native', ':kiaanverse-sakha-voice-native'

--- a/kiaanverse-mobile/native/kiaan-voice/android/build.gradle
+++ b/kiaanverse-mobile/native/kiaan-voice/android/build.gradle
@@ -1,17 +1,23 @@
 // KIAAN Voice Native — manually-registered Android library.
 //
-// REGISTRATION MODEL: this module is NOT autolinked. There is
-// deliberately no expo-module.config.json at the workspace root.
+// REGISTRATION MODEL: this module is NOT autolinked by EITHER Expo or
+// React Native autolinkers. Both opt-outs live in this directory:
+//
+//   • Expo autolinker — opt-out via the absence of
+//     `expo-module.config.json` at the workspace root.
+//   • RN autolinker   — opt-out via `react-native.config.js` declaring
+//     `dependency.platforms.{android,ios}: null`.
+//
 // Instead, the `withKiaanSakhaVoicePackages` config plugin
 // (apps/mobile/plugins/withKiaanSakhaVoicePackages.js) injects the
 // `include ':kiaanverse-kiaan-voice-native'` line + projectDir mapping
 // into apps/mobile/android/settings.gradle, plus the matching
 // `implementation project(...)` dep into app/build.gradle and the
 // runtime `packages.add(KiaanVoicePackage())` line into
-// MainApplication.kt. See that plugin's header for why autolinker is
-// bypassed (pnpm symlink causing dual-discovery → AGP namespace
-// collision → the long-running `Unresolved reference: sakha` build
-// failure).
+// MainApplication.kt. See that plugin's header for why both
+// autolinkers had to be bypassed (pnpm symlink causing dual-discovery
+// → AGP namespace collision → the long-running
+// `Unresolved reference: sakha` build failure).
 //
 // The KIAAN tier-1 voice Kotlin lives in this module's standard
 // `src/main/java/com/mindvibe/kiaan/voice/` tree:

--- a/kiaanverse-mobile/native/kiaan-voice/react-native.config.js
+++ b/kiaanverse-mobile/native/kiaan-voice/react-native.config.js
@@ -1,0 +1,34 @@
+/**
+ * React Native autolinker opt-out for @kiaanverse/kiaan-voice-native.
+ *
+ * RN autolinking (`react-native config`) scans every package under
+ * apps/mobile/node_modules/ for an android/build.gradle and registers
+ * each match as a gradle subproject — using slash-to-underscore name
+ * mangling on scoped packages. Because this workspace lives at
+ * `kiaanverse-mobile/native/kiaan-voice/` AND is symlinked into
+ * `apps/mobile/node_modules/@kiaanverse/kiaan-voice-native/` by pnpm,
+ * the auto-registration would add a duplicate gradle project
+ * `:kiaanverse_kiaan-voice-native` alongside the manually-registered
+ * `:kiaanverse-kiaan-voice-native` (added by the
+ * withKiaanSakhaVoicePackages config plugin in apps/mobile/plugins/).
+ *
+ * Both AARs would build with namespace `com.mindvibe.kiaan.voice`,
+ * AGP would detect the namespace collision, and one set of classes
+ * would be pruned from :app's compile classpath — manifesting as
+ * `Unresolved reference: sakha` at :app:compileReleaseKotlin.
+ *
+ * Setting `dependency.platforms.{android,ios}: null` tells RN
+ * autolinking that this package has NO native dependencies for those
+ * platforms, so it skips them. Combined with the absence of
+ * expo-module.config.json (which keeps the Expo autolinker out), this
+ * package is invisible to all autolinkers — registration only happens
+ * through the explicit settings.gradle injection in the config plugin.
+ */
+module.exports = {
+  dependency: {
+    platforms: {
+      android: null,
+      ios: null,
+    },
+  },
+};

--- a/kiaanverse-mobile/native/sakha-voice/android/build.gradle
+++ b/kiaanverse-mobile/native/sakha-voice/android/build.gradle
@@ -1,17 +1,23 @@
 // Sakha Voice Native — manually-registered Android library.
 //
-// REGISTRATION MODEL: this module is NOT autolinked. There is
-// deliberately no expo-module.config.json at the workspace root.
+// REGISTRATION MODEL: this module is NOT autolinked by EITHER Expo or
+// React Native autolinkers. Both opt-outs live in this directory:
+//
+//   • Expo autolinker — opt-out via the absence of
+//     `expo-module.config.json` at the workspace root.
+//   • RN autolinker   — opt-out via `react-native.config.js` declaring
+//     `dependency.platforms.{android,ios}: null`.
+//
 // Instead, the `withKiaanSakhaVoicePackages` config plugin
 // (apps/mobile/plugins/withKiaanSakhaVoicePackages.js) injects the
 // `include ':kiaanverse-sakha-voice-native'` line + projectDir mapping
 // into apps/mobile/android/settings.gradle, plus the matching
 // `implementation project(...)` dep into app/build.gradle and the
 // runtime `packages.add(SakhaVoicePackage())` line into
-// MainApplication.kt. See that plugin's header for why autolinker is
-// bypassed (pnpm symlink causing dual-discovery → AGP namespace
-// collision → the long-running `Unresolved reference: sakha` build
-// failure).
+// MainApplication.kt. See that plugin's header for why both
+// autolinkers had to be bypassed (pnpm symlink causing dual-discovery
+// → AGP namespace collision → the long-running
+// `Unresolved reference: sakha` build failure).
 //
 // The Sakha persona Kotlin lives in this module's standard
 // `src/main/java/com/mindvibe/kiaan/voice/sakha/` tree:

--- a/kiaanverse-mobile/native/sakha-voice/react-native.config.js
+++ b/kiaanverse-mobile/native/sakha-voice/react-native.config.js
@@ -1,0 +1,29 @@
+/**
+ * React Native autolinker opt-out for @kiaanverse/sakha-voice-native.
+ *
+ * Same rationale as kiaanverse-mobile/native/kiaan-voice/react-native.config.js.
+ * RN autolinking would otherwise create a duplicate
+ * `:kiaanverse_sakha-voice-native` gradle project (via the pnpm
+ * symlink at apps/mobile/node_modules/@kiaanverse/sakha-voice-native/),
+ * conflicting with the manually-registered
+ * `:kiaanverse-sakha-voice-native` from the
+ * withKiaanSakhaVoicePackages config plugin. Both AARs would carry
+ * namespace `com.mindvibe.kiaan.voice.sakha`, AGP would prune one,
+ * and :app:compileReleaseKotlin would fail with
+ * `Unresolved reference: sakha`.
+ *
+ * Setting `dependency.platforms.{android,ios}: null` tells RN
+ * autolinking that this package has NO native dependencies for those
+ * platforms, so it skips them. Combined with the absence of
+ * expo-module.config.json, this package is invisible to all
+ * autolinkers — registration only happens through the explicit
+ * settings.gradle injection in the config plugin.
+ */
+module.exports = {
+  dependency: {
+    platforms: {
+      android: null,
+      ios: null,
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Build #8 (after PR #1676 merged) **still failed** with `Unresolved reference: sakha`. The Expo autolinker was clean — **but React Native's autolinker** was still discovering the workspace voice modules via the pnpm symlink and creating duplicate `:kiaanverse_{X}-voice-native` gradle projects.

This PR adds the missing RN autolinker opt-out.

## Root cause (build #8)

PR #1676 cut the workspace voice modules out of Expo's autolinker. Build #8's "Using expo modules" header confirmed Expo was clean. But the **identical** AGP namespace collision warning still fired:

```
[:kiaanverse_sakha-voice-native] .../merged_manifest/release/AndroidManifest.xml Warning:
Namespace 'com.mindvibe.kiaan.voice.sakha' is used in multiple modules and/or libraries:
  :kiaanverse_sakha-voice-native, :kiaanverse-sakha-voice-native.
```

Source: **`react-native config`** — RN's own autolinker. RN autolinking scans `apps/mobile/node_modules/` for any package with `android/build.gradle` and registers each as a gradle subproject, mangling scoped names slash→`_` (`@kiaanverse/sakha-voice-native` → `kiaanverse_sakha-voice-native`). Since pnpm symlinks the workspace voice modules into `apps/mobile/node_modules/@kiaanverse/`, RN autolinker sees them and creates duplicates next to the manually-registered ones from our config plugin.

## The fix

Add `react-native.config.js` to each workspace voice module declaring no native deps for either platform — RN autolinking's standard opt-out:

```js
module.exports = {
  dependency: {
    platforms: {
      android: null,
      ios: null,
    },
  },
};
```

Combined with PR #1676's Expo opt-out (no `expo-module.config.json`), each workspace voice module is now invisible to **BOTH autolinkers**. Registration only happens through the explicit `settings.gradle` injection in `withKiaanSakhaVoicePackages`.

One discovery path → one gradle project → one AAR → one set of classes on `:app`'s compile classpath.

## Files

- **NEW** `kiaanverse-mobile/native/kiaan-voice/react-native.config.js`
- **NEW** `kiaanverse-mobile/native/sakha-voice/react-native.config.js`
- **MOD** `kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js` (header refresh — call out RN autolinker as the build #8 culprit)
- **MOD** `kiaanverse-mobile/native/{kiaan,sakha}-voice/android/build.gradle` (header refresh — document both opt-outs)

## Test plan

- [ ] Build #9 (preview profile, `--clear-cache`) clears `:app:compileReleaseKotlin`
- [ ] Build log shows **only** `:kiaanverse-{X}-voice-native:` (hyphen) tasks — no `:kiaanverse_{X}-voice-native:` (underscore) variants
- [ ] No `Namespace ... is used in multiple modules` warning for `com.mindvibe.kiaan.voice` / `com.mindvibe.kiaan.voice.sakha`
- [ ] Resulting `.apk` / `.aab` ships KiaanVoicePackage + SakhaVoicePackage + SakhaForegroundServicePackage
- [ ] App launches; SakhaVoiceModule registers without R8 stripping (proguard keeps already in place)

https://claude.ai/code/session_01H9YoG5EKB5GBz84hgTAhdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9YoG5EKB5GBz84hgTAhdg)_