### PR TITLE
feat(kiaan): wire chat + 6 tools to Wisdom Core (static+dynamic), modern-secular framing

### DIFF
--- a/backend/routes/kiaan.py
+++ b/backend/routes/kiaan.py
@@ -22,14 +22,16 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.deps import get_current_user
+from backend.deps import get_current_user, get_db
 from backend.middleware.rate_limiter import CHAT_RATE_LIMIT, limiter
 from backend.services.ai_provider import (
     AIProviderError,
     AIProviderNotConfigured,
     call_kiaan_ai,
 )
+from backend.services.kiaan_wisdom_helper import compose_kiaan_system_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +85,11 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     response: str
     conversation_id: str | None = None
+    # Verses surfaced from Wisdom Core (static + dynamic) that grounded
+    # the response. Empty list when retrieval was skipped or returned
+    # nothing — never None, so the Android client can render a flat
+    # `verses?.length` check without a null-guard.
+    verses: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class ToolRequest(BaseModel):
@@ -111,26 +118,51 @@ def _tool_input(inputs: dict[str, Any], key: str, default: str = "") -> str:
 async def _run_ai(
     *,
     message: str,
+    db: AsyncSession | None = None,
     history: list[dict[str, str]] | None = None,
     tool_name: str | None = None,
     gita_verse: dict[str, Any] | None = None,
     system_override: str | None = None,
-) -> str:
-    """Call the AI provider and translate errors into HTTP responses.
+) -> tuple[str, list[dict[str, Any]]]:
+    """Call the AI provider grounded in Wisdom Core, modern-secular framing.
+
+    When ``db`` is provided and the caller has *not* shipped its own
+    ``system_override``, this composes a system prompt = persona-version
+    1.2.0 (modern-secular text persona) + retrieved verses block from
+    :class:`backend.services.wisdom_core.WisdomCore` (static + dynamic
+    corpus, effectiveness-weighted). That replaces the legacy Krishna-
+    flavoured constant in :mod:`backend.services.ai_provider` for every
+    chat + tool request routed here.
+
+    Returns ``(response_text, verses)`` so the caller can echo verse
+    refs back to the client (Android already parses them from the
+    streaming endpoint's done frame; this gives the unary endpoints
+    parity).
 
     Provider configuration problems surface as 503 (service unavailable) —
     the app should keep working; only AI features are degraded. Transient
     upstream failures surface as 502 (bad gateway). Validation errors from
     the provider layer become 400.
     """
+    verses: list[dict[str, Any]] = []
+    if db is not None and not (system_override and system_override.strip()):
+        composed, verses = await compose_kiaan_system_prompt(
+            db=db,
+            query=message,
+            tool_name=tool_name,
+        )
+        if composed:
+            system_override = composed
+
     try:
-        return await call_kiaan_ai(
+        text = await call_kiaan_ai(
             message=message,
             conversation_history=history or [],
             gita_verse=gita_verse,
             tool_name=tool_name,
             system_override=system_override,
         )
+        return text, verses
     except AIProviderNotConfigured as exc:
         logger.error("KIAAN AI not configured: %s", exc)
         raise HTTPException(
@@ -155,20 +187,26 @@ async def _run_ai(
 async def _handle_sakha_chat(
     payload: ChatRequest,
     current_user_id: str,
+    db: AsyncSession,
 ) -> ChatResponse:
     """Shared implementation for the Sakha chat endpoint and its alias."""
     history = [
         {"role": m.role, "content": m.content} for m in payload.conversation_history
     ]
 
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=payload.message,
+        db=db,
         history=history,
         tool_name=payload.tool_name,
         gita_verse=payload.gita_verse,
         system_override=payload.system_context,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )
 
 
 @router.post("/chat", response_model=ChatResponse)
@@ -177,9 +215,10 @@ async def sakha_chat(
     request: Request,
     payload: ChatRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     """Main Sakha chat endpoint consumed by the Android chat screen."""
-    return await _handle_sakha_chat(payload, current_user_id)
+    return await _handle_sakha_chat(payload, current_user_id, db)
 
 
 @sakha_router.post("/chat", response_model=ChatResponse)
@@ -188,9 +227,10 @@ async def sakha_chat_alias(
     request: Request,
     payload: ChatRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     """Compat alias at ``/api/sakha/chat`` — identical to ``/api/kiaan/chat``."""
-    return await _handle_sakha_chat(payload, current_user_id)
+    return await _handle_sakha_chat(payload, current_user_id, db)
 
 
 # ── ENDPOINT 2: Emotional Reset ──────────────────────────────────────────
@@ -200,6 +240,7 @@ async def emotional_reset(
     request: Request,
     payload: ToolRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     emotion = _tool_input(payload.inputs, "emotion", "overwhelmed")
     intensity = _tool_input(payload.inputs, "intensity", "5")
@@ -208,14 +249,19 @@ async def emotional_reset(
     message = (
         f"I am experiencing {emotion} with an intensity of {intensity}/10. "
         f"Here is what happened: {situation}. "
-        "Please guide me through an emotional reset using Gita wisdom."
+        "Please guide me through an emotional reset."
     )
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=message,
+        db=db,
         tool_name="Emotional Reset",
         gita_verse=payload.gita_verse,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )
 
 
 # ── ENDPOINT 3: Ardha (Cognitive Reframing) ──────────────────────────────
@@ -225,24 +271,30 @@ async def ardha(
     request: Request,
     payload: ToolRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     situation = _tool_input(payload.inputs, "situation")
     belief = _tool_input(payload.inputs, "limiting_belief")
     fear = _tool_input(payload.inputs, "fear")
 
     message = (
-        "I need cognitive reframing through Gita wisdom. "
+        "I need cognitive reframing. "
         f"My situation: {situation}. "
         f"The limiting belief holding me: {belief}. "
         f"What I fear most: {fear}. "
-        "Please help me reframe this through Gita philosophy."
+        "Please help me reframe this."
     )
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=message,
+        db=db,
         tool_name="Ardha",
         gita_verse=payload.gita_verse,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )
 
 
 # ── ENDPOINT 4: Viyoga (Sacred Detachment) ───────────────────────────────
@@ -252,6 +304,7 @@ async def viyoga(
     request: Request,
     payload: ToolRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     attachment = _tool_input(payload.inputs, "attachment")
     attachment_type = _tool_input(payload.inputs, "attachment_type")
@@ -261,14 +314,19 @@ async def viyoga(
         f"I am struggling to let go of: {attachment}. "
         f"This is an attachment to: {attachment_type}. "
         f"What freedom would feel like: {freedom_vision}. "
-        "Please guide me through Viyoga — the sacred art of non-attachment."
+        "Please guide me through Viyoga — the practice of non-attachment."
     )
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=message,
+        db=db,
         tool_name="Viyoga",
         gita_verse=payload.gita_verse,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )
 
 
 # ── ENDPOINT 5: Karma Reset ──────────────────────────────────────────────
@@ -278,23 +336,29 @@ async def karma_reset(
     request: Request,
     payload: ToolRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     pattern = _tool_input(payload.inputs, "pattern")
     dimension = _tool_input(payload.inputs, "dimension")
     dharmic_action = _tool_input(payload.inputs, "dharmic_action")
 
     message = (
-        f"I want to examine this karmic pattern: {pattern}. "
-        f"This pattern involves: {dimension}. "
-        f"The dharmic action I feel called to: {dharmic_action}. "
-        "Please guide me through a Karma Reset using Gita wisdom."
+        f"I want to examine this recurring pattern: {pattern}. "
+        f"This pattern shows up as: {dimension}. "
+        f"The action I feel called to: {dharmic_action}. "
+        "Please guide me through a Karma Reset."
     )
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=message,
+        db=db,
         tool_name="Karma Reset",
         gita_verse=payload.gita_verse,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )
 
 
 # ── ENDPOINT 6: Relationship Compass ─────────────────────────────────────
@@ -304,6 +368,7 @@ async def relationship_compass(
     request: Request,
     payload: ToolRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     challenge = _tool_input(payload.inputs, "challenge")
     relationship_type = _tool_input(payload.inputs, "relationship_type")
@@ -313,14 +378,19 @@ async def relationship_compass(
         f"I have a relationship challenge: {challenge}. "
         f"This is with: {relationship_type}. "
         f"The core difficulty is: {difficulty}. "
-        "Please guide me through the Relationship Compass using Gita wisdom."
+        "Please guide me through the Relationship Compass."
     )
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=message,
+        db=db,
         tool_name="Relationship Compass",
         gita_verse=payload.gita_verse,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )
 
 
 # ── ENDPOINT 7: KarmaLytix Sacred Mirror ─────────────────────────────────
@@ -330,6 +400,7 @@ async def karmalytix(
     request: Request,
     payload: ToolRequest,
     current_user_id: str = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> ChatResponse:
     """Generate the weekly Sacred Mirror from journal METADATA only.
 
@@ -361,9 +432,14 @@ async def karmalytix(
         "Gita Echo (most relevant verse), Growth Edge (invitation to deepen), "
         "Blessing (acknowledgment of where they are)."
     )
-    response_text = await _run_ai(
+    response_text, verses = await _run_ai(
         message=message,
+        db=db,
         tool_name="KarmaLytix",
         gita_verse=payload.gita_verse,
     )
-    return ChatResponse(response=response_text, conversation_id=current_user_id)
+    return ChatResponse(
+        response=response_text,
+        conversation_id=current_user_id,
+        verses=verses,
+    )

--- a/backend/services/kiaan_core.py
+++ b/backend/services/kiaan_core.py
@@ -1253,34 +1253,51 @@ The user is greeting you. Welcome them with warmth and presence. Gently invite t
         context: str,
         limit: int = 15  # Expanded from 5 to 15
     ) -> list[dict[str, Any]]:
-        """Get relevant Gita verses based on query and context."""
+        """Retrieve verses via Wisdom Core (static Gita corpus + dynamic learned wisdom).
+
+        Routes through :func:`backend.services.wisdom_core.get_wisdom_core` so
+        the response is grounded in the unified corpus the rest of the platform
+        already uses (voice orchestrator, guidance route). The merge picks up:
+          - 700+ static Gita verses, scored by keyword + theme + domain match.
+          - Dynamic learned wisdom (validated rows from `learned_wisdom`).
+          - Effectiveness-weighted ordering when the dynamic corpus has data
+            for the surfaced moods.
+
+        Modern-secular framing is enforced by the persona prompt
+        (`prompts/sakha.text.openai.md` v1.2.0) — Wisdom Core supplies the
+        source material; the persona renders it in 2026 language.
+
+        On error (DB hiccup, missing tables, etc.) returns an empty list so
+        :meth:`_get_fallback_verses` can take over.
+        """
         try:
-            # Use wisdom KB to search verses
-            verse_results = await self.wisdom_kb.search_relevant_verses(
+            from backend.services.wisdom_core import get_wisdom_core
+
+            wisdom_core = get_wisdom_core()
+            results = await wisdom_core.search(
                 db=db,
                 query=query,
-                limit=limit
+                limit=limit,
             )
-            
-            # Format results
-            formatted_verses = []
-            for result in verse_results:
-                verse = result.get("verse")
-                if verse:
-                    chapter = getattr(verse, 'chapter', '')
-                    verse_num = getattr(verse, 'verse', '')
-                    formatted_verses.append({
-                        "verse_id": f"{chapter}.{verse_num}" if chapter and verse_num else "",
-                        "english": getattr(verse, 'english', ''),
-                        "principle": getattr(verse, 'principle', ''),
-                        "theme": getattr(verse, 'theme', ''),
-                        "score": result.get("score", 0.0)
-                    })
-            
+
+            formatted_verses: list[dict[str, Any]] = []
+            for r in results:
+                chapter = r.chapter or ""
+                verse_num = r.verse or ""
+                verse_id = r.verse_ref or (
+                    f"{chapter}.{verse_num}" if chapter and verse_num else ""
+                )
+                formatted_verses.append({
+                    "verse_id": verse_id,
+                    "english": r.content or "",
+                    "principle": r.principle or "",
+                    "theme": r.theme or "",
+                    "score": r.score,
+                })
             return formatted_verses
-            
+
         except Exception as e:
-            logger.error(f"KIAAN Core: Error getting verses: {e}")
+            logger.error(f"KIAAN Core: Wisdom Core search failed: {e}")
             return []
 
     async def _get_fallback_verses(self, db: AsyncSession, limit: int = 3) -> list[dict[str, Any]]:

--- a/backend/services/kiaan_wisdom_helper.py
+++ b/backend/services/kiaan_wisdom_helper.py
@@ -1,0 +1,191 @@
+"""Wisdom Core retrieval helper for the unified KIAAN router.
+
+Purpose
+-------
+``backend/routes/kiaan.py`` currently builds responses through
+:func:`backend.services.ai_provider.call_kiaan_ai`, which uses an
+inline persona constant (``KIAAN_SYSTEM_PROMPT``) and only sees the
+``gita_verse`` the *caller* hands in. That means:
+
+  * The chat endpoint and all six tool endpoints respond *without*
+    consulting the Wisdom Core (static + dynamic), so they ignore
+    700+ stored verses, learned wisdom, and effectiveness scoring.
+  * The persona used there is the older Krishna-flavoured constant,
+    not the modern-secular **persona-version 1.2.0** we ship in
+    ``prompts/sakha.text.openai.md``.
+
+This helper closes both gaps with two cheap operations:
+
+  1. Load the modern-secular text persona (``sakha.text.openai.md``)
+     once at module import.
+  2. Retrieve up to 3 ranked verses from
+     :class:`backend.services.wisdom_core.WisdomCore` and format them
+     as a ``RETRIEVED_VERSES`` block the persona expects (the persona
+     prompt explicitly states it consumes a ``retrieved_verses``
+     block from the orchestrator).
+
+Callers compose ``compose_kiaan_system_prompt(db, query, tool_name)``,
+hand the result to ``call_kiaan_ai(..., system_override=<that>)``,
+and the LLM receives **persona 1.2.0 + Wisdom Core context** — same
+quality bar the voice path already meets.
+
+Design notes
+------------
+- Persona file read once at import. If it is missing (e.g. partial
+  checkout, container without ``prompts/``) we log and fall back to
+  ``call_kiaan_ai``'s default — never raise, never break the request.
+- Wisdom Core search has a hard try/except wrap. A DB hiccup or
+  unmigrated schema must not 500 the chat endpoint; we degrade to
+  the persona-only prompt and the LLM still answers.
+- Verse list returned alongside the system prompt so the route layer
+  can echo verse refs to the client (the Android app already parses
+  ``verseRefs`` from the streaming done frame).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+# ── PERSONA LOADING ──────────────────────────────────────────────────────
+_PERSONA_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "prompts"
+    / "sakha.text.openai.md"
+)
+
+
+def _load_text_persona() -> str | None:
+    """Read the modern-secular text persona once. Returns None if missing."""
+    try:
+        return _PERSONA_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning(
+            "kiaan_wisdom_helper: persona file missing at %s — "
+            "falling back to ai_provider default persona",
+            _PERSONA_PATH,
+        )
+        return None
+    except Exception as exc:
+        logger.error(
+            "kiaan_wisdom_helper: failed to read persona %s: %s",
+            _PERSONA_PATH,
+            exc,
+        )
+        return None
+
+
+_TEXT_PERSONA: str | None = _load_text_persona()
+
+
+# ── PUBLIC API ───────────────────────────────────────────────────────────
+async def compose_kiaan_system_prompt(
+    db: AsyncSession,
+    query: str,
+    tool_name: str | None = None,
+    *,
+    verses_limit: int = 3,
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Compose a modern-secular system prompt grounded in Wisdom Core.
+
+    Args:
+        db: Async session for the Wisdom Core search.
+        query: User message (or tool-derived prompt) used as the search
+            query against the static + dynamic corpus.
+        tool_name: Optional tool name (e.g. ``"Emotional Reset"``) for
+            context — currently informational, kept for future per-tool
+            retrieval tuning.
+        verses_limit: How many verses to pull. Three is the sweet spot
+            the persona's 4-Part Structure expects (lead + supporting +
+            optional reference).
+
+    Returns:
+        ``(system_prompt, verses)``:
+          * ``system_prompt`` — full persona + retrieved-verses block,
+            ready to pass as ``system_override`` to ``call_kiaan_ai``.
+            ``None`` if the persona file failed to load (caller should
+            then drop ``system_override`` to use the legacy default).
+          * ``verses`` — list of dicts (``{verse_ref, principle, theme,
+            content}``) suitable for echoing to the client.
+
+    Never raises. Logs and degrades on every failure mode.
+    """
+    if _TEXT_PERSONA is None:
+        return None, []
+
+    verses: list[dict[str, Any]] = []
+    try:
+        # Local import keeps this module light at process start and
+        # avoids a circular import with services that already import
+        # ai_provider (which routes/kiaan.py also imports).
+        from backend.services.wisdom_core import get_wisdom_core
+
+        wisdom_core = get_wisdom_core()
+        results = await wisdom_core.search(
+            db=db,
+            query=query,
+            limit=verses_limit,
+        )
+        for r in results:
+            chapter = r.chapter or ""
+            verse_num = r.verse or ""
+            verse_ref = r.verse_ref or (
+                f"{chapter}.{verse_num}" if chapter and verse_num else ""
+            )
+            verses.append({
+                "verse_ref": verse_ref,
+                "chapter": chapter,
+                "verse": verse_num,
+                "sanskrit": r.sanskrit or "",
+                "english": r.content or "",
+                "principle": r.principle or "",
+                "theme": r.theme or "",
+            })
+    except Exception as exc:
+        # Retrieval failures must not break chat. Persona alone still
+        # produces a coherent (though un-grounded) response.
+        logger.warning(
+            "kiaan_wisdom_helper: Wisdom Core search failed (tool=%s): %s",
+            tool_name,
+            exc,
+        )
+
+    block = _format_retrieved_verses_block(verses)
+    system_prompt = (
+        f"{_TEXT_PERSONA}\n\n{block}" if block else _TEXT_PERSONA
+    )
+    return system_prompt, verses
+
+
+def _format_retrieved_verses_block(verses: list[dict[str, Any]]) -> str:
+    """Render the persona's expected ``retrieved_verses`` context block."""
+    if not verses:
+        return ""
+
+    lines: list[str] = ["## RETRIEVED VERSES (from Wisdom Core)"]
+    for i, v in enumerate(verses, start=1):
+        ref = v.get("verse_ref") or "?"
+        sanskrit = v.get("sanskrit") or ""
+        english = v.get("english") or ""
+        principle = v.get("principle") or ""
+        theme = v.get("theme") or ""
+        lines.append(f"\n### {i}. BG {ref}")
+        if sanskrit:
+            lines.append(f"Sanskrit: {sanskrit}")
+        if english:
+            lines.append(f"English: {english}")
+        if principle:
+            lines.append(f"Principle: {principle}")
+        if theme:
+            lines.append(f"Theme: {theme}")
+    lines.append(
+        "\nUse these verses verbatim where the 4-Part Structure calls for "
+        "an Ancient Wisdom Principle. Do not invent verses outside this "
+        "list."
+    )
+    return "\n".join(lines)

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
@@ -317,6 +317,7 @@ export default function ChatScreen(): React.JSX.Element {
           id={item.id}
           text={item.text}
           isStreaming={item.isStreaming === true}
+          verseRefs={item.verseRefs}
           onAskFollowUp={handleAskFollowUp}
         />
       );

--- a/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
@@ -75,6 +75,14 @@ export interface SakhaMessageProps {
   /** Stable message id for keying. */
   readonly id?: string;
   /**
+   * Verse refs surfaced by the backend's Wisdom Core retrieval pass
+   * (e.g. ['BG2.47', 'BG6.5']). Rendered as small subtle chips below
+   * the message body so the user can see what the response was
+   * grounded in. Hidden when empty/undefined — no UI clutter on
+   * conversational replies that don't need a citation.
+   */
+  readonly verseRefs?: readonly string[];
+  /**
    * Called when the user taps "Go deeper" — starts a follow-up turn
    * to take the conversation further on this topic. Chat tab wires
    * this to send() with a "please explain further" prompt seeded
@@ -217,6 +225,7 @@ function SakhaMessageInner({
   isStreaming,
   shloka,
   id,
+  verseRefs,
   onAskFollowUp,
 }: SakhaMessageProps): React.JSX.Element {
   const { width } = useWindowDimensions();
@@ -321,6 +330,22 @@ function SakhaMessageInner({
 
           {/* Optional inline shloka card. */}
           {shloka ? <InlineShloka shloka={shloka} /> : null}
+
+          {/* Wisdom Core citations — small gold chips listing the
+              Bhagavad Gita verses the backend's Wisdom Core retrieval
+              pass surfaced for this response. Renders only when the
+              streaming completed AND the backend returned at least one
+              ref. Quiet, dismissible, non-interactive — just lets the
+              user see the source the answer was grounded in. */}
+          {!isStreaming && verseRefs && verseRefs.length > 0 ? (
+            <View style={styles.verseRefRow}>
+              {verseRefs.map((ref) => (
+                <View key={ref} style={styles.verseRefChip}>
+                  <Text style={styles.verseRefText}>{formatVerseRef(ref)}</Text>
+                </View>
+              ))}
+            </View>
+          ) : null}
         </View>
 
         {shimmerKey ? <CompletionShimmer key={shimmerKey} /> : null}
@@ -395,6 +420,25 @@ function SakhaMessageInner({
       </View>
     </View>
   );
+}
+
+/**
+ * Normalise a verse ref into the user-facing chip label.
+ *
+ * Backend emits refs in two shapes (legacy + structured):
+ *   - "BG 2.47" (extracted via regex from streamed prose)
+ *   - "BG2.47"  (compact form from the structured retrieval list)
+ *   - "2.47"    (Wisdom Core's `verse_ref` field — no prefix)
+ *
+ * We render all three as "BG 2.47" so the chip looks consistent
+ * regardless of which path put the ref on the message.
+ */
+function formatVerseRef(ref: string): string {
+  const trimmed = ref.trim();
+  // "BG2.47" or "BG 2.47" → match "X.Y"
+  const match = trimmed.match(/(\d+)\.(\d+)/);
+  if (!match) return trimmed;
+  return `BG ${match[1]}.${match[2]}`;
 }
 
 /** Lightweight inline shloka renderer — used inside SakhaMessage bubbles. */
@@ -499,6 +543,31 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: 'rgba(212,160,23,0.18)',
     gap: 6,
+  },
+  // Wisdom Core verse-citation row. Sits at the bottom of the bubble
+  // body, below the streamed prose (and any inline shloka). Quiet
+  // gold chips so they read as supporting metadata, not as a card
+  // demanding attention. flexWrap so 3+ refs flow gracefully on
+  // narrow screens.
+  verseRefRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 10,
+  },
+  verseRefChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+    backgroundColor: 'rgba(212,160,23,0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(212,160,23,0.28)',
+  },
+  verseRefText: {
+    color: GOLD,
+    fontSize: 11,
+    fontWeight: '500',
+    letterSpacing: 0.3,
   },
   // View-mode + conversation-mode pill row (Saransh / Go deeper).
   // Sits ABOVE MessageActionBar so the user sees "what kind of view"

--- a/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
+++ b/kiaanverse-mobile/apps/mobile/components/chat/useSakhaStream.ts
@@ -67,6 +67,15 @@ export interface SakhaStreamMessage {
   readonly timestamp: number;
   /** True while the assistant response is actively streaming. */
   isStreaming?: boolean;
+  /**
+   * Verse references (e.g. ['BG2.47', 'BG6.5']) surfaced by the backend
+   * from the Wisdom Core retrieval pass and emitted in the streaming
+   * `done` frame. Rendered as a subtle citation chip below the message
+   * by `<SakhaMessage />`. Empty array (not undefined) when the backend
+   * returned no verses, so consumers can `.length`-check without a
+   * null-guard.
+   */
+  verseRefs?: readonly string[];
 }
 
 export interface UseSakhaStreamOptions {
@@ -399,6 +408,24 @@ export function useSakhaStream(
                 fullText += event.message;
               }
               if (event.done) {
+                // Capture verse refs surfaced by the backend's Wisdom
+                // Core retrieval (chat.py extracts BG-style refs from
+                // the streamed text *and* the orchestrator hands the
+                // retrieved-verse list to the prompt). We attach them
+                // to the assistant message so SakhaMessage can render
+                // a subtle citation chip.
+                if (Array.isArray(event.verseRefs)) {
+                  const refs = event.verseRefs.filter(
+                    (r): r is string => typeof r === 'string' && r.length > 0,
+                  );
+                  if (refs.length > 0) {
+                    setMessages((prev) =>
+                      prev.map((m) =>
+                        m.id === assistantId ? { ...m, verseRefs: refs } : m,
+                      ),
+                    );
+                  }
+                }
                 sawDone = true;
                 break;
               }


### PR DESCRIPTION
## Summary

Every Kiaan response — chat tab + Emotional Reset, Ardha, Viyoga, Karma Reset, Relationship Compass, KarmaLytix — now retrieves from the unified **Wisdom Core** (700+ static Gita verses + dynamic learned wisdom + effectiveness-weighted ordering) and answers under **persona-version 1.2.0** (modern-secular text framing). Verse refs flow through to the Android chat as subtle gold citation chips so the user sees what the answer was grounded in.

## What changed

### `backend/services/kiaan_core.py`

`_get_relevant_verses` switches from `wisdom_kb.search_relevant_verses` (static-only) → `wisdom_core.search()` (static + dynamic merge with effectiveness scoring). Used by `/api/chat/message/stream` (the SSE endpoint the Android chat tab actually hits). Result: every streaming chat response is now grounded in the same corpus the voice path and guidance route already use.

### `backend/services/kiaan_wisdom_helper.py` (NEW)

Single shared retrieval helper for the unified KIAAN router (`/api/kiaan/*` and `/api/sakha/*`):

- Loads `prompts/sakha.text.openai.md` (persona-version **1.2.0**, modern-secular framing) once at module import.
- `compose_kiaan_system_prompt(db, query, tool_name)` retrieves up to 3 ranked verses from `WisdomCore`, formats them as a `RETRIEVED VERSES` block, returns `(persona + block, verses)`.
- **Never raises** — DB hiccup or missing persona file degrades gracefully to `ai_provider`'s legacy default; chat keeps working.

### `backend/routes/kiaan.py`

`_run_ai` now accepts `db` and (when no caller-supplied `system_override`) composes the modern-secular system prompt + Wisdom Core context via the helper. Returns `(text, verses)`. Every handler (chat + chat-alias + 6 tools) gets `db: AsyncSession = Depends(get_db)`, unpacks the tuple, and echoes `verses` in the `ChatResponse` envelope. Tool prompts also dropped the trailing *"...using Gita wisdom"* tails — the persona handles framing now; doubling it up made responses feel didactic.

### Mobile — verse-ref citation chips

- `useSakhaStream.ts` — added `verseRefs?: readonly string[]` to `SakhaStreamMessage`, captures the array from the streaming `done` frame (already emitted by `routes/chat.py:628`) and attaches it to the assistant message.
- `SakhaMessage.tsx` — accepts `verseRefs`, renders each as a small gold chip ("BG 2.47") below the streamed prose. Hidden when empty. `formatVerseRef()` normalises the three formats the backend can emit (`BG 2.47`, `BG2.47`, `2.47`) into one consistent label.
- `app/(tabs)/chat.tsx` — `renderItem` forwards `item.verseRefs` to `<SakhaMessage />`.

## Why "modern + secular"

The user explicitly asked: *"Use Wisdom Core containing Static and Dynamic Core Wisdom for Kiaan Responses and across all tools in most modern and secular way."* Two layers of religious-framing cleanup:

1. **The legacy `KIAAN_SYSTEM_PROMPT` constant** in `ai_provider.py` (*"You are Sakha embodying Lord Krishna...address as 'dear seeker'"*) is bypassed for every request via `system_override`. The new system prompt is `prompts/sakha.text.openai.md` v1.2.0 — explicitly *"modern, secular framing — not preachy"*; *"the Gita is the **source** but the **render** must sound like wisdom that fits 2026 life"*; examples like *"doomscrolling at 1am"*, *"performance review anxiety"*, *"founder loneliness"*, *"elderly parent care"*.

2. **Tool prompts** no longer end with *"...through Gita wisdom"* / *"...through Gita philosophy"*. The persona prompt enforces grounding; appending the framing again at the user-message layer was preachy.

The legacy persona and `_TOOL_CONTEXTS` constant remain in `ai_provider.py` untouched as a fallback — any caller shipping its own `system_context` (or any caller without a `db`) keeps the previous behaviour. New work flows through the modern-secular path automatically.

## Verification — no errors / mismatches / false calls

| Check | Result |
|---|---|
| `python3 -m py_compile` on all 3 backend files | ✓ |
| All 5 mobile validators (`validate-plugins`, `validate-wss-types`, `validate-tool-contracts`, `test-pure-helpers`, `validate-bridge-coverage`) | ✓ Green |
| All 7 `_run_ai` callers unpack the new tuple correctly | ✓ |
| 8/8 handlers have `db: AsyncSession = Depends(get_db)` (chat + chat-alias + 6 tools) | ✓ |
| Orphan-import audit on edited mobile files | ✓ Clean |
| TypeScript parse on changed files | ✓ No new errors (only pre-existing implicit-any noise inherited from isolated tsc run) |
| Helper degrades gracefully on missing persona file / failed DB | ✓ Logs + fallback to legacy default — never raises |

## Ship strategy

| Layer | Change type | Path |
|---|---|---|
| Backend | New file + edits | Auto-deploys on Render when this PR merges to `main` |
| Mobile | JS only | OTA-eligible — `runtimeVersion: { policy: 'appVersion' }` is `1.3.2` (unchanged) |

After merge:

```bash
# Backend deploys automatically via Render
# Mobile JS bundle:
cd kiaanverse-mobile/apps/mobile
npx eas-cli update --branch production --message "Wisdom Core wiring: chat + 6 tools, modern-secular framing"
```

Existing 1.3.2 installs pick up the new citation chip UI on next app open; new responses immediately come from the Wisdom-Core-grounded pipeline.

## What's NOT in this PR (deferred)

| Concern | Why deferred |
|---|---|
| Effectiveness loop wiring (`record_wisdom_delivery` after stream) | Adds complexity to streaming path. Voice path already records deliveries; chat can follow in a separate small commit once we confirm Render telemetry shape. |
| Tool routes outside `kiaan.py` (Karma Reset on `karma_reset_kiaan.py`, Sacred Reflections, Mood Insights, etc.) | Different code paths with their own retrieval logic; this PR covers the 6 unified-router tools that share `_run_ai`. The other 9 tool routes are a separate scope. |
| Verse-detail rendering (Sanskrit + translation expandable card) | The chip is the visible citation; a tap-to-expand flyout is a UX enhancement, not a wiring bug. Follow-up. |
| Bumping `prompts/persona-version` | Persona prompt content unchanged — `1.2.0` already covers modern-secular. |

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_