### PR TITLE
fix(android): remove voice modules from pnpm workspace — plugin becomes SOLE gradle module registrant

### DIFF
--- a/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-post-install.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 # eas-build-post-install.sh — runs AFTER pnpm install on the EAS server.
 #
-# The PermissionsService.kt patch for compileSdk 35 is applied by:
-#   - postinstall script:       ./scripts/patch-expo-modules-core.js
-#   - Expo config plugin:       ./plugins/with-expo-modules-core-patch.js
-#
-# Two nukes:
+# Three nukes (mirrors eas-build-pre-install.sh):
 #
 #   1. expo-in-app-purchases (legacy Gradle-8.8-incompat package).
+#   2. @kiaanverse/{kiaan,sakha}-voice-native (legacy scoped names).
+#   3. kiaanverse-{kiaan,sakha}-voice-native (legacy unscoped names).
 #
-#   2. @kiaanverse/{kiaan,sakha}-voice-native symlinks (LEGACY scoped
-#      names — renamed to unscoped in PR #1696). Belt-and-braces with
-#      eas-build-pre-install.sh: if pnpm install somehow re-materialises
-#      a stale scoped symlink between the pre-install nuke and now, this
-#      catches it before the autolinker scans node_modules.
+# Belt-and-braces with the pre-install nuke: if pnpm install somehow
+# re-materialises a stale voice-native symlink between pre-install and
+# now, this catches it before gradle's autolinker scans node_modules.
+#
+# Per PR #1698, voice modules are NOT pnpm workspace packages, so pnpm
+# install should never create symlinks for them. This belt-and-braces
+# is defense against any unexpected behavior.
 #
 # We do NOT `set -e` so transient find / rm errors can't fail the build.
 
@@ -26,7 +26,7 @@ CANDIDATES=(
   "/home/expo/workingdir"
 )
 
-# ─── 1. expo-in-app-purchases (legacy Gradle-8.8-incompat package) ───────
+# ─── 1. expo-in-app-purchases ────────────────────────────────────────────
 log "Purging expo-in-app-purchases from all node_modules trees..."
 for root in "${CANDIDATES[@]}"; do
   [ -n "$root" ] && [ -d "$root" ] || continue
@@ -35,22 +35,34 @@ for root in "${CANDIDATES[@]}"; do
     -exec rm -rf {} + 2>/dev/null || true
 done
 
-# ─── 2. Stale @kiaanverse/{kiaan,sakha}-voice-native symlinks ────────────
-log "Purging any stale @kiaanverse-scoped voice-native symlinks..."
+# ─── 2 + 3. ALL voice-native symlinks (scoped + unscoped) ────────────────
+log "Purging any voice-native symlinks (scoped + unscoped)..."
 for root in "${CANDIDATES[@]}"; do
   [ -n "$root" ] && [ -d "$root" ] || continue
 
-  # Direct paths first (canonical pnpm hoist locations).
+  # Scoped @kiaanverse/* (pre-PR-#1696)
   rm -rf "$root/node_modules/@kiaanverse/kiaan-voice-native" 2>/dev/null || true
   rm -rf "$root/node_modules/@kiaanverse/sakha-voice-native" 2>/dev/null || true
   rm -rf "$root/apps/mobile/node_modules/@kiaanverse/kiaan-voice-native" 2>/dev/null || true
   rm -rf "$root/apps/mobile/node_modules/@kiaanverse/sakha-voice-native" 2>/dev/null || true
 
-  # Sweep every node_modules tree as a backstop.
+  # Unscoped kiaanverse-* (post-PR-#1696, pre-PR-#1698)
+  rm -rf "$root/node_modules/kiaanverse-kiaan-voice-native" 2>/dev/null || true
+  rm -rf "$root/node_modules/kiaanverse-sakha-voice-native" 2>/dev/null || true
+  rm -rf "$root/apps/mobile/node_modules/kiaanverse-kiaan-voice-native" 2>/dev/null || true
+  rm -rf "$root/apps/mobile/node_modules/kiaanverse-sakha-voice-native" 2>/dev/null || true
+
+  # Sweep every node_modules tree.
   find "$root" \
     \( -type d -o -type l \) \
     \( -name "kiaan-voice-native" -o -name "sakha-voice-native" \) \
     -path "*/node_modules/@kiaanverse/*" \
+    -exec rm -rf {} + 2>/dev/null || true
+
+  find "$root" \
+    \( -type d -o -type l \) \
+    \( -name "kiaanverse-kiaan-voice-native" -o -name "kiaanverse-sakha-voice-native" \) \
+    -path "*/node_modules/*" \
     -exec rm -rf {} + 2>/dev/null || true
 done
 

--- a/kiaanverse-mobile/apps/mobile/eas-build-pre-install.sh
+++ b/kiaanverse-mobile/apps/mobile/eas-build-pre-install.sh
@@ -1,25 +1,22 @@
 #!/bin/bash
 # eas-build-pre-install.sh — runs BEFORE pnpm install on the EAS server.
 #
-# Two nukes:
+# Three nukes:
 #
 #   1. expo-in-app-purchases (legacy Gradle-8.8-incompat package). Always purge.
 #
-#   2. @kiaanverse/{kiaan,sakha}-voice-native symlinks (LEGACY scoped names —
-#      renamed to unscoped `kiaanverse-{kiaan,sakha}-voice-native` in PR #1696
-#      to fix the autolinker name-mangling collision between RN and Expo).
+#   2. @kiaanverse/{kiaan,sakha}-voice-native (LEGACY scoped name pre-PR-#1696).
 #
-#      EAS Build aggressively caches `node_modules` across builds. After the
-#      rename, pnpm install creates the NEW unscoped symlinks but does NOT
-#      necessarily delete the OLD scoped ones from the cache — so EAS ends up
-#      with BOTH:
-#         apps/mobile/node_modules/@kiaanverse/{kiaan,sakha}-voice-native  (stale)
-#         apps/mobile/node_modules/kiaanverse-{kiaan,sakha}-voice-native   (current)
+#   3. kiaanverse-{kiaan,sakha}-voice-native (post-#1696 unscoped name, also
+#      now stale per PR #1698 which removed `native/*` from pnpm-workspace.yaml).
 #
-#      Both get registered as DIFFERENT gradle modules pointing at the SAME
-#      source through the symlinks → AGP namespace collision → build death.
-#      This nuke runs BEFORE pnpm install so any stale @kiaanverse-scoped
-#      voice-native dirs are gone before the autolinker scans node_modules.
+# After PR #1698 the voice modules are NOT pnpm workspace packages anymore.
+# pnpm install should not create symlinks for them in any node_modules. But
+# EAS Build aggressively caches `node_modules` across builds, so any stale
+# symlinks from prior structures (PRs #1685-#1697) MUST be wiped before pnpm
+# install runs — otherwise the autolinker scans node_modules, finds them, and
+# registers gradle modules pointing at the same workspace source dir as our
+# plugin's explicit registration, producing AGP namespace collisions.
 #
 # Idempotent: rm -rf on non-existent paths is a no-op.
 
@@ -36,36 +33,45 @@ find "$EAS_BUILD_WORKINGDIR" \
   -exec rm -rf {} + 2>/dev/null || true
 log "expo-in-app-purchases removed"
 
-# ─── 2. Stale @kiaanverse/{kiaan,sakha}-voice-native symlinks (post-PR-#1696) ─
-log "Removing any stale @kiaanverse-scoped voice-native symlinks..."
+# ─── 2. ALL voice-native symlinks (scoped + unscoped) ────────────────────
+log "Removing any voice-native symlinks (scoped @kiaanverse/* and unscoped kiaanverse-*)..."
 
-# Direct paths first (canonical pnpm hoist locations).
+# Direct paths first.
 for ROOT in \
   "$EAS_BUILD_WORKINGDIR" \
   "$EAS_BUILD_WORKINGDIR/kiaanverse-mobile" \
   "$EAS_BUILD_WORKINGDIR/kiaanverse-mobile/apps/mobile"; do
   [ -d "$ROOT" ] || continue
+
+  # Scoped (pre-PR-#1696)
   rm -rf "$ROOT/node_modules/@kiaanverse/kiaan-voice-native" 2>/dev/null || true
   rm -rf "$ROOT/node_modules/@kiaanverse/sakha-voice-native" 2>/dev/null || true
+
+  # Unscoped (post-PR-#1696, pre-PR-#1698)
+  rm -rf "$ROOT/node_modules/kiaanverse-kiaan-voice-native" 2>/dev/null || true
+  rm -rf "$ROOT/node_modules/kiaanverse-sakha-voice-native" 2>/dev/null || true
 done
 
-# Sweep every node_modules tree as a backstop. Kill the symlink itself
-# (-type l) AND any real directory that might have been materialised at
-# any depth.
+# Sweep every node_modules tree as a backstop.
 find "$EAS_BUILD_WORKINGDIR" \
   \( -type d -o -type l \) \
   \( -name "kiaan-voice-native" -o -name "sakha-voice-native" \) \
   -path "*/node_modules/@kiaanverse/*" \
   -exec rm -rf {} + 2>/dev/null || true
 
-# Also wipe any cached gradle build/ output that might reference the
-# stale @kiaanverse-scoped paths — without this, the cached AAR could
-# resurrect at link time.
 find "$EAS_BUILD_WORKINGDIR" \
-  -type d -path "*/@kiaanverse/kiaan-voice-native/android/build" \
-  -exec rm -rf {} + 2>/dev/null || true
-find "$EAS_BUILD_WORKINGDIR" \
-  -type d -path "*/@kiaanverse/sakha-voice-native/android/build" \
+  \( -type d -o -type l \) \
+  \( -name "kiaanverse-kiaan-voice-native" -o -name "kiaanverse-sakha-voice-native" \) \
+  -path "*/node_modules/*" \
   -exec rm -rf {} + 2>/dev/null || true
 
-log "stale @kiaanverse voice-native symlinks removed"
+# Also wipe cached gradle build/ output for both naming conventions.
+find "$EAS_BUILD_WORKINGDIR" \
+  -type d \
+  \( -path "*/@kiaanverse/kiaan-voice-native/android/build" \
+     -o -path "*/@kiaanverse/sakha-voice-native/android/build" \
+     -o -path "*/kiaanverse-kiaan-voice-native/android/build" \
+     -o -path "*/kiaanverse-sakha-voice-native/android/build" \) \
+  -exec rm -rf {} + 2>/dev/null || true
+
+log "voice-native symlinks removed"

--- a/kiaanverse-mobile/apps/mobile/package.json
+++ b/kiaanverse-mobile/apps/mobile/package.json
@@ -34,8 +34,6 @@
     "@kiaanverse/i18n": "workspace:*",
     "@kiaanverse/store": "workspace:*",
     "@kiaanverse/ui": "workspace:*",
-    "kiaanverse-kiaan-voice-native": "workspace:*",
-    "kiaanverse-sakha-voice-native": "workspace:*",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/netinfo": "^11.3.1",
     "@sentry/react-native": "~5.33.0",

--- a/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
+++ b/kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js
@@ -1,68 +1,99 @@
 /**
  * withKiaanSakhaVoicePackages — Expo config plugin.
  *
- * MODEL: minimal MainApplication.kt patch for ONE non-autolinked package.
+ * MODEL: pure manual gradle library registration (post-PR-#1698).
  *
- * Registration topology (post the long native-build saga, builds 1–9):
+ * The voice native modules at kiaanverse-mobile/native/{kiaan,sakha}-voice/
+ * are NO LONGER pnpm workspace packages (PR #1698 removed `native/*` from
+ * pnpm-workspace.yaml). This means:
  *
- *   • @kiaanverse/kiaan-voice-native (workspace at native/kiaan-voice/)
- *     - Hoisted by pnpm to apps/mobile/node_modules/@kiaanverse/kiaan-voice-native
- *     - RN autolinker scans node_modules, finds android/build.gradle,
- *       registers `:kiaanverse_kiaan-voice-native` as a gradle subproject,
- *       auto-detects `KiaanVoicePackage` via cli-platform-android's
- *       findPackageClassName regex, and adds it to PackageList.java.
- *     - Runtime registration: handled by `PackageList(this).packages` in
- *       MainApplication.kt template — NO plugin patch needed.
+ *   • pnpm does not hoist them anywhere — no symlinks in node_modules
+ *   • RN autolinker cannot find them (it scans node_modules)
+ *   • Expo autolinker cannot find them either (no expo-module.config.json
+ *     in their workspace dirs, and not in node_modules anyway)
  *
- *   • @kiaanverse/sakha-voice-native (workspace at native/sakha-voice/)
- *     - Same as above. Autolinker registers `:kiaanverse_sakha-voice-native`
- *       and adds `SakhaVoicePackage` to PackageList.java.
- *     - Runtime registration: handled by PackageList — NO plugin patch.
+ * This plugin is therefore the SOLE registrant of the voice gradle modules
+ * AND the SOLE registrant of their ReactPackage classes in MainApplication.
  *
- *   • SakhaForegroundServicePackage (local module at apps/mobile/native/android/)
- *     - This module ships an `expo-module.config.json` declaring only
- *       `KiaanAudioPlayerPackage` as an Expo module. It does NOT live in
- *       node_modules, so RN autolinker never sees it. Expo's autolinker
- *       only auto-registers what's listed in expo-module.config.json.
- *     - SakhaForegroundServicePackage is a regular ReactPackage in the
- *       same source tree but not declared as an Expo module → no
- *       autolinker finds it.
- *     - Runtime registration: this plugin manually adds
- *       `add(SakhaForegroundServicePackage())` to MainApplication.kt.
+ * Three injections per build:
  *
- * Why we DON'T inject KiaanVoicePackage / SakhaVoicePackage here anymore:
+ *   1. withSettingsGradle — appends:
+ *        include ':kiaanverse-kiaan-voice-native', ':kiaanverse-sakha-voice-native'
+ *        project(':kiaanverse-kiaan-voice-native').projectDir = file(...)
+ *        project(':kiaanverse-sakha-voice-native').projectDir = file(...)
+ *      The relative path is resolved from the host android/ folder
+ *      (apps/mobile/android/), going up three levels to the kiaanverse-mobile
+ *      root and then into native/{X}-voice/android/.
  *
- *   We tried a long sequence of variants (PRs #1676, #1686, #1687, #1688,
- *   #1689) chasing the "Unresolved reference: sakha" / namespace-collision
- *   build failure. The terminal mistake was dual-registration — both the
- *   plugin and the autolinker registering the SAME source as different
- *   gradle modules pointing at the SAME directory through pnpm's symlink,
- *   which produced AGP namespace collision and processReleaseJavaRes races.
+ *   2. withAppBuildGradle — appends a fresh `dependencies { ... }` block
+ *      with `implementation project(':kiaanverse-{kiaan,sakha}-voice-native')`
+ *      so :app sees the two AARs at compile time. Multiple `dependencies { }`
+ *      blocks in one build.gradle are additive in Gradle, so this never
+ *      collides with the autolinker's block (which doesn't include voice
+ *      anyway since the autolinker can't see them).
  *
- *   PR #1689 fixed half of it (removed the plugin's gradle module
- *   injection) but left the per-package react-native.config.js
- *   `platforms.android: null` opt-outs in place — those make
- *   cli-platform-android's `dependencyConfig` return `null` for the
- *   package (verified in node_modules/@react-native-community/
- *   cli-platform-android/build/config/index.js), which means the
- *   autolinker ALSO skips registration. Net result post-PR-#1689: NO
- *   gradle module is registered, the AAR is never compiled, and
- *   MainApplication.kt's manual `import com.mindvibe.kiaan.voice.
- *   KiaanVoicePackage` fails to resolve.
+ *   3. withMainApplication — injects three imports and matching
+ *      `add(...)` calls inside `PackageList(this).packages.apply { ... }`
+ *      so the host app instantiates the ReactPackage classes at runtime:
+ *        com.mindvibe.kiaan.voice.KiaanVoicePackage
+ *        com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage
+ *        com.kiaanverse.sakha.audio.SakhaForegroundServicePackage
  *
- *   The fix (this PR) is to delete the per-package `react-native.config.js`
- *   files, let RN autolinker do its job (register gradle module + add to
- *   PackageList.java), and stop having the plugin add manual `add()`
- *   calls — those would now duplicate what's already in PackageList.
+ *      The third package (SakhaForegroundServicePackage) lives in the
+ *      LOCAL gradle module at apps/mobile/native/android/, which IS still
+ *      autolinked through that module's expo-module.config.json (which
+ *      ships KiaanAudioPlayerPackage as an Expo Module). We need the
+ *      add() line for the foreground-service package because it's a
+ *      regular ReactPackage, not an Expo Module — the autolinker's
+ *      generated PackageList doesn't auto-instantiate it.
+ *
+ * MainApplication.kt template handling: Expo SDK 51's prebuild generates
+ *
+ *   override fun getPackages(): List<ReactPackage> {
+ *     // ...comment...
+ *     return PackageList(this).packages
+ *   }
+ *
+ * (no .apply{} block, no `val packages = ...`). We rewrite the return
+ * to wrap in `.apply { add(...) }` so all three add() calls land inside
+ * the closure where the receiver is the MutableList<ReactPackage>.
  *
  * Idempotent — re-running prebuild does not duplicate any line.
  */
 
-const { withMainApplication } = require('@expo/config-plugins');
+const {
+  withMainApplication,
+  withAppBuildGradle,
+  withSettingsGradle,
+} = require('@expo/config-plugins');
 
-const FG_IMPORT =
-  'import com.kiaanverse.sakha.audio.SakhaForegroundServicePackage';
+const KIAAN_IMPORT = 'import com.mindvibe.kiaan.voice.KiaanVoicePackage';
+const SAKHA_IMPORT = 'import com.mindvibe.kiaan.voice.sakha.SakhaVoicePackage';
+const FG_IMPORT = 'import com.kiaanverse.sakha.audio.SakhaForegroundServicePackage';
+const KIAAN_ADD = 'add(KiaanVoicePackage())';
+const SAKHA_ADD = 'add(SakhaVoicePackage())';
 const FG_ADD = 'add(SakhaForegroundServicePackage())';
+
+/** Gradle module entries we register. `name` is the gradle project name
+ *  (used in `:<name>` references), `dir` is the relative path from the
+ *  host app's android/ folder (where settings.gradle lives) to the
+ *  workspace module's android/ folder. */
+const WORKSPACE_MODULES = [
+  {
+    name: 'kiaanverse-kiaan-voice-native',
+    dir: '../../../native/kiaan-voice/android',
+  },
+  {
+    name: 'kiaanverse-sakha-voice-native',
+    dir: '../../../native/sakha-voice/android',
+  },
+];
+
+/** Idempotent markers so re-running prebuild doesn't duplicate lines. */
+const SETTINGS_MARKER = '// kiaanverse-voice-native-modules:start';
+const SETTINGS_MARKER_END = '// kiaanverse-voice-native-modules:end';
+const APP_GRADLE_MARKER = '// kiaanverse-voice-native-deps:start';
+const APP_GRADLE_MARKER_END = '// kiaanverse-voice-native-deps:end';
 
 function addImport(contents, importLine) {
   if (contents.includes(importLine)) return contents;
@@ -74,59 +105,49 @@ function addImport(contents, importLine) {
   return contents.replace(/^(package\s+\S+)/m, `$1\n\n${importLine}`);
 }
 
-function addPackageRegistration(contents, addLine) {
-  if (contents.includes(addLine)) return contents;
-  // Expo SDK 51's MainApplication.kt template (post the ReactNativeHostWrapper
-  // injection that Expo prebuild applies on top of the RN 0.74 template) has
-  // the following getPackages body shape:
-  //
-  //   override fun getPackages(): List<ReactPackage> {
-  //     // Packages that cannot be autolinked yet can be added manually here, for example:
-  //     // packages.add(new MyReactNativePackage());
-  //     return PackageList(this).packages
-  //   }
-  //
-  // We need to convert `return PackageList(this).packages` into a form that
-  // lets us insert `add(...)` calls — wrap it in `.apply { ... }`:
-  //
-  //   return PackageList(this).packages.apply {
-  //     add(SakhaForegroundServicePackage())
-  //   }
-  //
-  // The .apply{} closure receiver is the MutableList<ReactPackage>, so bare
-  // `add(...)` resolves to the list's add method.
-  //
-  // We support three patterns to be resilient to Expo template changes:
-  //   1. Plain `return PackageList(this).packages` (SDK 51 actual)
-  //   2. Existing `PackageList(this).packages.apply { ... }` (RN 0.74 plain)
-  //   3. Older `val packages = PackageList(this).packages` (pre-0.74)
-  // If none match, throw — better to fail prebuild than ship an APK without
-  // SakhaForegroundService registered.
+function addAllPackageRegistrations(contents, addLines) {
+  // Skip if all already present.
+  if (addLines.every((line) => contents.includes(line))) return contents;
 
-  // Pattern 1: SDK 51 form — `return PackageList(this).packages` (no .apply, no val)
-  // Wrap the return in .apply{ add(...) }
+  // Pattern 1: SDK 51 form — `return PackageList(this).packages`
+  // Wrap in .apply{ add(...); add(...); ... }
   const returnMatch = contents.match(/return\s+PackageList\(this\)\.packages\s*$/m);
   if (returnMatch) {
+    const adds = addLines
+      .filter((line) => !contents.includes(line))
+      .map((line) => `            ${line}`)
+      .join('\n');
     return contents.replace(
       /return\s+PackageList\(this\)\.packages\s*$/m,
-      `return PackageList(this).packages.apply {\n            ${addLine}\n          }`,
+      `return PackageList(this).packages.apply {\n${adds}\n          }`,
     );
   }
-  // Pattern 2: existing .apply{} block — inject inside it
+
+  // Pattern 2: existing .apply{} block — inject inside it.
   const applyMatch = contents.match(/PackageList\(this\)\.packages\.apply\s*\{\s*\n/);
   if (applyMatch) {
     const insertAt = applyMatch.index + applyMatch[0].length;
-    return contents.slice(0, insertAt) + `            ${addLine}\n` + contents.slice(insertAt);
+    const adds = addLines
+      .filter((line) => !contents.includes(line))
+      .map((line) => `            ${line}\n`)
+      .join('');
+    return contents.slice(0, insertAt) + adds + contents.slice(insertAt);
   }
-  // Pattern 3: older `val packages = ...` form — inject after the val
+
+  // Pattern 3: older `val packages = ...` form.
   const valMatch = contents.match(/val\s+packages\s*=\s*PackageList\(this\)\.packages/);
   if (valMatch) {
     const insertAt = valMatch.index + valMatch[0].length;
-    return contents.slice(0, insertAt) + `\n          packages.${addLine}` + contents.slice(insertAt);
+    const adds = addLines
+      .filter((line) => !contents.includes(line))
+      .map((line) => `\n          packages.${line}`)
+      .join('');
+    return contents.slice(0, insertAt) + adds + contents.slice(insertAt);
   }
+
   throw new Error(
     '[withKiaanSakhaVoicePackages] Could not find an injection point in ' +
-    'MainApplication.kt for `add(SakhaForegroundServicePackage())`. ' +
+    'MainApplication.kt for voice ReactPackage add() calls. ' +
     'Expected `return PackageList(this).packages`, ' +
     '`PackageList(this).packages.apply { ... }`, or ' +
     '`val packages = PackageList(this).packages`. Inspect the prebuild ' +
@@ -134,12 +155,73 @@ function addPackageRegistration(contents, addLine) {
   );
 }
 
+/**
+ * Append `include ':...'` and `project(':...').projectDir = file('...')`
+ * to settings.gradle. Idempotent via SETTINGS_MARKER.
+ */
+function appendSettingsGradleIncludes(contents) {
+  if (contents.includes(SETTINGS_MARKER)) return contents;
+  const lines = [
+    '',
+    SETTINGS_MARKER,
+    '// Voice native modules (kiaanverse-mobile/native/{kiaan,sakha}-voice/)',
+    '// are NOT pnpm workspace packages and NOT autolinked by anything.',
+    '// We register them here as pure gradle library modules. Sources are',
+    '// at the workspace path; gradle reads them directly via projectDir.',
+    `include ${WORKSPACE_MODULES.map((m) => `':${m.name}'`).join(', ')}`,
+    ...WORKSPACE_MODULES.map(
+      (m) => `project(':${m.name}').projectDir = new File(rootProject.projectDir, '${m.dir}')`,
+    ),
+    SETTINGS_MARKER_END,
+    '',
+  ];
+  return contents.replace(/\s*$/, '\n') + lines.join('\n') + '\n';
+}
+
+/**
+ * Append a fresh `dependencies { ... }` block with the workspace
+ * project deps. Gradle merges multiple dependencies blocks additively.
+ * Idempotent via APP_GRADLE_MARKER.
+ */
+function appendGradleDependencies(contents) {
+  if (contents.includes(APP_GRADLE_MARKER)) return contents;
+  const lines = [
+    '',
+    APP_GRADLE_MARKER,
+    '// Voice native modules registered manually by',
+    '// withKiaanSakhaVoicePackages.js — see settings.gradle injection above.',
+    'dependencies {',
+    ...WORKSPACE_MODULES.map((m) => `    implementation project(':${m.name}')`),
+    '}',
+    APP_GRADLE_MARKER_END,
+    '',
+  ];
+  return contents.replace(/\s*$/, '\n') + lines.join('\n') + '\n';
+}
+
 const withKiaanSakhaVoicePackages = (config) => {
+  // 1. settings.gradle — register the two voice gradle modules.
+  config = withSettingsGradle(config, (cfg) => {
+    if (cfg.modResults.language !== 'groovy') return cfg;
+    cfg.modResults.contents = appendSettingsGradleIncludes(cfg.modResults.contents);
+    return cfg;
+  });
+
+  // 2. app/build.gradle — add `implementation project(...)` deps.
+  config = withAppBuildGradle(config, (cfg) => {
+    if (cfg.modResults.language !== 'groovy') return cfg;
+    cfg.modResults.contents = appendGradleDependencies(cfg.modResults.contents);
+    return cfg;
+  });
+
+  // 3. MainApplication.kt — inject imports + add() calls.
   config = withMainApplication(config, (cfg) => {
     if (cfg.modResults.language !== 'kt') return cfg;
     let contents = cfg.modResults.contents;
+    contents = addImport(contents, KIAAN_IMPORT);
+    contents = addImport(contents, SAKHA_IMPORT);
     contents = addImport(contents, FG_IMPORT);
-    contents = addPackageRegistration(contents, FG_ADD);
+    contents = addAllPackageRegistrations(contents, [KIAAN_ADD, SAKHA_ADD, FG_ADD]);
     cfg.modResults.contents = contents;
     return cfg;
   });

--- a/kiaanverse-mobile/pnpm-lock.yaml
+++ b/kiaanverse-mobile/pnpm-lock.yaml
@@ -139,12 +139,6 @@ importers:
       expo-updates:
         specifier: ~0.25.28
         version: 0.25.28(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))
-      kiaanverse-kiaan-voice-native:
-        specifier: workspace:*
-        version: link:../../native/kiaan-voice
-      kiaanverse-sakha-voice-native:
-        specifier: workspace:*
-        version: link:../../native/sakha-voice
       lottie-react-native:
         specifier: ^7.0.0
         version: 7.3.6(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -239,10 +233,6 @@ importers:
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
-
-  native/kiaan-voice: {}
-
-  native/sakha-voice: {}
 
   packages/api:
     dependencies:

--- a/kiaanverse-mobile/pnpm-workspace.yaml
+++ b/kiaanverse-mobile/pnpm-workspace.yaml
@@ -1,28 +1,38 @@
 packages:
   - 'apps/*'
   - 'packages/*'
-  - 'native/*'
-  # native/{kiaan,sakha}-voice/ are pnpm workspace packages so pnpm hoists
-  # them into apps/mobile/node_modules/@kiaanverse/. The RN/Expo autolinker
-  # finds them there and registers `:kiaanverse_{X}-voice-native` gradle
-  # modules automatically — we WANT this; it's how the Kotlin sources get
-  # compiled and linked.
+  # native/{kiaan,sakha}-voice/ are NOT pnpm workspace packages.
   #
-  # Earlier PRs (#1687, #1688) tried to PREVENT pnpm from hoisting these
-  # packages, in an attempt to stop the autolinker from registering them.
-  # That approach failed for two compounding reasons:
+  # WHY: When the voice modules were pnpm workspace packages, pnpm with
+  # shamefully-hoist=true + node-linker=hoisted aggressively hoisted them
+  # into apps/mobile/node_modules/. Both RN and Expo autolinkers then found
+  # them there and registered them as gradle modules — but with DIFFERENT
+  # name-mangling strategies:
   #
-  #   1. The repo's .npmrc has shamefully-hoist=true + node-linker=hoisted,
-  #      which keeps creating the symlinks regardless of structural changes.
-  #   2. Even with our changes merged, the EAS build server reused cached
-  #      node_modules and kept finding stale symlinks.
+  #   • RN autolinker:   slash → underscore  (e.g. :kiaanverse_X-voice-native)
+  #   • Expo autolinker: slash → hyphen      (e.g. :kiaanverse-X-voice-native)
   #
-  # The actual root cause was that `withKiaanSakhaVoicePackages` ALSO
-  # registered the same source as `:kiaanverse-{X}-voice-native` (hyphen)
-  # via settings.gradle, creating a duplicate gradle module pointing at
-  # the SAME directory through the symlink. Two modules → AGP namespace
-  # collision → process JAR resources race → build death.
+  # This produced TWO gradle modules pointing at the SAME source through
+  # the pnpm symlink → AGP namespace collision → :app:compileReleaseKotlin
+  # "Unresolved reference: sakha". Killed builds 1–13.
   #
-  # The real fix (PR #1689) removes the plugin's gradle injections and
-  # lets the autolinker own the gradle module. The plugin keeps only the
-  # MainApplication.kt patches.
+  # PR #1696 renamed the packages to unscoped names hoping both autolinkers
+  # would produce identical names. They DO locally, but EAS Build's cached
+  # node_modules from pre-rename builds preserved the OLD @kiaanverse-scoped
+  # symlinks alongside the new ones — same dual-registration, same death.
+  #
+  # PR #1697 added pre/post-install nukes for the @kiaanverse-scoped stale
+  # symlinks — but build #13 STILL showed both module sets, indicating the
+  # nuke either didn't run or pnpm install on EAS recreated some symlinks
+  # in ways we can't reliably control.
+  #
+  # The DEFINITIVE fix: take the voice modules OUT of pnpm's workspace
+  # entirely. Without `native/*` here, pnpm cannot hoist them, cannot create
+  # symlinks for them, and the autolinkers cannot find them in node_modules.
+  # The `withKiaanSakhaVoicePackages` plugin then becomes the SOLE registrant
+  # via direct settings.gradle injection with `projectDir` pointing at
+  # `../../../native/{X}-voice/android` (the workspace path, no symlinks).
+  #
+  # The Kotlin sources at kiaanverse-mobile/native/{kiaan,sakha}-voice/
+  # remain in place — gradle reads them directly through the projectDir
+  # mapping, no node_modules indirection.


### PR DESCRIPTION
## After 13 failed builds — the definitive structural fix

Build #13 (post-PRs #1696/#1697) STILL failed with the same dual-registration namespace collision. Build log evidence:

```
:kiaanverse_sakha-voice-native (RN underscore-mangled name for SCOPED @kiaanverse/...)
  sourceDir: node_modules/@kiaanverse/sakha-voice-native/...

:kiaanverse-sakha-voice-native (Expo hyphen-mangled / plugin name)
  sourceDir: native/sakha-voice/...
```

The @kiaanverse-scoped symlinks SOMEHOW persist on EAS Build despite our renames (#1696) and shell-level nukes (#1697) — likely because pnpm's content-addressed store reconstitutes them from cache.

## Root cause (final analysis)

The fundamental problem is that the voice packages were **pnpm workspace packages**. With `shamefully-hoist=true` + `node-linker=hoisted`, pnpm aggressively hoists workspace packages into `node_modules/`. Both autolinkers scan `node_modules/` and register them with **different name-mangling regexes**:

| Autolinker | Source | Mangling |
|---|---|---|
| RN (`cli-platform-android/native_modules.gradle:462`) | `replaceAll('^@([\\w-.]+)/', '$1_')` | slash → **underscore** |
| Expo (`expo-modules-autolinking/build/platforms/android.js:165`) | `.replace(/\W+/g, '-')` | slash → **hyphen** |

Different names = two gradle modules pointing at the SAME source via pnpm symlinks → AGP namespace collision → build dies. PRs #1696/#1697 tried to align names + nuke stale symlinks. Both were correct fixes but insufficient against EAS's pnpm-store caching.

## The definitive fix

**Take the voice modules OUT of pnpm's workspace entirely.** Without them in `pnpm-workspace.yaml`:

- pnpm cannot hoist them
- pnpm cannot create symlinks for them in any node_modules tree
- pnpm has no record of them in any cache

With nothing in `node_modules`:
- RN autolinker finds nothing (it scans `node_modules`)
- Expo autolinker finds nothing either
- **The plugin becomes the SOLE registrant**

Plugin's three injections:

1. **`withSettingsGradle`** — `include ':kiaanverse-{X}-voice-native'` + `projectDir` pointing at `../../../native/{X}-voice/android` (workspace path, no symlink)
2. **`withAppBuildGradle`** — `implementation project(':kiaanverse-{X}-voice-native')`
3. **`withMainApplication`** — wraps `return PackageList(this).packages` with `.apply { add(...) }` for all three voice ReactPackages

ONE registrant. ONE gradle module per voice package. AGP namespace collision is now **structurally impossible**.

## Local verification

```
$ pnpm install
  Done. No voice symlinks created.

$ ls apps/mobile/node_modules/@kiaanverse/
  api  i18n  store  ui                    ← only legitimate scoped pkgs

$ ls apps/mobile/node_modules/ | grep -iE 'kiaan|sakha|voice'
  @kiaanverse                              ← no top-level voice symlinks

$ npx expo prebuild --platform android --clean --no-install
  ✔ Finished prebuild

$ grep -n 'kiaanverse' android/settings.gradle
  include ':kiaanverse-kiaan-voice-native', ':kiaanverse-sakha-voice-native'
  project(':kiaanverse-kiaan-voice-native').projectDir = ...
  project(':kiaanverse-sakha-voice-native').projectDir = ...

$ node -e "const c=require('@react-native-community/cli').loadConfig(); ..."
  RN autolinker voice deps count: 0       ← cannot register what it can't see

Generated MainApplication.kt:
  override fun getPackages(): List<ReactPackage> {
    // ...comment...
    return PackageList(this).packages.apply {
      add(KiaanVoicePackage())
      add(SakhaVoicePackage())
      add(SakhaForegroundServicePackage())
    }
  }

$ node scripts/validate-plugins.mjs       → 3 plugins OK
```

## Files changed (6)

- `kiaanverse-mobile/pnpm-workspace.yaml` — remove `native/*` glob
- `kiaanverse-mobile/apps/mobile/package.json` — remove voice deps
- `kiaanverse-mobile/apps/mobile/plugins/withKiaanSakhaVoicePackages.js` — restore `withSettingsGradle` + `withAppBuildGradle` + multi-form `addAllPackageRegistrations`
- `kiaanverse-mobile/apps/mobile/eas-build-pre-install.sh` — defense-in-depth nukes for both scoped + unscoped voice symlinks
- `kiaanverse-mobile/apps/mobile/eas-build-post-install.sh` — same belt-and-braces
- `kiaanverse-mobile/pnpm-lock.yaml` — regenerated (no voice workspace entries)

## Next EAS build

```bash
cd kiaanverse-mobile/apps/mobile
eas build --platform android --profile production --clear-cache
```

**`--clear-cache` is STRONGLY recommended** — wipes EAS's pnpm-store and gradle caches that may still hold references to the prior structures from builds 1–13.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_