### PR TITLE
chore(release): bump app version 1.3.1 → 1.3.2 for the next AAB

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app.config.ts
+++ b/kiaanverse-mobile/apps/mobile/app.config.ts
@@ -11,27 +11,49 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: 'Kiaanverse',
   slug: 'kiaanverse',
-  // 1.3.1 ships the Relationship Compass Android-release crash fix:
-  //   • R8/Proguard keep rules for react-native-svg, react-native-reanimated,
-  //     gesture-handler, lottie and the Hermes Intl bridge (without these the
-  //     Compass radar + compass-rose chambers crash the JNI bridge with
-  //     NoClassDefFoundError on the first render of the screen);
-  //   • Hermes-safe date formatting in the Seal + Gita Counsel chambers
-  //     (Intl.DateTimeFormat / toLocaleDateString were aborting render);
-  //   • numeric-only animated props for the SVG chamber animations in both
-  //     Relationship Compass (CompassRose, DharmaRadar) and Karma Reset
-  //     (KarmaSealMandala) — animating SVG transform strings via
-  //     useAnimatedProps was NPE-ing react-native-svg's ViewManager off
-  //     the UI thread;
-  //   • Hermes-safe sentence splitter in useCompassWisdom (the previous
-  //     regex used lookbehind + Unicode property escapes, both unsupported
-  //     by Hermes — every API response was being silently swapped for the
-  //     offline fallback because the regex literal threw SyntaxError).
-  // 1.3.0 bundled native additions (expo-document-picker, Sakha chat).
-  // runtimeVersion: { policy: 'appVersion' } scopes OTAs to `version`, so
-  // bumping prevents expo-updates from pushing the new JS to the broken
-  // 1.3.0 APK. The matching versionCode bump is required by Play.
-  version: '1.3.1',
+  // 1.3.2 ships the Voice Companion + Profile completion bundle:
+  //   • Voice navigation: TOOL_ROUTES now match real Expo Router paths
+  //     (PR-G #1679) — 9 of 15 tools used to 404 on voice-driven nav.
+  //     Visible-confirmation banner shows on every prefill destination.
+  //     Sacred Reflections EditorTab seeds from voice dictation.
+  //   • Ambient voice presence (PR-H #1680): root-mounted FAB +
+  //     opt-in "Hey Sakha" wake word, route-suppressed on auth /
+  //     onboarding / voice-companion. Sakha is now ambient, not
+  //     screen-bound.
+  //   • Production hardening (PR-I #1682): native FGS type now
+  //     correctly bitwise-ORs MICROPHONE | MEDIA_PLAYBACK so
+  //     Android 14+ doesn't SecurityException when the service
+  //     records mic in foreground. Voice screen now uses the
+  //     authenticated user.id instead of an anonymous device UUID
+  //     (cross-device + post-signup quotas now correct). Picovoice
+  //     access key no longer baked into the AAB until a Kotlin
+  //     reader exists.
+  //   • Voice nav prefill stringification hotfix (#1681): production
+  //     AAB used to silently strip every voice prefill payload because
+  //     expo-router serialises params via String() — useToolInvocation
+  //     now JSON.stringifies before navigate.
+  //   • Legal screens repaired (PR-J #1683 + PR-K #1684): Privacy
+  //     Policy, Terms of Service, Data & Privacy, Help Center, and
+  //     Contact Us all reachable from Profile (the (app)/* group
+  //     prefix in route strings was 404'ing every Profile menu
+  //     entry on production). Contact email unified to
+  //     sacredquest2@gmail.com everywhere. Help Center has a 9-FAQ
+  //     reference + crisis callout. Contact Us has 7 categorised
+  //     mailto buttons + crisis callout.
+  //
+  // The native FGS type fix is the reason for the version bump (not
+  // an OTA-eligible change) — runtimeVersion: { policy: 'appVersion' }
+  // scopes OTAs to `version`, so bumping forces 1.3.2 to ship as a
+  // fresh APK rather than letting JS-only changes drift into the
+  // 1.3.1 install via expo-updates. The matching versionCode bump
+  // is handled automatically by EAS (autoIncrement: true in
+  // eas.json's production profile).
+  //
+  // 1.3.1 shipped the Relationship Compass Android-release crash fix
+  // (R8 keep rules, Hermes-safe date formatting, numeric SVG props,
+  // Hermes-safe regex). 1.3.0 bundled native additions
+  // (expo-document-picker, Sakha chat).
+  version: '1.3.2',
   orientation: 'portrait',
   icon: './assets/icon.png',
   scheme: 'kiaanverse',


### PR DESCRIPTION
## Summary

Bumps the app SemVer from **1.3.1 → 1.3.2** to ship the Voice Companion + Profile completion bundle (PRs #1679, #1680, #1681, #1682, #1683, #1684) as a fresh APK / AAB.

PR-I (#1682) included a **native Kotlin change** (FGS type bitwise-OR fix). Native changes cannot ship as an OTA update because `runtimeVersion: { policy: 'appVersion' }` scopes OTA delivery to the matching `version` string — the SemVer bump forces a fresh installable rather than letting JS-only changes drift onto 1.3.1 devices while the native fix sits unused.

`versionCode` left untouched at 22 because EAS's production profile in `eas.json` uses `autoIncrement: true` + `appVersionSource: "remote"` — Expo's build server bumps it automatically for each production build. Touching it locally would only collide.

## What ships in 1.3.2

### Voice Companion (Sakha)
- ✅ Voice navigation actually lands — `TOOL_ROUTES` matches real Expo Router paths (#1679); 9 of 15 tools used to 404
- ✅ Sakha is **ambient** — root-mounted FAB + opt-in "Hey Sakha" wake word (#1680)
- ✅ Sacred Reflections seeds journal body from voice dictation (#1679)
- ✅ Native foreground service ORs `MICROPHONE | MEDIA_PLAYBACK` so Android 14+ doesn't `SecurityException` (#1682)
- ✅ Voice quotas / telemetry / crisis incidents track authenticated `user.id` (not anonymous device UUID) (#1682)
- ✅ Picovoice key no longer baked into the AAB until a Kotlin reader exists (#1682)
- ✅ Voice nav prefill stringification hotfix — production-AAB-only silent prefill drop fixed (#1681)

### Profile + Legal
- ✅ All 8 Profile menu routes repaired — Privacy / Terms / Data & Privacy / Help Center / Contact Us / Edit Profile / Change Password / Language / Notifications / My Subscription / Upgrade Plan all reachable (#1683 + #1684)
- ✅ Two new screens — Help Center (9-FAQ + crisis callout) and Contact Us (7 categorised mailto + crisis callout) (#1684)
- ✅ Contact email unified to **`sacredquest2@gmail.com`** everywhere
- ✅ Subscription Plans Terms / Privacy links repointed to in-app routes
- ⏸️ Billing History temporarily removed (no backend support yet)

## Pre-build test status

- **177 / 177** voice unit tests pass
- **15 / 15** real-provider tests pass
- **50 + 50** prompt regression cases pass
- **17 / 17** WSS frame parity
- **15 / 15** tool prefill contract parity
- **3 / 3** Expo plugins smoke green
- All pure-helper assertions green
- `app.config.ts` parses clean

## Ship checklist (post-merge)

1. **Verify Render env** — `OPENAI_API_KEY`, `KIAAN_SARVAM_API_KEY`, `KIAAN_ELEVENLABS_API_KEY` set on the production service.
2. **Clear local Metro cache:**
   ```bash
   cd kiaanverse-mobile/apps/mobile
   rm -rf .expo node_modules/.cache
   ```
3. **Trigger EAS build with `--clear-cache`** so the build server wipes its node_modules + Gradle + JS bundle:
   ```bash
   eas build --platform android --profile production --clear-cache
   ```
4. **Submit to Play Store:**
   ```bash
   eas submit --platform android --profile production --latest
   ```
5. **Smoke after install:**
   - Voice nav → ambient FAB visible on home + tools tabs
   - All 8 Profile menu items open their screen (no "Unmatched Route")
   - Privacy / Terms / Data & Privacy / Help / Contact each show content with `sacredquest2@gmail.com`
   - Voice → "open Ardha and reframe my thought about work" → expect Ardha screen with the visible-confirmation banner + thought field seeded

## Files

- `kiaanverse-mobile/apps/mobile/app.config.ts` (version + release-notes comment)

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_