### PR TITLE
fix(eas): nuke stale @kiaanverse voice-native symlinks in pre/post-install — EAS cache leftover from pre-PR-#1696 builds

### DIFF
--- a/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
@@ -5,19 +5,19 @@
 #   - postinstall script:       ./scripts/patch-expo-modules-core.js
 #   - Expo config plugin:       ./plugins/with-expo-modules-core-patch.js
 #
-# Single nuke here: expo-in-app-purchases (legacy Gradle-8.8-incompat package).
+# Two nukes:
 #
-# NOTE: PR #1689 removed the previous voice-native symlink nuke. The voice
-# native packages (@kiaanverse/{kiaan,sakha}-voice-native) are now expected
-# in apps/mobile/node_modules — pnpm hoists them as workspace packages and
-# the autolinker uses them to register :kiaanverse_{X}-voice-native gradle
-# modules. We need them present, not removed.
+#   1. expo-in-app-purchases (legacy Gradle-8.8-incompat package).
+#
+#   2. @kiaanverse/{kiaan,sakha}-voice-native symlinks (LEGACY scoped
+#      names — renamed to unscoped in PR #1696). Belt-and-braces with
+#      eas-build-pre-install.sh: if pnpm install somehow re-materialises
+#      a stale scoped symlink between the pre-install nuke and now, this
+#      catches it before the autolinker scans node_modules.
 #
 # We do NOT `set -e` so transient find / rm errors can't fail the build.
 
 log() { echo "[eas-post-install] $*"; }
-
-log "Purging expo-in-app-purchases from all node_modules trees..."
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || SCRIPT_DIR="."
 CANDIDATES=(
@@ -26,10 +26,31 @@ CANDIDATES=(
   "/home/expo/workingdir"
 )
 
+# ─── 1. expo-in-app-purchases (legacy Gradle-8.8-incompat package) ───────
+log "Purging expo-in-app-purchases from all node_modules trees..."
 for root in "${CANDIDATES[@]}"; do
   [ -n "$root" ] && [ -d "$root" ] || continue
   find "$root" \
     -type d -name "expo-in-app-purchases" -path "*/node_modules/*" \
+    -exec rm -rf {} + 2>/dev/null || true
+done
+
+# ─── 2. Stale @kiaanverse/{kiaan,sakha}-voice-native symlinks ────────────
+log "Purging any stale @kiaanverse-scoped voice-native symlinks..."
+for root in "${CANDIDATES[@]}"; do
+  [ -n "$root" ] && [ -d "$root" ] || continue
+
+  # Direct paths first (canonical pnpm hoist locations).
+  rm -rf "$root/node_modules/@kiaanverse/kiaan-voice-native" 2>/dev/null || true
+  rm -rf "$root/node_modules/@kiaanverse/sakha-voice-native" 2>/dev/null || true
+  rm -rf "$root/apps/mobile/node_modules/@kiaanverse/kiaan-voice-native" 2>/dev/null || true
+  rm -rf "$root/apps/mobile/node_modules/@kiaanverse/sakha-voice-native" 2>/dev/null || true
+
+  # Sweep every node_modules tree as a backstop.
+  find "$root" \
+    \( -type d -o -type l \) \
+    \( -name "kiaan-voice-native" -o -name "sakha-voice-native" \) \
+    -path "*/node_modules/@kiaanverse/*" \
     -exec rm -rf {} + 2>/dev/null || true
 done
 

--- a/kiaanverse-mobile/apps/mobile/eas-build-pre-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-pre-install.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 # eas-build-pre-install.sh — runs BEFORE pnpm install on the EAS server.
 #
-# Single nuke: expo-in-app-purchases (legacy). The package breaks Gradle 8.8
-# due to a removed `classifier` property. Always purge.
+# Two nukes:
 #
-# NOTE: PR #1689 removed the previous voice-native symlink nuke. The voice
-# native packages (@kiaanverse/{kiaan,sakha}-voice-native) are now expected
-# in apps/mobile/node_modules — pnpm hoists them as workspace packages and
-# the autolinker uses them to register :kiaanverse_{X}-voice-native gradle
-# modules. The plugin no longer registers its own duplicate gradle module,
-# so there's no symlink to fight against.
+#   1. expo-in-app-purchases (legacy Gradle-8.8-incompat package). Always purge.
+#
+#   2. @kiaanverse/{kiaan,sakha}-voice-native symlinks (LEGACY scoped names —
+#      renamed to unscoped `kiaanverse-{kiaan,sakha}-voice-native` in PR #1696
+#      to fix the autolinker name-mangling collision between RN and Expo).
+#
+#      EAS Build aggressively caches `node_modules` across builds. After the
+#      rename, pnpm install creates the NEW unscoped symlinks but does NOT
+#      necessarily delete the OLD scoped ones from the cache — so EAS ends up
+#      with BOTH:
+#         apps/mobile/node_modules/@kiaanverse/{kiaan,sakha}-voice-native  (stale)
+#         apps/mobile/node_modules/kiaanverse-{kiaan,sakha}-voice-native   (current)
+#
+#      Both get registered as DIFFERENT gradle modules pointing at the SAME
+#      source through the symlinks → AGP namespace collision → build death.
+#      This nuke runs BEFORE pnpm install so any stale @kiaanverse-scoped
+#      voice-native dirs are gone before the autolinker scans node_modules.
 #
 # Idempotent: rm -rf on non-existent paths is a no-op.
 
@@ -17,6 +27,7 @@ set -e
 
 log() { echo "[eas-build-pre-install] $*"; }
 
+# ─── 1. expo-in-app-purchases (legacy Gradle-8.8-incompat package) ───────
 log "Removing expo-in-app-purchases from node_modules..."
 rm -rf "$EAS_BUILD_WORKINGDIR/kiaanverse-mobile/node_modules/expo-in-app-purchases" 2>/dev/null || true
 rm -rf "$EAS_BUILD_WORKINGDIR/node_modules/expo-in-app-purchases" 2>/dev/null || true
@@ -24,3 +35,37 @@ find "$EAS_BUILD_WORKINGDIR" \
   -type d -name "expo-in-app-purchases" -path "*/node_modules/*" \
   -exec rm -rf {} + 2>/dev/null || true
 log "expo-in-app-purchases removed"
+
+# ─── 2. Stale @kiaanverse/{kiaan,sakha}-voice-native symlinks (post-PR-#1696) ─
+log "Removing any stale @kiaanverse-scoped voice-native symlinks..."
+
+# Direct paths first (canonical pnpm hoist locations).
+for ROOT in \
+  "$EAS_BUILD_WORKINGDIR" \
+  "$EAS_BUILD_WORKINGDIR/kiaanverse-mobile" \
+  "$EAS_BUILD_WORKINGDIR/kiaanverse-mobile/apps/mobile"; do
+  [ -d "$ROOT" ] || continue
+  rm -rf "$ROOT/node_modules/@kiaanverse/kiaan-voice-native" 2>/dev/null || true
+  rm -rf "$ROOT/node_modules/@kiaanverse/sakha-voice-native" 2>/dev/null || true
+done
+
+# Sweep every node_modules tree as a backstop. Kill the symlink itself
+# (-type l) AND any real directory that might have been materialised at
+# any depth.
+find "$EAS_BUILD_WORKINGDIR" \
+  \( -type d -o -type l \) \
+  \( -name "kiaan-voice-native" -o -name "sakha-voice-native" \) \
+  -path "*/node_modules/@kiaanverse/*" \
+  -exec rm -rf {} + 2>/dev/null || true
+
+# Also wipe any cached gradle build/ output that might reference the
+# stale @kiaanverse-scoped paths — without this, the cached AAR could
+# resurrect at link time.
+find "$EAS_BUILD_WORKINGDIR" \
+  -type d -path "*/@kiaanverse/kiaan-voice-native/android/build" \
+  -exec rm -rf {} + 2>/dev/null || true
+find "$EAS_BUILD_WORKINGDIR" \
+  -type d -path "*/@kiaanverse/sakha-voice-native/android/build" \
+  -exec rm -rf {} + 2>/dev/null || true
+
+log "stale @kiaanverse voice-native symlinks removed"


### PR DESCRIPTION
## What build #12 (post-#1696) actually showed

PR #1696's package rename (`@kiaanverse/X-voice-native` → `kiaanverse-X-voice-native`) is correct — verified locally that fresh `pnpm install` creates only the new unscoped symlinks. But EAS Build #12 STILL failed with the same namespace collision because **EAS's cached node_modules from previous builds still contains the OLD `@kiaanverse/{kiaan,sakha}-voice-native` symlinks** alongside the new ones.

Build log evidence:
```
> Task :kiaanverse_sakha-voice-native:compileReleaseKotlin
w: file:///.../node_modules/@kiaanverse/sakha-voice-native/android/...   ← OLD path

> Task :kiaanverse-sakha-voice-native:compileReleaseKotlin
w: file:///.../native/sakha-voice/android/...                             ← NEW path

Namespace 'com.mindvibe.kiaan.voice.sakha' is used in multiple modules:
  :kiaanverse_sakha-voice-native, :kiaanverse-sakha-voice-native
```

Both registered → namespace collision → build dies (12th time).

## Root cause

EAS Build aggressively caches `node_modules` across builds. When PR #1696 renamed the packages, pnpm install on EAS:
- Created the NEW `kiaanverse-{kiaan,sakha}-voice-native` symlinks ✅
- Did NOT delete the OLD `@kiaanverse/{kiaan,sakha}-voice-native` symlinks left in the cache ❌

`--clear-cache` would fix this but isn't always sufficient at the workspace-package symlink level.

## The fix

Defensive nuke for `@kiaanverse/{kiaan,sakha}-voice-native` symlinks in **both** `eas-build-pre-install.sh` and `eas-build-post-install.sh`:

- **Pre-install**: removes stale symlinks BEFORE pnpm install runs.
- **Post-install**: belt-and-braces — catches any that re-materialise from a deeper cache layer.

This restores the same defensive pattern from PR #1688 (correctly removed in #1689 when the strategy was different — but needed again now because the actual package names changed in #1696, which is real cache-invalidation work EAS doesn't do automatically).

The legitimate `@kiaanverse/{api, i18n, store, ui}` packages are NOT touched.

## Local verification

```
$ rm -rf apps/mobile/node_modules/@kiaanverse/{kiaan,sakha}-voice-native \
        apps/mobile/node_modules/kiaanverse-{kiaan,sakha}-voice-native
$ pnpm install
$ ls apps/mobile/node_modules/ | grep voice
  → kiaanverse-kiaan-voice-native
  → kiaanverse-sakha-voice-native
$ ls apps/mobile/node_modules/@kiaanverse/
  → api  i18n  store  ui
  (no voice packages — confirmed)
```

## Files changed

- `kiaanverse-mobile/apps/mobile/eas-build-pre-install.sh` (+44/-7 lines)
- `kiaanverse-mobile/apps/mobile/eas-build-post-install.sh` (+30/-7 lines)

No source-code or plugin changes. Only the EAS shell hooks.

## Next EAS build

```bash
cd kiaanverse-mobile/apps/mobile
eas build --platform android --profile production --clear-cache
```

`--clear-cache` is still recommended to also wipe gradle's AAR cache (otherwise pre-rename cached AARs could resurface during the `bundleRelease` link step). With this PR, even without `--clear-cache`, the symlink-level stale state gets purged.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_