### PR TITLE
fix(android): plugin must inject add() inside .apply{} block — RN 0.74 template doesn't have val packages = ...

### DIFF
--- a/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
@@ -62,7 +62,7 @@ const { withMainApplication } = require('@expo/config-plugins');
 
 const FG_IMPORT =
   'import com.kiaanverse.sakha.audio.SakhaForegroundServicePackage';
-const FG_ADD = 'packages.add(SakhaForegroundServicePackage())';
+const FG_ADD = 'add(SakhaForegroundServicePackage())';
 
 function addImport(contents, importLine) {
   if (contents.includes(importLine)) return contents;
@@ -76,14 +76,48 @@ function addImport(contents, importLine) {
 
 function addPackageRegistration(contents, addLine) {
   if (contents.includes(addLine)) return contents;
-  // Expo SDK 51's MainApplication.kt template has:
-  //   val packages = PackageList(this).packages
-  //   // Packages that cannot be autolinked yet can be added manually here, ...
-  //   return packages
-  // We insert our packages.add(...) call right after the val declaration.
-  return contents.replace(
-    /(val\s+packages\s*=\s*PackageList\(this\)\.packages)/,
-    `$1\n          ${addLine}`,
+  // Expo SDK 51's MainApplication.kt template (inherited from React Native
+  // 0.74's template) generates:
+  //
+  //   override fun getPackages(): List<ReactPackage> =
+  //       PackageList(this).packages.apply {
+  //         // Packages that cannot be autolinked yet can be added manually here, for example:
+  //         // add(MyReactNativePackage())
+  //       }
+  //
+  // We inject `add(SakhaForegroundServicePackage())` inside that .apply{}
+  // block, right after the opening brace and before the placeholder
+  // comment line. The closure receiver in `.apply { ... }` is the
+  // MutableList<ReactPackage>, so `add(...)` resolves to its `add` method.
+  //
+  // The previous regex looked for `val packages = PackageList(this).packages`
+  // which was a different style — that style does NOT appear in the SDK 51
+  // template, so the previous regex silently matched nothing and the
+  // SakhaForegroundServicePackage was never registered. This regex matches
+  // the actual template form.
+  const applyMatch = contents.match(/PackageList\(this\)\.packages\.apply\s*\{\s*\n/);
+  if (applyMatch) {
+    const insertAt = applyMatch.index + applyMatch[0].length;
+    const indent = '          ';
+    return contents.slice(0, insertAt) + `${indent}${addLine}\n` + contents.slice(insertAt);
+  }
+  // Fallback for the older `val packages = ...` style (e.g. if Expo
+  // changes the template in a future SDK or a developer customized
+  // MainApplication.kt manually):
+  const valMatch = contents.match(/val\s+packages\s*=\s*PackageList\(this\)\.packages/);
+  if (valMatch) {
+    const insertAt = valMatch.index + valMatch[0].length;
+    return contents.slice(0, insertAt) + `\n          packages.${addLine}` + contents.slice(insertAt);
+  }
+  // If neither pattern matches, we cannot proceed silently — fail loudly
+  // so the build surfaces the problem instead of producing an APK that
+  // boots without SakhaForegroundService registered.
+  throw new Error(
+    '[withKiaanSakhaVoicePackages] Could not find an injection point in ' +
+    'MainApplication.kt for `add(SakhaForegroundServicePackage())`. ' +
+    'Expected either `PackageList(this).packages.apply { ... }` or ' +
+    '`val packages = PackageList(this).packages`. Inspect the prebuild ' +
+    'output and update this plugin if Expo changed the template.',
   );
 }
 


### PR DESCRIPTION
## TL;DR

Defensive pre-flight catch on top of #1694. Without this fix, the next EAS build would **succeed** but `SakhaForegroundService` would never register at runtime — background audio playback would die as soon as the app loses focus.

## What I found during pre-flight verification

I simulated the plugin's `MainApplication.kt` patch against the actual React Native 0.74 template (the one Expo SDK 51 prebuild uses verbatim — there's NO separate Expo template; verified by `find node_modules -name MainApplication.kt` returning only RN's path).

The template's `getPackages()` body uses `.apply{}` closure form:

```kotlin
override fun getPackages(): List<ReactPackage> =
    PackageList(this).packages.apply {
      // Packages that cannot be autolinked yet can be added manually here, for example:
      // add(MyReactNativePackage())
    }
```

But the plugin's `addPackageRegistration` regex was looking for:

```kotlin
val packages = PackageList(this).packages
```

That form **does not exist** in the SDK 51 template. The regex matched nothing → `packages.add(SakhaForegroundServicePackage())` was silently NOT injected. This was a latent bug masked by the `Unresolved reference: sakha` failures from PRs #1686-#1689 — the build never got far enough to expose it.

## The fix

Updated `addPackageRegistration` to:

1. **Match `PackageList(this).packages.apply {`** (SDK 51's actual form) and inject `add(SakhaForegroundServicePackage())` inside the closure. The `.apply{}` receiver is the `MutableList<ReactPackage>`, so bare `add(...)` resolves to the list's add method without needing a `packages.` prefix.

2. **Fall back to the older `val packages = PackageList(this).packages`** form for forward-compat in case Expo changes the template.

3. **Throw a loud error if NEITHER pattern matches**, rather than failing silently. Better to fail prebuild than ship an APK without FGS registered.

Also updated `FG_ADD` constant from `packages.add(...)` to `add(...)` — inside `.apply{}` the explicit receiver is wrong; bare `add(...)` is correct.

## Local verification

```
$ node simulate-plugin-against-rn-template.js
→ Has FG import:                      true
→ Has FG add inside .apply:           true
→ Idempotency (re-run does not dupe): true
```

Patched MainApplication.kt body:

```kotlin
override fun getPackages(): List<ReactPackage> =
    PackageList(this).packages.apply {
      add(SakhaForegroundServicePackage())
      // Packages that cannot be autolinked yet can be added manually here, for example:
      // add(MyReactNativePackage())
    }
```

```
$ node scripts/validate-plugins.mjs
→ 3 plugins OK (withKiaanForegroundService, withKiaanAudioFocus, withPicovoice)

$ node scripts/validate-wss-types.mjs
→ 17 frame types match

$ node scripts/validate-tool-contracts.mjs
→ 15 tools match across TS + Python
```

## Files

- `kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js` — updated regex + FG_ADD constant + fail-loud fallback (1 file, +43/-9)

## Next EAS build

Once merged:

```bash
cd kiaanverse-mobile/apps/mobile
eas build --platform android --profile production --clear-cache
```

`--clear-cache` is critical — wipes the EAS server's cached `node_modules` and gradle build dirs from the 9 previous failed builds.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_