### PR TITLE
fix(voice): silence-proof TTS end-to-end + provider chain reorder (Sarvam → ElevenLabs → Microsoft Neural → Bhashini-future)

### DIFF
--- a/backend/services/tts_service.py
+++ b/backend/services/tts_service.py
@@ -442,10 +442,33 @@ class TTSService:
         voice_id: Optional[str] = None,
     ) -> Optional[bytes]:
         """
-        Synthesize using the provider fallback chain.
+        Synthesize using the canonical provider fallback chain.
 
-        Indian Languages: Sarvam AI -> ElevenLabs -> Edge TTS
-        International Languages: ElevenLabs -> Sarvam AI (if applicable)
+        Uniform priority across ALL languages (no Indian/International
+        branching) per product directive:
+
+           1. Sarvam AI (paid plan — primary)
+           2. ElevenLabs (premium fallback)
+           3. Microsoft Neural via Edge TTS (free fallback)
+           4. Bhashini AI (planned — see TODO below)
+
+        Why uniform: the user runs paid Sarvam which handles 11 Indic
+        languages + Indian-accented English natively, so it should be
+        tried first regardless of language. ElevenLabs is the next-best
+        for naturalness on any language. Microsoft Neural via the
+        ``edge-tts`` library is a free, key-less last-resort that
+        supports 50+ languages with Neural-quality voices — better
+        than no audio.
+
+        Bhashini AI integration is planned: when wired, insert a step
+        between ElevenLabs and Edge TTS for Indic languages so users
+        get sovereign Indic voices when the paid providers are
+        unavailable. Until then, Edge TTS covers Indic via Microsoft
+        Neural's hi-IN / ta-IN / bn-IN / mr-IN / gu-IN voices.
+
+        Each provider's adapter is a no-op (returns None) when its
+        env-var key is unset, so the chain naturally skips disabled
+        tiers without explicit checks.
         """
         # Map voice_type to voice_id if not provided
         if not voice_id:
@@ -476,32 +499,69 @@ class TTSService:
                 "chanting": "peaceful",
             }.get(voice_type, "neutral")
 
-        if self._is_indian_language(language):
-            # Indian language chain: Sarvam -> ElevenLabs -> Edge TTS
-            audio = await self._synthesize_with_sarvam(text, language, voice_type, mood, voice_id)
-            if audio:
-                logger.info(f"Sarvam AI synthesis success for {language}")
-                return audio
+        # ── Tier 1: Sarvam AI (paid, primary for ALL languages) ──
+        audio = await self._synthesize_with_sarvam(
+            text, language, voice_type, mood, voice_id
+        )
+        if audio:
+            logger.info(
+                f"Sarvam AI (Tier 1) synthesis success for {language} "
+                f"voice={voice_id}"
+            )
+            return audio
 
-            audio = await self._synthesize_with_elevenlabs(text, language, voice_id, mood)
-            if audio:
-                logger.info(f"ElevenLabs synthesis success for {language}")
-                return audio
-        else:
-            # International language chain: ElevenLabs -> Sarvam (if en-IN)
-            audio = await self._synthesize_with_elevenlabs(text, language, voice_id, mood)
-            if audio:
-                logger.info(f"ElevenLabs synthesis success for {language}")
-                return audio
+        # ── Tier 2: ElevenLabs (premium fallback) ──
+        audio = await self._synthesize_with_elevenlabs(
+            text, language, voice_id, mood
+        )
+        if audio:
+            logger.info(
+                f"ElevenLabs (Tier 2) synthesis success for {language} "
+                f"voice={voice_id}"
+            )
+            return audio
 
-            # Try Sarvam as fallback for English
-            if language in ("en", "en-IN"):
-                audio = await self._synthesize_with_sarvam(text, language, voice_type, mood, voice_id)
+        # ── Tier 3: Microsoft Neural via Edge TTS (free fallback) ──
+        # Same naturalness tier as Sarvam/ElevenLabs (Microsoft Neural
+        # voices are studio-grade), no API key required, supports
+        # 50+ languages including all Indic languages we serve. Last-
+        # resort but still divine-sounding.
+        try:
+            from backend.services.edge_tts_service import (
+                synthesize_edge_tts,
+                is_edge_tts_available,
+            )
+            if is_edge_tts_available():
+                audio = await synthesize_edge_tts(
+                    text=text,
+                    language=language,
+                    voice_id=voice_id,
+                    mood=mood,
+                )
                 if audio:
-                    logger.info(f"Sarvam AI fallback synthesis success for {language}")
+                    logger.info(
+                        f"Microsoft Neural / Edge TTS (Tier 3) synthesis "
+                        f"success for {language} voice={voice_id}"
+                    )
                     return audio
+        except ImportError:
+            logger.debug("Edge TTS unavailable (edge-tts package not installed)")
+        except Exception as e:
+            logger.warning(f"Edge TTS Tier 3 failed: {e}")
 
-        logger.error(f"All TTS providers failed for language: {language}")
+        # ── Tier 4: Bhashini AI (planned) ────────────────────────────
+        # When integrated, insert here for Indic languages. Government
+        # of India sovereign Indic neural — free, fast, optimized for
+        # Marathi / Tamil / Bengali / Sanskrit. The provider class
+        # already exists at backend/services/voice/bhashini_provider.py
+        # for the WSS path; needs a sync wrapper for this REST path.
+        # See `tts_router.py` for the WSS-side wiring as reference.
+
+        logger.error(
+            f"All TTS tiers failed for language={language} voice_id={voice_id}. "
+            f"Configured: sarvam={self._sarvam_available} "
+            f"elevenlabs={self._elevenlabs_available}"
+        )
         return None
 
     def synthesize(

--- a/kiaanverse-mobile/apps/mobile/voice/lib/cloudTTS.ts
+++ b/kiaanverse-mobile/apps/mobile/voice/lib/cloudTTS.ts
@@ -330,23 +330,31 @@ export async function cloudSpeak(
   }
 
   try {
-    const { sound } = await Audio.Sound.createAsync(
-      { uri },
-      { shouldPlay: true },
-    );
-    currentSound = sound;
-    options.onStart?.();
-    sound.setOnPlaybackStatusUpdate((status) => {
+    // Holder for the sound — referenced inside the status callback
+    // BEFORE createAsync resolves. Passing the callback as the third
+    // arg of createAsync (rather than via setOnPlaybackStatusUpdate
+    // afterwards) eliminates a tiny race where very short clips can
+    // fire didJustFinish before the late-bound listener attaches —
+    // which would mean onDone never fires and the voice-companion
+    // auto-listen loop hangs in the 'speaking' state forever.
+    const holder: { sound: Audio.Sound | null } = { sound: null };
+    const onStatus = (status: import('expo-av').AVPlaybackStatus) => {
       if (!status.isLoaded) return;
       if (status.didJustFinish) {
-        // Clear current sound *before* firing onDone so a synchronous
-        // re-call inside the callback (auto-listen flows do this) sees
-        // a clean slate.
-        if (currentSound === sound) currentSound = null;
-        sound.unloadAsync().catch(() => undefined);
+        const s = holder.sound;
+        if (s && currentSound === s) currentSound = null;
+        if (s) s.unloadAsync().catch(() => undefined);
         options.onDone?.();
       }
-    });
+    };
+    const { sound } = await Audio.Sound.createAsync(
+      { uri },
+      { shouldPlay: true, volume: 1.0 },
+      onStatus,
+    );
+    holder.sound = sound;
+    currentSound = sound;
+    options.onStart?.();
   } catch (e) {
     const err = e instanceof Error ? e : new Error(String(e));
     if (typeof console !== 'undefined' && console.warn) {

--- a/kiaanverse-mobile/apps/mobile/voice/lib/cloudTTS.ts
+++ b/kiaanverse-mobile/apps/mobile/voice/lib/cloudTTS.ts
@@ -258,6 +258,39 @@ async function unloadCurrent(): Promise<void> {
 }
 
 /**
+ * Force the audio session into playback mode. ``useDictation`` sets the
+ * mode to ``allowsRecordingIOS: true`` when listening — if we attempt to
+ * play audio while that mode is still active, the route is the mic
+ * earpiece (very quiet) on iOS and the recording stream on Android,
+ * which can result in NO audible output.
+ *
+ * Also crucial: ``playsInSilentModeIOS: true`` so iOS users on silent
+ * mode still hear Sakha (this is a feature, not a notification).
+ *
+ * Idempotent — expo-av no-ops if the same mode is set twice. Errors are
+ * silently swallowed so a permission edge case doesn't break playback;
+ * the createAsync call below will surface any real failure.
+ */
+async function ensurePlaybackAudioMode(): Promise<void> {
+  try {
+    await Audio.setAudioModeAsync({
+      allowsRecordingIOS: false,
+      playsInSilentModeIOS: true,
+      staysActiveInBackground: false,
+      shouldDuckAndroid: true,
+      playThroughEarpieceAndroid: false,
+      interruptionModeIOS: 1, // DoNotMix — Sakha takes the channel
+      interruptionModeAndroid: 1, // DoNotMix
+    });
+  } catch (e) {
+    // Best-effort. Real audio failures will surface from createAsync.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('cloudTTS: ensurePlaybackAudioMode failed:', e);
+    }
+  }
+}
+
+/**
  * Synthesize + play a single clip. Cancels any in-flight playback
  * before starting. Cache hits play immediately; cache misses fetch
  * first (typical 200–600ms for a 200-character response).
@@ -276,11 +309,22 @@ export async function cloudSpeak(
     return;
   }
 
+  // Force the audio session into playback mode BEFORE doing anything
+  // else. If useDictation just finished, the mode is still recording —
+  // playing under recording mode produces no audible output.
+  await ensurePlaybackAudioMode();
+
   let uri: string;
   try {
     uri = await fetchClip(text, options);
   } catch (e) {
     const err = e instanceof Error ? e : new Error(String(e));
+    // Log so silent failures are diagnosable from adb logcat. Without
+    // this, a 401/403/timeout looks identical to "audio is fine, just
+    // really quiet" to the user.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('cloudTTS: fetch failed —', err.message);
+    }
     options.onError?.(err);
     return;
   }
@@ -305,6 +349,9 @@ export async function cloudSpeak(
     });
   } catch (e) {
     const err = e instanceof Error ? e : new Error(String(e));
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('cloudTTS: playback failed —', err.message);
+    }
     options.onError?.(err);
   }
 }

--- a/kiaanverse-mobile/apps/mobile/voice/lib/divineVoice.ts
+++ b/kiaanverse-mobile/apps/mobile/voice/lib/divineVoice.ts
@@ -724,12 +724,27 @@ export function previewVoice(
         : persona === 'storyteller'
           ? 'storytelling'
           : 'calm';
+    // Cloud preview with on-device fallback. Without the fallback, a
+    // missing/invalid API key produces a silent picker — users tap
+    // Play and hear nothing. We surface SOMETHING in every case.
+    const fallbackToDevice = (reason: string) => {
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn('previewVoice: cloud failed, falling through —', reason);
+      }
+      const preset = PERSONA_PRESETS[persona];
+      Speech.speak(text, {
+        language,
+        rate: preset.rate,
+        pitch: preset.pitch,
+      });
+    };
     void cloudSpeak(text, {
       voiceId: backendId,
       language,
       voiceType,
       baseUrl: preview?.baseUrl,
       getAccessToken: preview?.getAccessToken,
+      onError: (err) => fallbackToDevice(err.message),
     });
     return;
   }

--- a/kiaanverse-mobile/apps/mobile/voice/lib/divineVoice.ts
+++ b/kiaanverse-mobile/apps/mobile/voice/lib/divineVoice.ts
@@ -553,10 +553,20 @@ export async function speakDivinely(
         : 'calm';
 
   // ── Tier 1: explicit cloud override ──
-  // The verse-detail screen's per-pill picker hands us ``divine-krishna``
-  // etc. directly. Skip the persisted-preference lookup entirely so
-  // the chosen voice plays exactly as labelled.
+  // The verse-detail screen's per-pill picker and Voice Companion hand
+  // us ``divine-krishna`` etc. directly. Skip the persisted-preference
+  // lookup entirely so the chosen voice plays exactly as labelled.
+  //
+  // If cloud fails (network, 401/403 from missing API key, mock provider
+  // returning empty audio, etc.) we MUST fall through to on-device
+  // Speech.speak so the user always hears something. Without this
+  // fallback, every "no audio output" failure mode is silent — the
+  // caller's onError fires (which voice-companion treats as onDone for
+  // the auto-listen loop), state cycles past 'speaking' instantly, and
+  // the user sees the screen flicker but never hears Sakha.
   if (options.cloudVoiceId) {
+    let cloudFailed = false;
+    let cloudError: Error | null = null;
     await cloudSpeak(text, {
       voiceId: options.cloudVoiceId,
       language,
@@ -564,20 +574,38 @@ export async function speakDivinely(
       baseUrl: options.baseUrl,
       getAccessToken: options.getAccessToken,
       onDone: options.onDone,
-      onError: options.onError,
+      onError: (err) => {
+        cloudFailed = true;
+        cloudError = err;
+      },
     });
-    return;
+    if (!cloudFailed) {
+      return;
+    }
+    // Cloud path failed → fall through to on-device. Log so the
+    // failure is diagnosable, but don't surface to the user as an
+    // error — they're about to hear the on-device voice instead.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        'speakDivinely: cloud TTS failed, falling through to on-device —',
+        cloudError?.message,
+      );
+    }
+    // Drop through to Tier 3 below.
   }
 
-  const resolvedVoice = getDivineVoiceSync(language);
+  const resolvedVoice = options.cloudVoiceId
+    ? undefined // explicit-cloud-failed branch: ignore persisted voice
+    : getDivineVoiceSync(language);
 
   // ── Tier 2: user-persisted cloud voice ──
-  if (isCloudVoiceId(resolvedVoice)) {
+  // Same fallthrough-on-failure as Tier 1 — never leave the user silent.
+  if (resolvedVoice && isCloudVoiceId(resolvedVoice)) {
     const backendId = parseCloudVoiceId(resolvedVoice as string);
     const meta = findCloudVoice(resolvedVoice as string);
-    if (!backendId || !meta) {
-      // Stale persisted id — fall through to on-device.
-    } else {
+    if (backendId && meta) {
+      let cloudFailed = false;
+      let cloudError: Error | null = null;
       await cloudSpeak(text, {
         voiceId: backendId,
         language,
@@ -585,10 +613,22 @@ export async function speakDivinely(
         baseUrl: options.baseUrl,
         getAccessToken: options.getAccessToken,
         onDone: options.onDone,
-        onError: options.onError,
+        onError: (err) => {
+          cloudFailed = true;
+          cloudError = err;
+        },
       });
-      return;
+      if (!cloudFailed) {
+        return;
+      }
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn(
+          'speakDivinely: persisted cloud voice failed, falling through to on-device —',
+          cloudError?.message,
+        );
+      }
     }
+    // Stale persisted id or cloud failure — drop through.
   }
 
   // ── Tier 3: on-device path ──


### PR DESCRIPTION
## Summary

Three commits addressing the user-reported "no audio output" across the app + restructuring the TTS provider chain to the user's stated priority (paid Sarvam → ElevenLabs → Microsoft Neural → Bhashini-future).

Continuation of #1712 (merged) which delivered the mobile voice picker + persona v1.3.0 + verse-pill cloud routing. This PR completes the audio-output fix end-to-end.

## Commits

| SHA | Theme |
|---|---|
| `36175c05` | First-tier silent-failure fixes — playback audio mode + cloud→on-device fallback in `speakDivinely` |
| `1980f983` | Deeper-tier fixes — `previewVoice` fallback + `Audio.Sound.createAsync` listener race for short clips |
| `e410fa3c` | Backend provider chain restructure — Sarvam→ElevenLabs→Microsoft Neural→Bhashini-future, uniform across all languages |

## Root causes traced

### 1. Audio session left in recording mode
`useDictation` sets `Audio.setAudioModeAsync({ allowsRecordingIOS: true })` when listening starts. On iOS that routes audio to the earpiece (very quiet); on Android it routes playback to the recording stream (silent). When dictation hands off to the LLM and Sakha tries to speak, the mode is still recording → no audible output.

**Fix:** `cloudSpeak` now calls `ensurePlaybackAudioMode()` BEFORE every `Audio.Sound.createAsync` — forces `allowsRecordingIOS: false`, `playsInSilentModeIOS: true`, `interruptionModeIOS/Android: DoNotMix`.

### 2. `speakDivinely` had no fallback when cloud failed
When the verse pills, Voice Companion, or chat Listen passed an explicit `cloudVoiceId`, `speakDivinely` called `cloudSpeak` and returned. If cloud failed (401/403 from missing API key, network timeout, mock provider returning empty audio, subscription gating), `onError` fired and we returned silent. Voice Companion's `onError = onSpeechFinished` ate the failure — silent skip in the auto-listen loop.

**Fix:** Both Tier 1 (explicit) and Tier 2 (persisted) now intercept `onError` from cloudSpeak. On failure, drop through to Tier 3 (on-device `Speech.speak` with divine prosody). User always hears something.

### 3. `previewVoice` had no fallback either
Voice picker's "Play" button calls `previewVoice` directly. With missing/invalid keys, users heard nothing. Now falls through to on-device with logging.

### 4. `setOnPlaybackStatusUpdate` race for short clips
Listener was attached AFTER `createAsync` resolved. For very short audio (<50ms), `didJustFinish` could fire before listener attached → `onDone` never fired → voice-companion stuck in 'speaking' state forever.

**Fix:** Listener passed as 3rd arg of `createAsync` (bound at creation, no race). Used `holder` pattern to break sound/listener cyclic dependency. Explicit `volume: 1.0` added too.

### 5. Backend provider chain wasted paid Sarvam plan + Edge TTS never called
Old chain: Indian languages tried Sarvam first; International (en, es, fr, ...) tried ElevenLabs first with Sarvam fallback only for English. Wasted user's paid Sarvam plan on English content (most chat / voice-companion traffic). Plus the comment claimed "Indian: Sarvam → ElevenLabs → Edge TTS" but Edge TTS was NEVER actually called — the `edge-tts` package + Microsoft Neural (50+ langs, studio-grade) was a free fallback sitting unused.

**Fix:** Uniform 4-tier chain across ALL languages: Sarvam (paid primary) → ElevenLabs (premium fallback) → Microsoft Neural via Edge TTS (free, ALWAYS available) → Bhashini AI (placeholder for future). Each tier explicitly logs identification.

## Errors made diagnosable

Every silent-failure path now emits a `console.warn` (mobile, surfaces in adb logcat) or `logger.info/warning/error` (backend, surfaces in Render logs):

```
cloudTTS: fetch failed — backend 403 Forbidden — {"error":"feature_not_available", ...}
cloudTTS: playback failed — could not decode audio data
speakDivinely: cloud TTS failed, falling through to on-device — backend 403 ...
previewVoice: cloud failed, falling through — Network request failed

INFO  Sarvam AI (Tier 1) synthesis success for hi voice=divine-saraswati
INFO  ElevenLabs (Tier 2) synthesis success for en voice=divine-krishna
INFO  Microsoft Neural / Edge TTS (Tier 3) synthesis success for ta ...
ERROR All TTS tiers failed for language=mr ... Configured: sarvam=True elevenlabs=False
```

## Provider priority (matches user's stated order)

| Tier | Provider | Status | Env var | Coverage |
|---|---|---|---|---|
| 1 | **Sarvam AI** | User has paid plan | `SARVAM_API_KEY` or `KIAAN_SARVAM_API_KEY` | 11 Indic + Indian English |
| 2 | **ElevenLabs** | Premium tier | `ELEVENLABS_API_KEY` or `KIAAN_ELEVENLABS_API_KEY` | 29+ languages |
| 3 | **Microsoft Neural** (Edge TTS) | Free, no key | none — `edge-tts>=6.1.0` already in `requirements.txt` | 50+ languages |
| 4 | **Bhashini AI** | Planned | TBD | Placeholder — provider class exists for WSS, sync wrapper for REST is a follow-up |

Mobile fallback (cloud → on-device `Speech.speak`) remains as final safety net if REST itself is unreachable.

## Coverage matrix

| Surface | Path | Cloud-fail fallback |
|---|---|---|
| Voice Companion live conversation | `speakDivinely(cloudVoiceId)` → cloud → on-device | ✓ |
| Chat Listen button | `speakDivinely` → cloud or on-device | ✓ |
| Verse-detail pills (Krishna/Saraswati/Rishi/Nova) | `speakDivinely(cloudVoiceId)` → cloud → on-device | ✓ |
| Voice picker preview (settings/voice) | `previewVoice` → cloud → on-device | ✓ |
| Voice Companion picker preview | `previewVoice` → cloud → on-device | ✓ |
| Backend `/api/voice/synthesize` | Sarvam → ElevenLabs → Microsoft Neural → ❌Bhashini | ✓ 3 tiers ship now |

## Verification

| Check | Result |
|---|---|
| `python3 -m py_compile` on all changed backend files | ✓ |
| Brackets balanced on all changed mobile files | ✓ |
| All 5 mobile validators (validate-plugins, validate-wss-types, validate-tool-contracts, test-pure-helpers, validate-bridge-coverage) | ✓ Green |
| `edge-tts>=6.1.0,<8.0.0` confirmed in `requirements.txt` | ✓ |
| Tier 1/2/3/4 explicit logging in place | ✓ |
| Audio mode forced before every `createAsync` | ✓ |
| Listener bound at sound creation — no race window | ✓ |
| All 4 cloud-routing paths fall through to on-device on cloud failure | ✓ |

## Ship strategy

**Backend changes** (`tts_service.py`) — auto-deploy on Render after merge.

**Mobile changes** (`cloudTTS.ts`, `divineVoice.ts`) — JS-only, `runtimeVersion: { policy: 'appVersion' }` is `1.3.2` unchanged → OTA-eligible:

```bash
cd kiaanverse-mobile/apps/mobile
npx eas-cli update --branch production --message "No-silent-output: audio mode + cloud->device fallback + Sarvam-first chain"
```

After this PR ships and a Sarvam env-var is confirmed set on Render, every Sakha utterance flows: paid Sarvam (Tier 1) → ElevenLabs (Tier 2) → Microsoft Neural (Tier 3) → on-device Speech.speak (mobile fallback). Silence-proof end-to-end.

## What's NOT in this PR (deferred)

- Wiring Tier 4 Bhashini AI for the REST path. Provider class already exists at `backend/services/voice/bhashini_provider.py` for WSS; needs a sync wrapper. Marked at the Tier 4 placeholder comment in `tts_service.py::_synthesize_with_providers`.

https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBpqhoie8wZ6eQy8LrfQAr)_