### PR TITLE
fix(android): swap ConcatenatingMediaSource2 → legacy CMS — fix build #19 Media3 API mismatch

### DIFF
--- a/kiaanverse-mobile/apps/mobile/native/android/build.gradle
+++ b/kiaanverse-mobile/apps/mobile/native/android/build.gradle
@@ -130,8 +130,14 @@ dependencies {
     // NOT as a Maven coordinate.)
 
     // AndroidX Media3 — the audio pipeline. ExoPlayer + DataSource +
-    // ProgressiveMediaSource. Locked to 1.4.x (Sakha tested against
-    // ConcatenatingMediaSource2 which lands in 1.4 stable).
+    // ProgressiveMediaSource + (legacy) ConcatenatingMediaSource.
+    // Locked to 1.4.x for the Sakha streaming TTS architecture, which
+    // appends Opus chunks to a live ConcatenatingMediaSource as they
+    // arrive over the WSS. ConcatenatingMediaSource2 (the 1.0+ Builder-
+    // only replacement) is immutable post-build, so it doesn't fit our
+    // runtime-append model — see KiaanAudioPlayerModule's class-level
+    // comment on `concatSource`. Build #19 caught this mismatch when
+    // the code tried to call addMediaSource() on a CMS2 instance.
     implementation "androidx.media3:media3-exoplayer:${MEDIA3_VERSION}"
     implementation "androidx.media3:media3-datasource:${MEDIA3_VERSION}"
     implementation "androidx.media3:media3-common:${MEDIA3_VERSION}"

--- a/kiaanverse-mobile/apps/mobile/native/android/src/main/java/com/kiaanverse/sakha/audio/KiaanAudioPlayerModule.kt
+++ b/kiaanverse-mobile/apps/mobile/native/android/src/main/java/com/kiaanverse/sakha/audio/KiaanAudioPlayerModule.kt
@@ -63,7 +63,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.source.ConcatenatingMediaSource2
+import androidx.media3.exoplayer.source.ConcatenatingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -116,7 +116,21 @@ class KiaanAudioPlayerModule(
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private var player: ExoPlayer? = null
-    private var concatSource: ConcatenatingMediaSource2? = null
+    // Why ConcatenatingMediaSource and NOT ConcatenatingMediaSource2:
+    // CMS2 (Media3 1.0+) is BUILDER-ONLY and IMMUTABLE post-build — it has
+    // no runtime `addMediaSource(int, MediaSource)`, only `Builder.add(...)`.
+    // Our streaming TTS architecture depends on appending each Opus chunk
+    // as it arrives over the WSS, so we need the legacy CMS which exposes
+    // `addMediaSource()` on the live instance. Build #19 failed with
+    // `Unresolved reference: addMediaSource` precisely because of this
+    // mismatch. CMS is `@UnstableApi` (covered by the class-level @OptIn)
+    // and `@Deprecated` since Media3 1.4 with no removal-version pinned —
+    // safe for the 1.x line we're using. If/when we migrate to Media3 2.0
+    // (which removes CMS), the right move is `player.addMediaSource()`
+    // directly, since the player has its own internal queue with the same
+    // API the code expects here.
+    @Suppress("DEPRECATION")
+    private var concatSource: ConcatenatingMediaSource? = null
     private var visualizer: Visualizer? = null
     private val rmsBuffer = ArrayDeque<Float>()
     @Volatile
@@ -145,7 +159,8 @@ class KiaanAudioPlayerModule(
                 .build()
                 .also { p ->
                     p.addListener(playbackListener)
-                    concatSource = ConcatenatingMediaSource2.Builder().build()
+                    @Suppress("DEPRECATION")
+                    concatSource = ConcatenatingMediaSource()
                     p.setMediaSource(concatSource!!)
                     p.prepare()
                     p.playWhenReady = false
@@ -402,7 +417,8 @@ class KiaanAudioPlayerModule(
             mainHandlerSync {
                 player?.stop()
                 player?.clearMediaItems()
-                concatSource = ConcatenatingMediaSource2.Builder().build()
+                @Suppress("DEPRECATION")
+                concatSource = ConcatenatingMediaSource()
                 player?.setMediaSource(concatSource!!)
                 player?.prepare()
                 nextSourceIndex = 0


### PR DESCRIPTION
## Summary

Build #19 went the furthest yet — the plugin chain from PR #1700 / #1701 worked end-to-end. From the build log:

```
[withKiaanSakhaVoicePackages] Registered in-tree gradle subproject
:kiaan-voice-native (projectDir=../native/android) and injected
4 imports + 4 ReactPackage add() calls into MainApplication.kt.
```

The plugin breadcrumb fired exactly as designed. Every other module compiled (Sentry, Skia, Lottie, Reanimated, Gesture-Handler, IAP, expo-modules-core, all 24 expo-* modules, async-storage, netinfo). Then ONE Kotlin compile error in our own voice library:

```
e: KiaanAudioPlayerModule.kt:326:31 Unresolved reference: addMediaSource
```

## Root cause

`ConcatenatingMediaSource2` (the Media3 1.0+ replacement for the legacy `ConcatenatingMediaSource`) is **Builder-only and IMMUTABLE post-build**. Its only public construction API is `Builder.add(MediaSource)` — there is no runtime `addMediaSource(int, MediaSource)` method on the built instance.

The Sakha streaming TTS architecture appends each Opus chunk to a live media source as it arrives over the WSS, so CMS2's immutable post-build contract doesn't fit. The legacy `ConcatenatingMediaSource` (without the `2`) DOES expose `addMediaSource(int, MediaSource)` on the live instance — exactly the API our code needs.

## Fix

4 surgical edits in `KiaanAudioPlayerModule.kt`:
- `import ConcatenatingMediaSource` (was `ConcatenatingMediaSource2`)
- field type `ConcatenatingMediaSource?`
- two construction sites: `ConcatenatingMediaSource()` (was `ConcatenatingMediaSource2.Builder().build()`)
- `addMediaSource(nextSourceIndex, src)` line **stays the same** — same signature on the legacy class

Plus inline documentation:
- Class-level comment on `concatSource` field explaining WHY we picked the legacy class, the Media3 2.0 migration path (use `player.addMediaSource()` directly when CMS is removed in 2.0), and a reference to build #19 so a future engineer doesn't "modernize" by reverting.
- `@Suppress("DEPRECATION")` at field + each construction site (CMS is `@Deprecated` since Media3 1.4 with no removal version pinned in the 1.x line).
- `build.gradle` dependency-block comment updated with same reasoning.

## Comprehensive Media3 audit

`KiaanAudioPlayerModule.kt` is the **only** file in the voice library that touches Media3 (verified via `grep -l "androidx.media3"`). Every other Media3 API surface used in this file is stable across 1.0-1.4 and unchanged in 1.4.1:

- `ExoPlayer.Builder().setAudioAttributes().setWakeMode().build()`
- `AudioAttributes.Builder().setContentType().setUsage().build()`
- `Player.Listener` interface + `Player.STATE_*` constants
- `ProgressiveMediaSource.Factory(DataSource.Factory).createMediaSource(MediaItem)`
- `DefaultDataSource.Factory(Context)`
- `MediaItem.fromUri(Uri)`
- `player.setMediaSource() / prepare() / stop() / clearMediaItems()`

## Deeper API-surface audit (no further fixes needed)

After fixing the Media3 issue, audited every third-party API call across all 22 voice Kotlin files. All clean:

| Surface | Verdict |
|---|---|
| TFLite 2.14.0 (`Interpreter`, `NnApiDelegate`, `GpuDelegate`, `Interpreter.Options.addDelegate/setNumThreads`) | ✓ All APIs stable in 2.14. Note: dead code path (no call sites for `KiaanWakeWordDetector`) |
| OkHttp 4.12.0 (`OkHttpClient.Builder`, `Request.Builder`, `RequestBody.toRequestBody`, `MediaType.toMediaType`, `Response.code/body/isSuccessful/charStream/close`) | ✓ Stable |
| kotlinx.coroutines 1.7.3 (`Flow`, `callbackFlow`, `ProducerScope`, `awaitClose`, `ensureActive`, `suspendCancellableCoroutine`, `Mutex.withLock`) | ✓ Stable since 1.5 |
| AndroidX core-ktx 1.13.1 (`NotificationCompat`, `ContextCompat`) | ✓ Stable |
| `ServiceInfo.FOREGROUND_SERVICE_TYPE_*` (API 29+ requirement) | ✓ Gated behind `if (SDK_INT >= UPSIDE_DOWN_CAKE)` (API 34) |
| `PendingIntent.FLAG_IMMUTABLE` (API 23+) | ✓ Properly gated |
| `registerReceiver(null, filter)` (API 34 typed-flag) | ✓ Null-receiver case is exempt from typed-flag requirement per AOSP source |
| `closeQuietly` on Response | ✓ Defined privately in same file as wrapper around `Response.close()` |
| `@OptIn(UnstableApi::class)` coverage for Media3 unstable APIs | ✓ Class-level annotation covers all calls |

## Test plan

All 6 offline validators green on this branch:

- [x] `validate-plugins` — 3/3 plugins
- [x] `validate-voice-plugin` — 43+13 patch checks (with realistic plugin-chain fixtures)
- [x] `validate-wss-types` — 17/17 frame types
- [x] `validate-tool-contracts` — 15/15 contracts
- [x] `test-pure-helpers` — all helpers OK
- [x] `validate-bridge-coverage` — 17/17 JS↔Kotlin bridge methods
- [ ] EAS Build #20 — `cd kiaanverse-mobile/apps/mobile && npx eas-cli build --platform android --profile preview --clear-cache`

## What this fix could not have caught offline

The Media3 mismatch was **Kotlin source vs third-party API symbol table**. Catching this offline would have required either:
1. Running the actual Kotlin compiler against the `androidx.media3:1.4.1` AAR (only possible after `pnpm install`), or
2. Manual API audit against the published Media3 1.4.1 surface

Neither was in our offline toolchain. The CI now runs `pnpm install` before validators (PR #1701 wiring), so a bytecode-level check could be added in a future PR — but the gradle build itself runs right after and provides the same signal more precisely.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_