### PR TITLE
test(voice): repair voice test suite + cross-validators after PR #1677

### DIFF
--- a/kiaanverse-mobile/apps/mobile/scripts/test-pure-helpers.mjs
+++ b/kiaanverse-mobile/apps/mobile/scripts/test-pure-helpers.mjs
@@ -14,7 +14,7 @@ import { dirname, resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const SOURCE = resolve(__dirname, '..', 'hooks', 'voice', 'useToolInvocation.ts');
+const SOURCE = resolve(__dirname, '..', 'voice', 'hooks', 'useToolInvocation.ts');
 
 // Strip TS types and React imports to extract just the two helpers.
 // We're not running a real TS compiler here — just pulling the function

--- a/kiaanverse-mobile/apps/mobile/scripts/validate-plugins.mjs
+++ b/kiaanverse-mobile/apps/mobile/scripts/validate-plugins.mjs
@@ -28,12 +28,17 @@ const PLUGINS = [
 
 const stub = {
   withAndroidManifest: (config, modifier) => {
+    // Match the real Expo runtime: modResults is the full XML root with a
+    // top-level `manifest` key. Plugins like withKiaanForegroundService
+    // need `modResults.manifest.queries` — passing the inner manifest only
+    // breaks the speech-recognition <queries> patch.
     const fakeManifest = {
       manifest: {
         application: [{ $: {}, service: [], 'meta-data': [] }],
+        queries: [],
       },
     };
-    modifier({ ...config, modResults: fakeManifest.manifest });
+    modifier({ ...config, modResults: fakeManifest });
     return config;
   },
   withStringsXml: (config, modifier) => {

--- a/kiaanverse-mobile/apps/mobile/scripts/validate-tool-contracts.mjs
+++ b/kiaanverse-mobile/apps/mobile/scripts/validate-tool-contracts.mjs
@@ -27,7 +27,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const TS_PATH = resolve(__dirname, '..', 'lib', 'tool-prefill-contracts.ts');
+const TS_PATH = resolve(__dirname, '..', 'voice', 'lib', 'tool-prefill-contracts.ts');
 // repo root is 4 levels up from apps/sakha-mobile/scripts/
 const PY_PATH = resolve(
   __dirname, '..', '..', '..', '..',

--- a/kiaanverse-mobile/apps/mobile/scripts/validate-wss-types.mjs
+++ b/kiaanverse-mobile/apps/mobile/scripts/validate-wss-types.mjs
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const TS_PATH = resolve(__dirname, '..', 'lib', 'wss-types.ts');
+const TS_PATH = resolve(__dirname, '..', 'voice', 'lib', 'wss-types.ts');
 // repo root is 4 levels up from apps/sakha-mobile/scripts/
 const PY_PATH = resolve(
   __dirname,

--- a/tests/unit/test_prompt_loader.py
+++ b/tests/unit/test_prompt_loader.py
@@ -38,10 +38,18 @@ def _reset_cache():
     reset_cache_for_tests()
 
 
+def _expected_persona_version() -> str:
+    """Read the source-of-truth persona-version file at test time so the
+    suite stays green across persona bumps without hand-editing every
+    assertion (the loader's cross-version-check still guarantees the two
+    prompt files agree with this pin)."""
+    return PERSONA_VERSION_FILE.read_text(encoding="utf-8").strip()
+
+
 class TestPersonaVersion:
     def test_version_is_pinned_semver(self):
         v = get_persona_version()
-        assert v == "1.0.0"
+        assert v == _expected_persona_version()
 
     def test_version_is_cached(self):
         v1 = get_persona_version()
@@ -55,20 +63,22 @@ class TestPersonaVersion:
 
 class TestGetPersona:
     def test_voice_persona_loads(self):
+        expected = _expected_persona_version()
         p = get_persona("voice")
         assert p.render_mode == "voice"
-        assert p.persona_version == "1.0.0"
-        assert "1.0.0" in p.text
+        assert p.persona_version == expected
+        assert expected in p.text
         assert len(p.text) > 1000
         assert len(p.sha256) == 64
         assert str(SAKHA_VOICE_PROMPT) == p.source_path
 
     def test_text_persona_loads(self):
+        expected = _expected_persona_version()
         p = get_persona("text")
         assert p.render_mode == "text"
-        assert p.persona_version == "1.0.0"
+        assert p.persona_version == expected
         assert "**Ancient Wisdom Principle:**" in p.text
-        assert "1.0.0" in p.text
+        assert expected in p.text
 
     def test_persona_is_cached_and_immutable(self):
         a = get_persona("voice")
@@ -120,7 +130,7 @@ class TestResetCacheGuard:
         # After reset, a new load should succeed and yield a new instance
         # (different identity than any object captured before reset).
         p2 = get_persona("voice")
-        assert p2.persona_version == "1.0.0"
+        assert p2.persona_version == _expected_persona_version()
 
 
 class TestThreadSafety:

--- a/tests/unit/test_voice_quota_endpoint.py
+++ b/tests/unit/test_voice_quota_endpoint.py
@@ -16,7 +16,14 @@ from fastapi import FastAPI  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 from backend.routes.voice_quota import router  # noqa: E402
-from backend.services.prompt_loader import reset_cache_for_tests  # noqa: E402
+from backend.services.prompt_loader import (  # noqa: E402
+    PERSONA_VERSION_FILE,
+    reset_cache_for_tests,
+)
+
+
+def _live_persona_version() -> str:
+    return PERSONA_VERSION_FILE.read_text(encoding="utf-8").strip()
 from backend.services.voice.quota_service import (  # noqa: E402
     get_voice_quota_service,
 )
@@ -47,7 +54,7 @@ class TestPersonaVersionEndpoint:
         r = client.get("/api/voice/persona-version")
         assert r.status_code == 200
         data = r.json()
-        assert data["persona_version"] == "1.0.0"
+        assert data["persona_version"] == _live_persona_version()
         assert data["schema_version"] == "1.0.0"
         assert data["subprotocol"] == "kiaan-voice-v1"
         assert data["server_loaded_at_iso"].startswith("20")  # ISO 8601 UTC
@@ -127,7 +134,7 @@ class TestQuotaEndpoint:
 
     def test_persona_version_in_response(self, client):
         r = client.get("/api/voice/quota?user_id=u-q-bhakta&tier=bhakta")
-        assert r.json()["persona_version"] == "1.0.0"
+        assert r.json()["persona_version"] == _live_persona_version()
 
     def test_missing_user_id_is_422(self, client):
         r = client.get("/api/voice/quota")

--- a/tests/unit/test_voice_wss_endpoint.py
+++ b/tests/unit/test_voice_wss_endpoint.py
@@ -24,11 +24,14 @@ from fastapi import FastAPI  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 from backend.routes.voice_companion_wss import router  # noqa: E402
+from backend.services.prompt_loader import PERSONA_VERSION_FILE  # noqa: E402
 from backend.services.voice.stt_router import MockSTTProvider  # noqa: E402
 from backend.services.voice.tts_router import get_tts_router  # noqa: E402
 from backend.services.voice.wss_frames import SCHEMA_VERSION, SUBPROTOCOL  # noqa: E402
 
-PERSONA_VERSION = "1.0.0"
+# Read live from disk so persona bumps don't break the suite. The loader's
+# cross-version-check still guarantees the prompt files agree with this.
+PERSONA_VERSION = PERSONA_VERSION_FILE.read_text(encoding="utf-8").strip()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Repairs the voice CI gate after the build-fix series (#1670–#1677) merged. Three sets of stale references broke 14 of 177 unit tests + 1 plugin smoke test + 2 cross-validators. **No production code touched** — test/validator harness only.

## Why these tests were failing on main

| Group | Count | Root cause |
|---|---:|---|
| Persona-version pinned tests | 14 | `prompts/persona-version` was bumped `1.0.0` → `1.2.0` alongside the voice work; tests hardcoded the old pin. Fixed by reading the source-of-truth file at test time so future bumps don't break the suite. The loader's cross-version-check still guarantees the two prompt files agree. |
| Cross-validator path drift | 3 scripts | `apps/sakha-mobile/` was deleted; validators moved to `apps/mobile/scripts/` but still referenced `apps/mobile/lib/{wss-types,tool-prefill-contracts}.ts`. Files now live under `apps/mobile/voice/lib/` and `apps/mobile/voice/hooks/`. |
| Plugin smoke harness shape mismatch | 1 plugin | `withKiaanForegroundService.ensureSpeechQueries()` reaches for `modResults.manifest.queries` (Android 11+ `<queries>` for `android.speech.RecognitionService` package visibility — required for `SakhaVoiceModule.dictateOnce()` to find the on-device `SpeechRecognizer`). Smoke harness was passing inner manifest only; real Expo runtime passes the full XML root wrapper. |

## Test status after this PR

- **177 / 177** voice unit tests pass (was 163/177)
- **15 / 15** real-provider tests pass (`tests/unit/test_voice_real_providers.py`)
- **100 / 100** prompt regression cases (50 voice + 50 text)
- **17 / 17** WSS frame types match TS↔Python
- **15 / 15** tool contracts match TS↔Python
- **3 / 3** Expo plugins smoke-test green
- All pure-helper assertions green (`computeNavDelay` + `downgradeIfLowConfidence`)

**Total: 312 / 312 automated checks pass.**

## Files changed (7)

- `tests/unit/test_prompt_loader.py` — read live persona-version
- `tests/unit/test_voice_quota_endpoint.py` — same
- `tests/unit/test_voice_wss_endpoint.py` — same
- `kiaanverse-mobile/apps/mobile/scripts/validate-wss-types.mjs` — `lib/` → `voice/lib/`
- `kiaanverse-mobile/apps/mobile/scripts/validate-tool-contracts.mjs` — same
- `kiaanverse-mobile/apps/mobile/scripts/test-pure-helpers.mjs` — `hooks/voice/` → `voice/hooks/`
- `kiaanverse-mobile/apps/mobile/scripts/validate-plugins.mjs` — wrap modResults to match real Expo runtime, seed `queries: []`

## Test plan

- [x] `python3 /tmp/run_all_voice_tests.py` → 177/177 pass
- [x] `python3 /tmp/run_real_provider_tests.py` → 15/15 pass
- [x] `python3 scripts/run_sakha_regression.py --offline --render-mode=voice` → 50/50
- [x] `python3 scripts/run_sakha_regression.py --offline --render-mode=text` → 50/50
- [x] `node apps/mobile/scripts/validate-wss-types.mjs` → 17 frames match
- [x] `node apps/mobile/scripts/validate-tool-contracts.mjs` → 15 contracts match
- [x] `node apps/mobile/scripts/validate-plugins.mjs` → 3 plugins green
- [x] `node apps/mobile/scripts/test-pure-helpers.mjs` → all helpers green

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_