### PR TITLE
feat(mobile): Saransh toggle + chat polish + voice-companion orphan cleanup

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
@@ -6,8 +6,7 @@
  *   2. SubMandalaTexture – faint sacred-geometry backdrop behind the scroll area
  *   3a. Empty state      – HeroMandala + hero prompt + ConversationStarters
  *   3b. Messages list    – alternating UserMessage / SakhaMessage + TypingIndicator
- *   4. InsightFab       – floating lightbulb that injects a curated Gita prompt
- *   5. ChatInput        – voice/text composer with send pulse
+ *   4. ChatInput        – voice/text composer with send pulse
  *
  * Data flow:
  *   - `useSakhaStream` owns the SSE lifecycle (POST → token stream → done).
@@ -47,7 +46,6 @@ import * as Haptics from 'expo-haptics';
 import * as Speech from 'expo-speech';
 
 import { useDictation } from '../../voice/hooks/useDictation';
-import { divineProsody } from '../../voice/lib/divineVoice';
 
 import {
   ChatHeader,
@@ -55,7 +53,6 @@ import {
   ChatInput,
   ConversationStarters,
   HeroMandala,
-  InsightFab,
   SakhaMessage,
   TypingIndicator,
   UserMessage,
@@ -73,8 +70,8 @@ const MAX_CACHED_MESSAGES = 60;
  * Height of the custom DivineTabBar's content (safe-area bottom is added on
  * top inside the tab bar itself). The tab bar is `position: absolute, bottom:
  * 0` so it overlays tab screens; we reserve this space on the chat root so
- * the ChatInput and the InsightFab both sit above it instead of being
- * covered by the Home / Sakha / Shlokas row.
+ * the ChatInput sits above it instead of being covered by the Home /
+ * Sakha / Shlokas row.
  *
  * Must stay in sync with `TAB_BAR_HEIGHT` in components/navigation/DivineTabBar.tsx.
  */
@@ -178,46 +175,22 @@ export default function ChatScreen(): React.JSX.Element {
       // android.speech.tts.TextToSpeech directly, so this is the
       // exact cross-platform parity the user asked for.
       //
-      // Read latestAssistantMessageRef.current — captured at the
-      // moment the stream finishes — rather than reading
-      // `messages` (which is stale inside this callback closure
-      // because onStreamCompleted is registered with an empty
-      // dependency tail in the hook).
-      const latestText = latestAssistantMessageRef.current;
-      if (latestText && latestText.trim().length > 0) {
-        Speech.stop();
-        // Use divineProsody so this auto-speak picks the same neural
-        // voice + contemplative cadence as the per-message Listen
-        // button (which uses ListenButton + warmDivineVoiceCache).
-        // The cache is warmed lazily — first auto-speak after app
-        // launch may use the engine default for ~50ms while the cache
-        // populates; subsequent ones get the divine voice.
-        Speech.speak(latestText, {
-          ...divineProsody('en-IN'),
-        });
-      }
+      // Auto-speak removed (per user request 2025-11): chat responses
+      // should NOT play automatically. The user reads at their own
+      // pace; they tap the Listen button on a specific message bubble
+      // (see SakhaMessage's MessageActionBar) when they want to hear
+      // it. This matches kiaanverse.com mobile behavior — chat is for
+      // considered messages + reading, voice-companion is for fluid
+      // conversation. Auto-listen still fires on /voice-companion.
     });
     return () => {
       onStreamCompleted(null);
-      // Clean up any in-flight speech when the chat tab unmounts.
+      // Clean up any in-flight speech when the chat tab unmounts —
+      // catches the case where the user tapped Listen on a message,
+      // started playback, then navigated away mid-utterance.
       Speech.stop();
     };
   }, [onStreamCompleted]);
-
-  // Track the latest assistant message text so the onStreamCompleted
-  // callback (registered once on mount) can speak the freshest value.
-  // Using a ref instead of relying on the closure over `messages`
-  // avoids the stale-closure trap.
-  const latestAssistantMessageRef = useRef<string>('');
-  useEffect(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const m = messages[i];
-      if (m.role === 'assistant') {
-        latestAssistantMessageRef.current = m.text;
-        break;
-      }
-    }
-  }, [messages]);
 
   // ── Auto-scroll on new content. ───────────────────────────────────────────
   useEffect(() => {
@@ -258,12 +231,6 @@ export default function ChatScreen(): React.JSX.Element {
     },
     [handleSend]
   );
-
-  const handleInsightPress = useCallback((prompt: string) => {
-    // Fill the composer so the user can edit before sending, rather than
-    // auto-sending — gives them control over their spiritual dialogue.
-    setInput(prompt);
-  }, []);
 
   const handleClearConversation = useCallback(() => {
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
@@ -433,15 +400,6 @@ export default function ChatScreen(): React.JSX.Element {
             </View>
           )}
 
-          {/* Floating insight FAB — seeds a Gita-rooted reflection prompt.
-              Positioned relative to the body's bottom edge, which — thanks
-              to the flex layout and the root's reserved tab-bar space —
-              already sits just above the ChatInput composer. */}
-          <InsightFab
-            onPress={handleInsightPress}
-            hidden={streaming}
-            bottomOffset={12}
-          />
         </View>
 
         <ChatInput

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
@@ -290,6 +290,22 @@ export default function ChatScreen(): React.JSX.Element {
     }
   }, [dictation.state.tag]);
 
+  // "Go deeper" follow-up handler — fires when the user taps the
+  // conversation-mode pill on a Sakha message bubble. Sends the
+  // follow-up prompt as a NEW user turn so the LLM has the prior
+  // context server-side and can take the topic further.
+  //
+  // We pass the prompt through handleSend (not direct send) so the
+  // online + streaming guards still apply — taps fired during a
+  // network drop or while a previous response is still streaming
+  // are swallowed by the same safeguards.
+  const handleAskFollowUp = useCallback(
+    (followUpPrompt: string) => {
+      void handleSend(followUpPrompt);
+    },
+    [handleSend],
+  );
+
   // ── Rendering helpers ────────────────────────────────────────────────────
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<SakhaStreamMessage>) => {
@@ -301,10 +317,11 @@ export default function ChatScreen(): React.JSX.Element {
           id={item.id}
           text={item.text}
           isStreaming={item.isStreaming === true}
+          onAskFollowUp={handleAskFollowUp}
         />
       );
     },
-    []
+    [handleAskFollowUp]
   );
 
   const keyExtractor = useCallback((item: SakhaStreamMessage) => item.id, []);

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/journal.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/journal.tsx
@@ -56,6 +56,7 @@ import type { JournalEntry } from '@kiaanverse/api';
 import { useTranslation } from '@kiaanverse/i18n';
 import { JournalEntryCard } from '../../components/journal/JournalEntryCard';
 import { LotusGlyph } from '../../components/sacred-reflections/LotusGlyph';
+import { TAB_BAR_HEIGHT } from '../../components/navigation/DivineTabBar';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.4;
@@ -485,10 +486,18 @@ function JournalView(): React.JSX.Element {
         />
       </SacredTransition>
 
-      {/* FAB */}
+      {/* FAB — lifted above the tab bar.
+          Earlier shape used `bottom: insets.bottom + spacing.lg` which
+          ignored the tab bar height. The DivineTabBar overlays every
+          tab screen at the bottom (height = TAB_BAR_HEIGHT + safe-area),
+          so the FAB was hiding behind the navigation row.
+          Now: tab bar height + safe-area + a comfortable gap. */}
       <Pressable
         onPress={handleFabPress}
-        style={[styles.fab, { bottom: insets.bottom + spacing.lg }]}
+        style={[
+          styles.fab,
+          { bottom: insets.bottom + TAB_BAR_HEIGHT + spacing.lg },
+        ]}
         accessibilityRole="button"
         accessibilityLabel={t('newEntry', 'Create new journal entry')}
       >

--- a/kiaanverse-mobile/apps/mobile/app/voice-companion/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/voice-companion/index.tsx
@@ -52,7 +52,7 @@
  * is removed.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Pressable,
@@ -69,7 +69,7 @@ import { Shankha } from '../../voice/components/Shankha';
 import { SacredGeometry } from '../../voice/components/SacredGeometry';
 import { Color, Spacing, Type } from '../../voice/lib/theme';
 import { useDictation } from '../../voice/hooks/useDictation';
-import { divineProsody, warmDivineVoiceCache } from '../../voice/lib/divineVoice';
+import { divineProsody } from '../../voice/lib/divineVoice';
 import { useSakhaStream } from '../../components/chat/useSakhaStream';
 
 /**

--- a/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
@@ -16,9 +16,10 @@
  * prose (if provided).
  */
 
-import React, { useEffect, useMemo } from 'react';
-import { StyleSheet, Text, View, useWindowDimensions } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -28,8 +29,10 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
+import { ArrowDownToLine, MessageCircleMore } from 'lucide-react-native';
 
 import { MessageActionBar } from '../../voice/components/MessageActionBar';
+import { isWorthSummarizing, summarize } from '../../voice/lib/summarize';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let MandalaSpin: React.ComponentType<any> | null = null;
@@ -71,6 +74,13 @@ export interface SakhaMessageProps {
   readonly shloka?: SakhaMessageShloka;
   /** Stable message id for keying. */
   readonly id?: string;
+  /**
+   * Called when the user taps "Go deeper" — starts a follow-up turn
+   * to take the conversation further on this topic. Chat tab wires
+   * this to send() with a "please explain further" prompt seeded
+   * with the current message context.
+   */
+  readonly onAskFollowUp?: (followUpPrompt: string) => void;
 }
 
 /** Regex that splits text into whitespace vs. non-whitespace runs. */
@@ -207,11 +217,28 @@ function SakhaMessageInner({
   isStreaming,
   shloka,
   id,
+  onAskFollowUp,
 }: SakhaMessageProps): React.JSX.Element {
   const { width } = useWindowDimensions();
   const maxWidth = Math.round(width * MAX_WIDTH_PERCENT);
 
-  const tokens = useMemo(() => tokenize(text), [text]);
+  // ── Saransh (सारांश, "summary") view mode ──
+  // 'full'    — render the full streamed response (default).
+  // 'saransh' — render the heuristic-extracted short summary.
+  // Toggleable via a pill button below the bubble. Only shown when
+  // the message is long enough for a summary to be meaningfully
+  // different from the full text (isWorthSummarizing >= 280 chars).
+  const [viewMode, setViewMode] = useState<'full' | 'saransh'>('full');
+  const summaryText = useMemo(() => summarize(text), [text]);
+  const showSaranshToggle =
+    !isStreaming &&
+    isWorthSummarizing(text) &&
+    summaryText.length > 0 &&
+    summaryText !== text;
+  // Pick which text to actually animate + display.
+  const displayedText = viewMode === 'saransh' ? summaryText : text;
+
+  const tokens = useMemo(() => tokenize(displayedText), [displayedText]);
   const lastNonWhitespace = useMemo(() => {
     for (let i = tokens.length - 1; i >= 0; i--) {
       const tok = tokens[i];
@@ -219,6 +246,24 @@ function SakhaMessageInner({
     }
     return -1;
   }, [tokens]);
+
+  const handleToggleSaransh = useCallback(() => {
+    void Haptics.selectionAsync().catch(() => {});
+    setViewMode((m) => (m === 'full' ? 'saransh' : 'full'));
+  }, []);
+
+  const handleGoDeeper = useCallback(() => {
+    if (!onAskFollowUp) return;
+    void Haptics.selectionAsync().catch(() => {});
+    // Simple "explain further" prompt — the LLM has the prior
+    // conversation context server-side so it knows what "this
+    // topic" refers to. Sending a richer prompt with the current
+    // message text inline would double-count it in the model's
+    // context window for no added benefit.
+    onAskFollowUp(
+      'Please go deeper into this — share more nuance, examples, or a Gita reference.',
+    );
+  }, [onAskFollowUp]);
 
   // Reveal index grows as the text grows, so every new token fades in.
   const revealIndex = tokens.length - 1;
@@ -280,15 +325,72 @@ function SakhaMessageInner({
 
         {shimmerKey ? <CompletionShimmer key={shimmerKey} /> : null}
 
+        {/* View-mode + conversation-mode controls. Saransh toggle
+            (Hindi: सारांश, "summary") flips between the full streamed
+            response and a heuristic short summary. "Go deeper" sends
+            a follow-up prompt to continue the conversation on this
+            topic — the user can chain Saransh for the gist + Go
+            deeper for nuance, mimicking how kiaanverse.com lets users
+            switch between detailed/summary modes mid-conversation.
+
+            Both controls only render AFTER streaming completes so a
+            partially-streamed message doesn't get a "Saransh" pill
+            it doesn't deserve yet. */}
+        {!isStreaming && text.trim().length > 0 ? (
+          <View style={styles.viewModeRow}>
+            {showSaranshToggle ? (
+              <Pressable
+                onPress={handleToggleSaransh}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  viewMode === 'saransh'
+                    ? 'Show full explanation'
+                    : 'Show short summary (Saransh)'
+                }
+                style={({ pressed }) => [
+                  styles.actionBtn,
+                  viewMode === 'saransh' && styles.actionBtnActive,
+                  pressed && styles.actionBtnPressed,
+                ]}
+                hitSlop={8}
+              >
+                <ArrowDownToLine size={14} color={GOLD} />
+                <Text style={styles.actionLabel}>
+                  {viewMode === 'saransh' ? 'Full' : 'Saransh'}
+                </Text>
+              </Pressable>
+            ) : null}
+            {onAskFollowUp ? (
+              <Pressable
+                onPress={handleGoDeeper}
+                accessibilityRole="button"
+                accessibilityLabel="Continue the conversation — go deeper into this topic"
+                style={({ pressed }) => [
+                  styles.actionBtn,
+                  pressed && styles.actionBtnPressed,
+                ]}
+                hitSlop={8}
+              >
+                <MessageCircleMore size={14} color={GOLD} />
+                <Text style={styles.actionLabel}>Go deeper</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : null}
+
         {/* Per-message action bar — Speak / Copy / Share / Save to
             Journal. Only renders AFTER streaming completes so the user
             doesn't see a half-formed bubble with action affordances.
-            Mirror of the desktop SakhaMessageBubble's action set on
-            kiaanverse.com. Each handler is fire-and-forget (errors
-            swallowed) — these are nice-to-have actions; a Share-sheet
-            cancel or a TTS engine hiccup must not crash the bubble. */}
+            Listen reads `displayedText` so it speaks the SAME view
+            the user is currently looking at (Saransh or Full).
+            Each handler is fire-and-forget (errors swallowed) —
+            these are nice-to-have actions; a Share-sheet cancel or
+            a TTS engine hiccup must not crash the bubble. */}
         {!isStreaming && text.trim().length > 0 ? (
-          <MessageActionBar text={text} journalSource="sakha-chat" />
+          <MessageActionBar
+            text={displayedText}
+            journalSource="sakha-chat"
+          />
         ) : null}
       </View>
     </View>
@@ -397,6 +499,46 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: 'rgba(212,160,23,0.18)',
     gap: 6,
+  },
+  // View-mode + conversation-mode pill row (Saransh / Go deeper).
+  // Sits ABOVE MessageActionBar so the user sees "what kind of view"
+  // controls first, then the per-message actions (Listen / Copy /
+  // Share / Journal) below. Same gold pill aesthetic as the action
+  // bar; visually one continuous control surface.
+  viewModeRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(212,160,23,0.12)',
+  },
+  actionBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 14,
+    backgroundColor: 'rgba(212,160,23,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.18)',
+  },
+  actionBtnActive: {
+    // Fill state — applied when Saransh view is currently selected
+    // so the user can tell at a glance which view they're seeing.
+    backgroundColor: 'rgba(212,160,23,0.22)',
+    borderColor: 'rgba(212,160,23,0.45)',
+  },
+  actionBtnPressed: {
+    backgroundColor: 'rgba(212,160,23,0.18)',
+    borderColor: 'rgba(212,160,23,0.36)',
+  },
+  actionLabel: {
+    color: GOLD,
+    fontSize: 12,
+    fontWeight: '500',
   },
   shlokaSanskrit: {
     fontFamily: 'NotoSansDevanagari-Regular',

--- a/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/navigation/DivineTabBar.tsx
@@ -114,8 +114,12 @@ const TOP_BORDER_COLORS: readonly [string, string, string, string, string] = [
   'transparent',
 ];
 
-/** Base height of the tab bar content (safe-area inset is added on top). */
-const TAB_BAR_HEIGHT = 64;
+/** Base height of the tab bar content (safe-area inset is added on top).
+ *
+ *  Exported so screens with floating elements (FABs, snackbars,
+ *  composers) can lift themselves above the tab bar instead of being
+ *  covered by it. The journal tab's "+" FAB relies on this value. */
+export const TAB_BAR_HEIGHT = 64;
 /** Active indicator dot diameter. */
 const DOT_SIZE = 4;
 /** Distance between the dot's bottom edge and the icon's top edge. */

--- a/kiaanverse-mobile/apps/mobile/voice/lib/summarize.ts
+++ b/kiaanverse-mobile/apps/mobile/voice/lib/summarize.ts
@@ -1,0 +1,134 @@
+/**
+ * summarize — extract a short, meaningful summary from a Sakha response.
+ *
+ * Port of the desktop kiaanverse.com `buildSummary` heuristic
+ * (components/chat/MessageBubble.tsx). Keeps the Android app's
+ * "Saransh" (Hindi: सारांश, summary) toggle behaviorally identical
+ * to the web's "summary" view mode so users get the same short-form
+ * experience across platforms.
+ *
+ * Strategy:
+ *   1. Normalize whitespace + strip markdown emphasis (`*foo*`).
+ *   2. Split into sentences (>20 chars).
+ *   3. Find one sentence with a "wisdom marker" (psychology /
+ *      attachment / pattern / etc.) — these are usually the
+ *      core insight of a Sakha response.
+ *   4. Find one sentence with an "action marker" (practice / try /
+ *      begin / etc.) — these usually contain the practical takeaway.
+ *   5. Combine wisdom + action. If neither exists, fall back to the
+ *      first 2 substantive sentences.
+ *   6. Cap at 350 chars (matches web).
+ *   7. Ensure clean ending punctuation.
+ *
+ * Returns empty string for empty/whitespace-only input.
+ *
+ * No backend call. No LLM round-trip. No latency. Same heuristic
+ * the web uses as a fallback when AI-generated summary is absent —
+ * mobile uses it as the PRIMARY path (no need to plumb a separate
+ * summary field through the chat-streaming protocol).
+ */
+
+const WISDOM_MARKERS = [
+  'pattern',
+  'regulation',
+  'nervous system',
+  'attachment',
+  'mechanism',
+  'cognitive',
+  'habit',
+  'values',
+  'conditioning',
+  'awareness',
+];
+
+const ACTION_MARKERS = [
+  'step',
+  'practice',
+  'try',
+  'begin',
+  'start',
+  'notice',
+  'focus',
+  'take',
+  'action',
+  'choose',
+];
+
+/** Threshold below which a message is too short to need summarization. */
+export const SUMMARIZE_THRESHOLD_CHARS = 280;
+
+/** Hard cap on summary length to match the web's 350-char ceiling. */
+const SUMMARY_MAX_CHARS = 350;
+
+/** Inner truncation budget — leaves room for the trailing "..." marker. */
+const SUMMARY_TRUNCATE_AT = 340;
+
+export function summarize(text: string): string {
+  // Normalize: collapse whitespace runs, strip *italic-emphasis* spans,
+  // trim. Empty input returns empty so callers can decide whether to
+  // show "no summary available" or hide the toggle entirely.
+  const normalized = text
+    .replace(/\s+/g, ' ')
+    .replace(/\*[^*]*\*/g, '')
+    .trim();
+  if (!normalized) return '';
+
+  // Sentence split via lookbehind on terminal punctuation. Filter out
+  // very short fragments (< 20 chars) — these are usually section
+  // headers or "Hi." style fillers, not substantive content.
+  const sentences = normalized
+    .split(/(?<=[.!?])\s+/u)
+    .filter((s) => s.length > 20);
+
+  if (sentences.length === 0) {
+    // Whole text was one short fragment — return as-is, capped.
+    return cap(normalized);
+  }
+
+  const wisdomSentence = sentences.find((s) =>
+    WISDOM_MARKERS.some((m) => s.toLowerCase().includes(m)),
+  );
+  const actionSentence = sentences.find((s) =>
+    ACTION_MARKERS.some((m) => s.toLowerCase().includes(m)),
+  );
+
+  let summary = '';
+  if (wisdomSentence) summary = wisdomSentence;
+  if (actionSentence && actionSentence !== wisdomSentence) {
+    summary = summary ? `${summary} ${actionSentence}` : actionSentence;
+  }
+
+  // No marker hits → fall back to the first 2 substantive sentences.
+  // These usually carry the lead of the response (Sakha's prose tends
+  // to open with the central insight).
+  if (!summary) {
+    summary = sentences.slice(0, 2).join(' ');
+  }
+
+  return cap(summary);
+}
+
+/**
+ * Cap to SUMMARY_MAX_CHARS, ensure clean ending punctuation. Pulled
+ * out so the empty-fragments fallback path can use it too.
+ */
+function cap(s: string): string {
+  let out = s;
+  if (out.length > SUMMARY_MAX_CHARS) {
+    out = out.slice(0, SUMMARY_TRUNCATE_AT) + '...';
+  }
+  if (out && !out.endsWith('.') && !out.endsWith('...')) {
+    out = out.replace(/[!?]?$/u, '.');
+  }
+  return out;
+}
+
+/**
+ * Should a Saransh toggle be shown for this text? Returns false when
+ * the message is already short enough that a summary view would be
+ * indistinguishable from the full text — saves UI clutter on quick
+ * one-line responses ("Sure, here you go", "Got it", etc.).
+ */
+export function isWorthSummarizing(text: string): boolean {
+  return text.trim().length > SUMMARIZE_THRESHOLD_CHARS;
+}


### PR DESCRIPTION
## Summary

Three commits landed on the branch after PR #1705 merged, addressing UX feedback from the user against the native Android Play Store build.

| SHA | Theme | What |
|---|---|---|
| `287eeebc` | Chat polish | Removed `InsightFab` (yellow lightbulb FAB on chat — "of no use"); removed chat auto-speak (responses now stay silent until user taps Listen); lifted Sacred Reflections FAB above tab bar (was hiding behind navigation per user screenshot). |
| `430fcf7b` | **Saransh (सारांश) toggle** | New `voice/lib/summarize.ts` ports the desktop kiaanverse.com `buildSummary` heuristic to the Android app. SakhaMessage now shows a **Saransh / Full** view-mode pill on long answers (>280 chars) and a **Go deeper** pill that re-asks the question conversationally. Listen button reads whichever view is currently shown. |
| `3f1fbaee` | Hygiene | Removed orphan imports in `voice-companion/index.tsx` (`React` not needed under `jsx: "react-jsx"` runtime; `warmDivineVoiceCache` already pre-warmed in `_layout.tsx:97`). No behavior change. |

## What this fixes

### Chat polish — `287eeebc`

User screenshots showed:
1. A floating yellow lightbulb (`InsightFab`) overlapping chat — user requested removal: *"This Bulb must be removed it's of no use"*
2. Chat responses auto-reading aloud as soon as they finished streaming — user requested: *"The Response generated on Kiaan Chat after asking the query must not start automatically reading. It should read only on clicking Listen"*
3. Sacred Reflections FAB hidden behind the bottom tab bar

Fixes:
- Removed `<InsightFab />` JSX, `handleInsightPress` callback, and the entire `Speech.speak` auto-fire branch in `onStreamCompleted` (kept `Speech.stop()` in cleanup so any in-flight speech stops cleanly).
- `journal.tsx` FAB position changed from `bottom: insets.bottom + spacing.lg` to `bottom: insets.bottom + TAB_BAR_HEIGHT + spacing.lg` — `TAB_BAR_HEIGHT` is now exported from `DivineTabBar.tsx` for reuse.

### Saransh toggle + Go-deeper — `430fcf7b`

User asked: *"Kiaan Chat Responses for Native Android app on play store are Lacking summary Answers of the Long answers something similar to Desktop kiaan AI. One can Toggle between explanation and Short Answer name it As Saransh. It can go on as conversation mode if someone wants to do it ve deeper."*

Implementation:
- New `voice/lib/summarize.ts` — port of desktop's `MessageBubble.tsx::buildSummary` heuristic (wisdom markers + action markers, 350-char cap). No backend round-trip, no LLM latency, behaviorally identical to web.
- `SakhaMessage` accepts `onAskFollowUp` prop; renders two pills below long answers:
  - **Saransh (सारांश)** — toggles between full and summary view. Tokens re-derive from `displayedText` so the typewriter animation respects the toggle.
  - **Go deeper** — calls `onAskFollowUp(prompt)` in chat.tsx, which sends *"Please go deeper into this..."* as a follow-up question via `handleSend`.
- `MessageActionBar` receives `text={displayedText}` so Listen reads the current view (full or saransh).
- Threshold `SUMMARIZE_THRESHOLD_CHARS = 280` — short answers don't show the toggle (saves UI clutter on quick replies).

### Orphan cleanup — `3f1fbaee`

Surfaced during a verification pass on PR #1705. Two unused imports in `voice-companion/index.tsx`:

1. `React` — `tsconfig.base.json` sets `jsx: "react-jsx"` so the default React import is auto-injected by the runtime. Importing it explicitly is dead code.
2. `warmDivineVoiceCache` — imported but never called. Pre-warm already happens once at app start in `app/_layout.tsx:97`. The voice-companion screen was claiming a side-effecting helper without exercising it.

User had requested *"Ensure no errors, no mismatches and no false calls"* — these were false calls in spirit (imports declaring intent that the code didn't honor). Removed both.

## Verification

| Check | Result |
|---|---|
| All 5 mobile validators (`validate-plugins`, `validate-wss-types`, `validate-tool-contracts`, `test-pure-helpers`, `validate-bridge-coverage`) | ✓ Green |
| `summarize()` logic tested across 8 edge cases (empty, short, fragment-only, wisdom+action markers, no-markers fallback, >350-cap, italic-strip, threshold boundary) | ✓ All correct |
| Orphan-import audit on all 7 changed files | ✓ Clean after `3f1fbaee` |
| Bracket balance on changed files | ✓ Paired |
| Pre-warm still wired at app start (`_layout.tsx:97`) | ✓ Confirmed |

## Ship strategy

**JS-only changes.** `runtimeVersion: { policy: 'appVersion' }` is `1.3.2` (unchanged). OTA-eligible:

```bash
cd kiaanverse-mobile/apps/mobile
npx eas-cli update --branch production --message "Saransh + chat polish + voice-companion cleanup"
```

Existing 1.3.2 installs pick up on next app open. **No Play Store review.**

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_