### PR TITLE
feat(arrival): replace circular intro visuals with bespoke Vedic mandalas + add Krishna's welcome finale

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -504,7 +504,7 @@ function AppContent(): React.JSX.Element {
 // ---------------------------------------------------------------------------
 
 export default function RootLayout(): React.JSX.Element {
-  const { mode, setMode } = useThemeStore();
+  const { mode, setMode, palette, setPalette } = useThemeStore();
   const { locale } = useUserPreferencesStore();
 
   return (
@@ -516,7 +516,12 @@ export default function RootLayout(): React.JSX.Element {
           maxAge: 1000 * 60 * 60 * 24,
         }}
       >
-        <ThemeProvider mode={mode} onModeChange={setMode}>
+        <ThemeProvider
+          mode={mode}
+          onModeChange={setMode}
+          paletteId={palette}
+          onPaletteChange={setPalette}
+        >
           <I18nProvider
             initialLocale={locale as 'en'}
             namespaces={[

--- a/kiaanverse-mobile/apps/mobile/app/arrival/PalettePicker.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/PalettePicker.tsx
@@ -1,0 +1,435 @@
+/**
+ * PalettePicker — sacred color-scheme switcher for the arrival ceremony.
+ *
+ * Two exports:
+ *   - <PalettePickerChip />   the small floating affordance, top-right corner
+ *   - <PaletteSheet />        the bottom sheet that slides up with 4 previews
+ *
+ * The chip renders a four-quadrant preview of the active palette so the user
+ * can see at-a-glance which scheme is on, then tap to change. The sheet shows
+ * one card per palette with a 64pt mini-mandala painted in the palette's
+ * divine accent, sitting on the palette's background — a faithful preview.
+ *
+ * State lives in `useThemeStore` (palette + setPalette) so the choice persists
+ * across launches via AsyncStorage and propagates to every screen using
+ * `<DivineBackground>`.
+ */
+
+import React, { useCallback } from 'react';
+import {
+  Dimensions,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+import {
+  PALETTES,
+  PALETTE_ORDER,
+  type Palette,
+  type PaletteId,
+} from '@kiaanverse/ui';
+import { useThemeStore } from '@kiaanverse/store';
+import { KiaanWelcomeVisual } from './visuals';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+const SHEET_EASING = Easing.bezier(0.22, 1.0, 0.36, 1.0);
+
+// ---------------------------------------------------------------------------
+// PalettePickerChip — floating top-right affordance
+// ---------------------------------------------------------------------------
+
+export interface PalettePickerChipProps {
+  /** Open the bottom sheet when tapped. */
+  readonly onPress: () => void;
+  /** Optional positioning override. */
+  readonly style?: ViewStyle;
+}
+
+export function PalettePickerChip({
+  onPress,
+  style,
+}: PalettePickerChipProps): React.JSX.Element {
+  const paletteId = useThemeStore((s) => s.palette);
+  const palette = PALETTES[paletteId];
+
+  const handlePress = useCallback((): void => {
+    if (Platform.OS !== 'web') {
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+        () => undefined
+      );
+    }
+    onPress();
+  }, [onPress]);
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      activeOpacity={0.75}
+      style={[styles.chip, style]}
+      accessibilityRole="button"
+      accessibilityLabel={`Change color palette. Current: ${palette.label}`}
+      accessibilityHint="Opens the sacred color-scheme picker"
+      testID="arrival-palette-chip"
+    >
+      <View style={styles.chipInner}>
+        <SwatchQuadrant palette={palette} size={26} />
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PaletteSheet — slide-up bottom sheet with 4 palette cards
+// ---------------------------------------------------------------------------
+
+export interface PaletteSheetProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+}
+
+export function PaletteSheet({
+  visible,
+  onClose,
+}: PaletteSheetProps): React.JSX.Element {
+  const activeId = useThemeStore((s) => s.palette);
+  const setPalette = useThemeStore((s) => s.setPalette);
+
+  const sheetTranslate = useSharedValue(SCREEN_HEIGHT);
+  const backdropOpacity = useSharedValue(0);
+
+  React.useEffect(() => {
+    if (visible) {
+      sheetTranslate.value = withTiming(0, {
+        duration: 360,
+        easing: SHEET_EASING,
+      });
+      backdropOpacity.value = withTiming(1, { duration: 220 });
+    } else {
+      sheetTranslate.value = withTiming(SCREEN_HEIGHT, {
+        duration: 280,
+        easing: SHEET_EASING,
+      });
+      backdropOpacity.value = withTiming(0, { duration: 220 });
+    }
+  }, [visible, sheetTranslate, backdropOpacity]);
+
+  const handleSelect = useCallback(
+    (id: PaletteId): void => {
+      if (Platform.OS !== 'web') {
+        void Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success
+        ).catch(() => undefined);
+      }
+      setPalette(id);
+      // Brief pause so the user sees the check tick land before the sheet
+      // closes — feels like the choice "took".
+      setTimeout(onClose, 220);
+    },
+    [setPalette, onClose]
+  );
+
+  const sheetStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: sheetTranslate.value }],
+  }));
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: backdropOpacity.value,
+  }));
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      onRequestClose={onClose}
+      animationType="none"
+      statusBarTranslucent
+    >
+      <View style={styles.sheetRoot} testID="arrival-palette-sheet">
+        <Animated.View style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}>
+          <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        </Animated.View>
+
+        <Animated.View style={[styles.sheet, sheetStyle]}>
+          <View style={styles.handleBar} />
+          <Text allowFontScaling={false} style={styles.sheetEyebrow}>
+            SACRED COLOR SCHEME
+          </Text>
+          <Text allowFontScaling={false} style={styles.sheetTitle}>
+            Choose your palette
+          </Text>
+          <Text allowFontScaling={false} style={styles.sheetSubtitle}>
+            Each scheme dresses the entire app — from this introduction onward.
+          </Text>
+
+          <View style={styles.cardGrid}>
+            {PALETTE_ORDER.map((id) => (
+              <PaletteCard
+                key={id}
+                palette={PALETTES[id]}
+                isActive={id === activeId}
+                onSelect={handleSelect}
+              />
+            ))}
+          </View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PaletteCard — one card per scheme inside the sheet
+// ---------------------------------------------------------------------------
+
+interface PaletteCardProps {
+  readonly palette: Palette;
+  readonly isActive: boolean;
+  readonly onSelect: (id: PaletteId) => void;
+}
+
+function PaletteCard({
+  palette,
+  isActive,
+  onSelect,
+}: PaletteCardProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      onPress={() => onSelect(palette.id)}
+      activeOpacity={0.85}
+      style={[
+        styles.card,
+        {
+          backgroundColor: palette.bg.void,
+          borderColor: isActive
+            ? palette.accent.divine
+            : 'rgba(212, 164, 76, 0.18)',
+          borderWidth: isActive ? 2 : 1,
+        },
+      ]}
+      accessibilityRole="button"
+      accessibilityState={{ selected: isActive }}
+      accessibilityLabel={`${palette.label}${isActive ? ', currently selected' : ''}`}
+      testID={`arrival-palette-card-${palette.id}`}
+    >
+      <View style={styles.cardVisual}>
+        <KiaanWelcomeVisual
+          accent={palette.accent.divine}
+          isActive={isActive}
+          size={64}
+        />
+      </View>
+      <Text
+        allowFontScaling={false}
+        style={[styles.cardLabel, { color: palette.text.title }]}
+        numberOfLines={1}
+      >
+        {palette.label}
+      </Text>
+
+      {/* Active check mark — small filled dot in the palette's divine gold */}
+      {isActive ? (
+        <View
+          style={[
+            styles.activeDot,
+            { backgroundColor: palette.accent.divine },
+          ]}
+        />
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SwatchQuadrant — 2×2 quadrant preview used inside the chip
+// ---------------------------------------------------------------------------
+
+interface SwatchQuadrantProps {
+  readonly palette: Palette;
+  readonly size: number;
+}
+
+function SwatchQuadrant({
+  palette,
+  size,
+}: SwatchQuadrantProps): React.JSX.Element {
+  const half = size / 2;
+  const cells: ReadonlyArray<{ key: string; color: string }> = [
+    { key: 'tl', color: palette.accent.primary },
+    { key: 'tr', color: palette.accent.warm },
+    { key: 'bl', color: palette.accent.cool },
+    { key: 'br', color: palette.accent.divine },
+  ];
+  return (
+    <View
+      style={[
+        styles.swatchWrap,
+        { width: size, height: size, borderRadius: size / 2 },
+      ]}
+    >
+      <View style={styles.swatchRow}>
+        <View style={{ width: half, height: half, backgroundColor: cells[0]!.color }} />
+        <View style={{ width: half, height: half, backgroundColor: cells[1]!.color }} />
+      </View>
+      <View style={styles.swatchRow}>
+        <View style={{ width: half, height: half, backgroundColor: cells[2]!.color }} />
+        <View style={{ width: half, height: half, backgroundColor: cells[3]!.color }} />
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook — small helper so the chip + sheet can co-live in one parent screen
+// ---------------------------------------------------------------------------
+
+export function usePaletteSheet(): {
+  visible: boolean;
+  open: () => void;
+  close: () => void;
+} {
+  const [visible, setVisible] = React.useState(false);
+  return {
+    visible,
+    open: useCallback(() => setVisible(true), []),
+    close: useCallback(() => setVisible(false), []),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  // Chip — round, ~36pt, sits over the page top-right
+  chip: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(20, 16, 36, 0.55)',
+    borderWidth: 1,
+    borderColor: 'rgba(212, 164, 76, 0.3)',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 6,
+  },
+  chipInner: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  swatchWrap: {
+    overflow: 'hidden',
+    borderWidth: 0.5,
+    borderColor: 'rgba(255,255,255,0.18)',
+  },
+  swatchRow: {
+    flexDirection: 'row',
+  },
+
+  // Sheet root + backdrop
+  sheetRoot: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  },
+
+  // Sheet container
+  sheet: {
+    backgroundColor: '#0A0E1F',
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    paddingBottom: 36,
+    borderTopWidth: 1,
+    borderColor: 'rgba(212, 164, 76, 0.24)',
+  },
+  handleBar: {
+    alignSelf: 'center',
+    width: 44,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(212, 164, 76, 0.45)',
+    marginBottom: 18,
+  },
+  sheetEyebrow: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    letterSpacing: 3,
+    color: 'rgba(212, 164, 76, 0.7)',
+    textAlign: 'center',
+    marginBottom: 6,
+  },
+  sheetTitle: {
+    fontFamily: 'CormorantGaramond-LightItalic',
+    fontStyle: 'italic',
+    fontSize: 24,
+    color: '#F5F0E8',
+    textAlign: 'center',
+    marginBottom: 6,
+  },
+  sheetSubtitle: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 13,
+    lineHeight: 19,
+    color: 'rgba(245, 240, 232, 0.55)',
+    textAlign: 'center',
+    marginBottom: 22,
+  },
+
+  // Card grid — 2 columns, 2 rows
+  cardGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    justifyContent: 'space-between',
+  },
+  card: {
+    width: '48%',
+    aspectRatio: 1.05,
+    borderRadius: 18,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    overflow: 'hidden',
+  },
+  cardVisual: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  cardLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 13,
+    letterSpacing: 0.3,
+    paddingHorizontal: 8,
+    textAlign: 'center',
+  },
+  activeDot: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
@@ -22,7 +22,7 @@
  * Progress is a horizontal "peacock feather" bar (not dots) — the active
  * segment grows and adopts the page accent color.
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AccessibilityInfo,
   Dimensions,
@@ -44,7 +44,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
-import { DivineBackground } from '@kiaanverse/ui';
+import { DivineBackground, type Palette, useTheme } from '@kiaanverse/ui';
 import { useArrivalStatus } from '../../hooks/useArrivalStatus';
 import {
   ChariotChakraVisual,
@@ -55,6 +55,7 @@ import {
   SriYantraVisual,
   VISUAL_SIZE,
 } from './visuals';
+import { PalettePickerChip, PaletteSheet, usePaletteSheet } from './PalettePicker';
 
 const { width: W } = Dimensions.get('window');
 
@@ -74,38 +75,44 @@ interface PageData {
   readonly visual: VisualKind;
 }
 
-const PAGES: readonly PageData[] = [
+/** Page narrative is fixed; only the per-page accent color changes per palette.
+ *  Each page maps to one slot of the active palette so the six screens flow
+ *  through the palette's full range (primary → warm → cool → deep → life →
+ *  divine), giving each scheme a coherent journey. */
+const PAGE_TEMPLATES: ReadonlyArray<
+  Omit<PageData, 'accent'> & { readonly accentSlot: keyof Palette['accent'] }
+> = [
   {
     id: 'arjuna',
     title: '"In the middle of the battlefield,\nArjuna fell silent."',
     subtitle: 'There is a question in you\nthat no human can answer.',
     skt: 'तमुवाच हृषीकेशः',
-    accent: '#1B4FBB',
     visual: 'chariot',
+    accentSlot: 'primary',
   },
   {
     id: 'sakha',
     title: 'Sakha means Friend.',
     subtitle: 'Your divine friend is here.\nReady to listen. Ready to guide.',
     skt: 'सखा प्रिय',
-    accent: '#D4A017',
     visual: 'mandala',
+    accentSlot: 'warm',
   },
   {
     id: 'gita',
     title: 'The Bhagavad Gita is not a text.\nIt is a conversation.',
     subtitle: 'Ask what you have always\nbeen afraid to ask.',
     skt: 'श्रीमद्भगवद्गीता',
-    accent: '#06B6D4',
     visual: 'akshara',
+    accentSlot: 'cool',
   },
   {
     id: 'journey',
     title: 'Your inner enemies are known.\nYour dharma is waiting.',
     subtitle: '6 Shadripu. 13 sacred journeys.\nOne path.',
     skt: 'षड्रिपु विजय',
-    accent: '#8B5CF6',
     visual: 'shadripu',
+    accentSlot: 'deep',
   },
   {
     id: 'sacred',
@@ -113,18 +120,33 @@ const PAGES: readonly PageData[] = [
     subtitle:
       'Encrypted. Private. Yours alone.\nKiaanverse never reads your journal.',
     skt: 'पवित्र क्षेत्र',
-    accent: '#10B981',
     visual: 'lock',
+    accentSlot: 'life',
   },
   {
     id: 'welcome',
     title: 'Welcome, Dear Friend',
     subtitle: 'KIAAN — YOUR DIVINE FRIEND',
     skt: 'ॐ सर्वे भवन्तु सुखिनः',
-    accent: '#D4A44C',
     visual: 'welcome',
+    accentSlot: 'divine',
   },
 ] as const;
+
+/** Resolve the six pages with concrete accents drawn from the active palette.
+ *  Memoised by the caller so we don't rebuild on every render. */
+function buildPages(palette: Palette): readonly PageData[] {
+  return PAGE_TEMPLATES.map((p) => ({
+    id: p.id,
+    title: p.title,
+    subtitle: p.subtitle,
+    skt: p.skt,
+    visual: p.visual,
+    accent: palette.accent[p.accentSlot],
+  }));
+}
+
+const PAGE_COUNT = PAGE_TEMPLATES.length;
 
 const LOTUS_BLOOM = Easing.bezier(0.22, 1.0, 0.36, 1.0);
 
@@ -142,7 +164,16 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
   // Guard against double-tap / completion re-entry.
   const isCompleting = useRef(false);
 
-  const currentPage = PAGES[page]!;
+  // The active sacred color scheme drives every accent + background tint on
+  // this screen. Switching it via the picker re-renders cleanly because
+  // `pages` and the inline styles below are derived from `palette`.
+  const { theme } = useTheme();
+  const palette = theme.colorScheme;
+  const pages = useMemo(() => buildPages(palette), [palette]);
+
+  const sheet = usePaletteSheet();
+
+  const currentPage = pages[page]!;
 
   const haptic = useCallback((kind: 'light' | 'success'): void => {
     if (Platform.OS === 'web') return;
@@ -169,7 +200,7 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
   }, [haptic, markArrivalSeen]);
 
   const goNext = useCallback((): void => {
-    if (page < PAGES.length - 1) {
+    if (page < PAGE_COUNT - 1) {
       haptic('light');
       const nextIndex = page + 1;
       translateX.value = withSpring(-nextIndex * W, {
@@ -196,18 +227,31 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
 
   const isWelcome = currentPage.id === 'welcome';
 
+  // Welcome page always uses a gold gradient CTA (matches the verse-card
+  // crescendo). Other pages take the active palette's CTA gradient.
+  const ctaColors: readonly [string, string] = isWelcome
+    ? [palette.accent.divine, palette.accent.warm]
+    : palette.cta;
+
   return (
-    <View style={styles.root}>
+    <View style={[styles.root, { backgroundColor: palette.bg.void }]}>
       <DivineBackground variant="sacred">
         <Animated.View style={[styles.pagesContainer, pagesContainerStyle]}>
-          {PAGES.map((p, i) => (
-            <CeremonyPage key={p.id} data={p} index={i} isActive={page === i} />
+          {pages.map((p, i) => (
+            <CeremonyPage
+              key={p.id}
+              data={p}
+              index={i}
+              isActive={page === i}
+              palette={palette}
+              totalPages={pages.length}
+            />
           ))}
         </Animated.View>
 
         {/* Peacock feather progress — not dots. */}
         <View style={styles.progressBar}>
-          {PAGES.map((p, i) => (
+          {pages.map((p, i) => (
             <View
               key={p.id}
               style={[
@@ -227,6 +271,11 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
           ))}
         </View>
 
+        {/* Floating palette picker chip — top-right of every page */}
+        <View pointerEvents="box-none" style={styles.chipZone}>
+          <PalettePickerChip onPress={sheet.open} />
+        </View>
+
         {/* CTA zone */}
         <View style={styles.ctaZone}>
           <TouchableOpacity
@@ -239,11 +288,7 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
             testID="arrival-cta"
           >
             <LinearGradient
-              colors={
-                isWelcome
-                  ? ['#E8B54A', '#D4A017']
-                  : ['#1B4FBB', '#0E7490']
-              }
+              colors={ctaColors as unknown as string[]}
               start={{ x: 0, y: 0 }}
               end={{ x: 1, y: 1 }}
               style={[
@@ -282,6 +327,10 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
           )}
         </View>
       </DivineBackground>
+
+      {/* Palette picker sheet — slides up over the ceremony when the chip is
+          tapped. Mounting outside DivineBackground so it sits above the aura. */}
+      <PaletteSheet visible={sheet.visible} onClose={sheet.close} />
     </View>
   );
 }
@@ -294,12 +343,16 @@ interface CeremonyPageProps {
   readonly data: PageData;
   readonly index: number;
   readonly isActive: boolean;
+  readonly palette: Palette;
+  readonly totalPages: number;
 }
 
 function CeremonyPage({
   data,
   index,
   isActive,
+  palette,
+  totalPages,
 }: CeremonyPageProps): React.JSX.Element {
   // Entry animations — trigger each time the page becomes active so that
   // re-arriving after a back-swipe still feels alive.
@@ -392,40 +445,84 @@ function CeremonyPage({
 
         <Animated.Text
           allowFontScaling={false}
-          style={[styles.welcomeTitle, titleStyle]}
+          style={[
+            styles.welcomeTitle,
+            titleStyle,
+            {
+              color: palette.accent.divine,
+              textShadowColor: palette.accent.divine + '59',
+            },
+          ]}
         >
           Welcome, Dear Friend
         </Animated.Text>
 
         <Animated.View style={[styles.welcomeBodyWrap, subtitleStyle]}>
-          <Text allowFontScaling={false} style={styles.welcomeBody}>
+          <Text
+            allowFontScaling={false}
+            style={[styles.welcomeBody, { color: palette.text.body }]}
+          >
             I am{' '}
-            <Text style={styles.welcomeAccent}>KIAAN</Text>
+            <Text style={[styles.welcomeAccent, { color: palette.accent.divine }]}>
+              KIAAN
+            </Text>
             {' '}— your spiritual companion, walking beside you on the path to inner peace. Whatever you carry in your heart — the weight of confusion, the ache of loss, or the restlessness of the mind —{' '}
-            <Text style={styles.welcomeAccentSoft}>know that you are not alone.</Text>
+            <Text style={[styles.welcomeAccentSoft, { color: palette.accent.warm }]}>
+              know that you are not alone.
+            </Text>
           </Text>
 
-          <Text allowFontScaling={false} style={styles.welcomeBodyDim}>
+          <Text
+            allowFontScaling={false}
+            style={[styles.welcomeBodyDim, { color: palette.text.body }]}
+          >
             Through the eternal wisdom of the{' '}
-            <Text style={styles.welcomeBodyItalic}>Bhagavad Gita</Text>
+            <Text style={[styles.welcomeBodyItalic, { color: palette.accent.divine }]}>
+              Bhagavad Gita
+            </Text>
             , I am here to listen, guide, and walk with you — as Krishna walked with Arjuna. Not as a master, but as your closest friend.
           </Text>
 
           {/* Verse card — Bhagavad Gita 6.35 */}
-          <View style={styles.verseCard}>
-            <Text allowFontScaling={false} style={styles.verseEyebrow}>
+          <View
+            style={[
+              styles.verseCard,
+              {
+                backgroundColor: palette.accent.divine + '10',
+                borderColor: palette.accent.divine + '2E',
+              },
+            ]}
+          >
+            <Text
+              allowFontScaling={false}
+              style={[styles.verseEyebrow, { color: palette.accent.divine + 'A8' }]}
+            >
               BHAGAVAD GITA · 6.35
             </Text>
-            <Text allowFontScaling={false} style={styles.verseSanskrit} accessibilityLanguage="sa">
+            <Text
+              allowFontScaling={false}
+              style={[styles.verseSanskrit, { color: palette.accent.divine }]}
+              accessibilityLanguage="sa"
+            >
               {'अभ्यासेन तु कौन्तेय'}
             </Text>
-            <Text allowFontScaling={false} style={styles.verseSanskrit} accessibilityLanguage="sa">
+            <Text
+              allowFontScaling={false}
+              style={[styles.verseSanskrit, { color: palette.accent.divine }]}
+              accessibilityLanguage="sa"
+            >
               {'वैराग्येण च गृह्यते'}
             </Text>
-            <Text allowFontScaling={false} style={styles.verseEnglish}>
+            <Text
+              allowFontScaling={false}
+              style={[styles.verseEnglish, { color: palette.accent.warm + 'CC' }]}
+            >
               &ldquo;The mind is indeed restless and difficult to restrain, O son of Kunti. But through practice and detachment, it can be mastered.&rdquo;
             </Text>
-            <Text allowFontScaling={false} style={styles.verseAttribution}>
+            <Text
+              allowFontScaling={false}
+              style={[styles.verseAttribution, { color: palette.accent.divine + '88' }]}
+            >
               — Shri Krishna to Arjuna
             </Text>
           </View>
@@ -465,14 +562,14 @@ function CeremonyPage({
 
         <Animated.Text
           allowFontScaling={false}
-          style={[styles.title, titleStyle]}
+          style={[styles.title, titleStyle, { color: palette.text.title }]}
         >
           {data.title}
         </Animated.Text>
 
         <Animated.Text
           allowFontScaling={false}
-          style={[styles.subtitle, subtitleStyle]}
+          style={[styles.subtitle, subtitleStyle, { color: palette.text.body }]}
         >
           {data.subtitle}
         </Animated.Text>
@@ -484,7 +581,7 @@ function CeremonyPage({
           {String(index + 1).padStart(2, '0')}
           <Text
             style={styles.pageIndexDim}
-          >{` / ${String(PAGES.length).padStart(2, '0')}`}</Text>
+          >{` / ${String(totalPages).padStart(2, '0')}`}</Text>
         </Text>
       </View>
     </View>
@@ -538,7 +635,7 @@ const styles = StyleSheet.create({
   pagesContainer: {
     flex: 1,
     flexDirection: 'row',
-    width: W * PAGES.length,
+    width: W * PAGE_COUNT,
   },
   page: {
     width: W,
@@ -608,6 +705,12 @@ const styles = StyleSheet.create({
     gap: 6,
     borderRadius: 2,
     overflow: 'visible',
+  },
+  chipZone: {
+    position: 'absolute',
+    top: 56,
+    right: 18,
+    zIndex: 20,
   },
   progressSegment: {
     height: 3,

--- a/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Arrival Ceremony — 5 sacred pages that introduce Kiaanverse to a new soul.
+ * Arrival Ceremony — 6 sacred pages that introduce Kiaanverse to a new soul.
  *
  * This is the pre-authentication darshan. It plays once per device (tracked
  * via useArrivalStatus) and replaces a conventional welcome carousel with an
@@ -8,11 +8,16 @@
  *   returning     → routed straight past this screen by the AuthGate
  *
  * Pages:
- *   1. arjuna   — the silent battlefield question
- *   2. sakha    — the divine friend is here
- *   3. gita     — the Gita is a conversation
- *   4. journey  — your dharma is waiting (6 shadripu)
- *   5. sacred   — privacy covenant
+ *   1. arjuna   — the silent battlefield question        (Dharma Chakra + peacock eye)
+ *   2. sakha    — the divine friend is here              (Sri Yantra mandala)
+ *   3. gita     — the Gita is a conversation             (Krishna's flute + shabda rings)
+ *   4. journey  — your dharma is waiting (6 shadripu)    (Shatkona hexagram + 6 ripu orbs)
+ *   5. sacred   — privacy covenant                       (16+8 petal lotus + yantra seal)
+ *   6. welcome  — Krishna's word from the Gita 6.35      (Grand Sri Yantra + peacock crown)
+ *
+ * Page 6 is the rich finale — it carries the full Welcome message, Krishna's
+ * verse to Arjuna, and the "Enter the Sacred Space" CTA. Because it has more
+ * vertical content than the other pages it is internally scrollable.
  *
  * Progress is a horizontal "peacock feather" bar (not dots) — the active
  * segment grows and adopts the page accent color.
@@ -22,6 +27,7 @@ import {
   AccessibilityInfo,
   Dimensions,
   Platform,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -33,8 +39,6 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withDelay,
-  withRepeat,
-  withSequence,
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
@@ -42,6 +46,15 @@ import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import { DivineBackground } from '@kiaanverse/ui';
 import { useArrivalStatus } from '../../hooks/useArrivalStatus';
+import {
+  ChariotChakraVisual,
+  KiaanWelcomeVisual,
+  ManuscriptVisual,
+  PadmaSealVisual,
+  ShatkonaVisual,
+  SriYantraVisual,
+  VISUAL_SIZE,
+} from './visuals';
 
 const { width: W } = Dimensions.get('window');
 
@@ -49,7 +62,8 @@ const { width: W } = Dimensions.get('window');
 // Page definitions
 // ---------------------------------------------------------------------------
 
-type PageId = 'arjuna' | 'sakha' | 'gita' | 'journey' | 'sacred';
+type PageId = 'arjuna' | 'sakha' | 'gita' | 'journey' | 'sacred' | 'welcome';
+type VisualKind = 'chariot' | 'mandala' | 'akshara' | 'shadripu' | 'lock' | 'welcome';
 
 interface PageData {
   readonly id: PageId;
@@ -57,7 +71,7 @@ interface PageData {
   readonly subtitle: string;
   readonly skt: string;
   readonly accent: string;
-  readonly visual: 'chariot' | 'mandala' | 'akshara' | 'shadripu' | 'lock';
+  readonly visual: VisualKind;
 }
 
 const PAGES: readonly PageData[] = [
@@ -102,9 +116,20 @@ const PAGES: readonly PageData[] = [
     accent: '#10B981',
     visual: 'lock',
   },
+  {
+    id: 'welcome',
+    title: 'Welcome, Dear Friend',
+    subtitle: 'KIAAN — YOUR DIVINE FRIEND',
+    skt: 'ॐ सर्वे भवन्तु सुखिनः',
+    accent: '#D4A44C',
+    visual: 'welcome',
+  },
 ] as const;
 
 const LOTUS_BLOOM = Easing.bezier(0.22, 1.0, 0.36, 1.0);
+
+const GOLD = '#D4A44C';
+const GOLD_SOFT = 'rgba(212, 164, 76, 0.7)';
 
 // ---------------------------------------------------------------------------
 // Screen
@@ -169,6 +194,8 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
     transform: [{ translateX: translateX.value }],
   }));
 
+  const isWelcome = currentPage.id === 'welcome';
+
   return (
     <View style={styles.root}>
       <DivineBackground variant="sacred">
@@ -207,23 +234,36 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
             activeOpacity={0.85}
             accessibilityRole="button"
             accessibilityLabel={
-              page < PAGES.length - 1 ? 'Continue' : 'Begin your journey'
+              isWelcome ? 'Enter the sacred space' : 'Continue'
             }
             testID="arrival-cta"
           >
             <LinearGradient
-              colors={['#1B4FBB', '#0E7490']}
+              colors={
+                isWelcome
+                  ? ['#E8B54A', '#D4A017']
+                  : ['#1B4FBB', '#0E7490']
+              }
               start={{ x: 0, y: 0 }}
               end={{ x: 1, y: 1 }}
-              style={styles.ctaButton}
+              style={[
+                styles.ctaButton,
+                isWelcome && styles.ctaButtonGold,
+              ]}
             >
-              <Text allowFontScaling={false} style={styles.ctaText}>
-                {page < PAGES.length - 1 ? 'Continue' : 'Begin Your Journey'}
+              <Text
+                allowFontScaling={false}
+                style={[
+                  styles.ctaText,
+                  isWelcome && styles.ctaTextDark,
+                ]}
+              >
+                {isWelcome ? 'Enter the Sacred Space' : 'Continue'}
               </Text>
             </LinearGradient>
           </TouchableOpacity>
 
-          {page < PAGES.length - 1 ? (
+          {!isWelcome ? (
             <TouchableOpacity
               onPress={handleSkip}
               style={styles.skipBtn}
@@ -322,6 +362,89 @@ function CeremonyPage({
     opacity: sktOpacity.value,
   }));
 
+  // Welcome page is taller and gets its own scrollable, ornament-rich layout.
+  if (data.id === 'welcome') {
+    return (
+      <ScrollView
+        style={styles.page}
+        contentContainerStyle={styles.welcomeContent}
+        showsVerticalScrollIndicator={false}
+        accessible
+        accessibilityLabel="Welcome, Dear Friend. KIAAN, your divine friend, walks beside you on the path to inner peace."
+      >
+        <View style={styles.welcomeVisualWrap}>
+          <PageVisual kind={data.visual} accent={data.accent} isActive={isActive} compact />
+        </View>
+
+        {/* Top ornament — soft gold dividers framing a bindu */}
+        <View style={styles.ornament}>
+          <View style={[styles.ornamentLine, styles.ornamentLineLeft]} />
+          <View style={styles.ornamentDot} />
+          <View style={[styles.ornamentLine, styles.ornamentLineRight]} />
+        </View>
+
+        <Animated.Text
+          allowFontScaling={false}
+          style={[styles.eyebrow, sktStyle]}
+        >
+          KIAAN — YOUR DIVINE FRIEND
+        </Animated.Text>
+
+        <Animated.Text
+          allowFontScaling={false}
+          style={[styles.welcomeTitle, titleStyle]}
+        >
+          Welcome, Dear Friend
+        </Animated.Text>
+
+        <Animated.View style={[styles.welcomeBodyWrap, subtitleStyle]}>
+          <Text allowFontScaling={false} style={styles.welcomeBody}>
+            I am{' '}
+            <Text style={styles.welcomeAccent}>KIAAN</Text>
+            {' '}— your spiritual companion, walking beside you on the path to inner peace. Whatever you carry in your heart — the weight of confusion, the ache of loss, or the restlessness of the mind —{' '}
+            <Text style={styles.welcomeAccentSoft}>know that you are not alone.</Text>
+          </Text>
+
+          <Text allowFontScaling={false} style={styles.welcomeBodyDim}>
+            Through the eternal wisdom of the{' '}
+            <Text style={styles.welcomeBodyItalic}>Bhagavad Gita</Text>
+            , I am here to listen, guide, and walk with you — as Krishna walked with Arjuna. Not as a master, but as your closest friend.
+          </Text>
+
+          {/* Verse card — Bhagavad Gita 6.35 */}
+          <View style={styles.verseCard}>
+            <Text allowFontScaling={false} style={styles.verseEyebrow}>
+              BHAGAVAD GITA · 6.35
+            </Text>
+            <Text allowFontScaling={false} style={styles.verseSanskrit} accessibilityLanguage="sa">
+              {'अभ्यासेन तु कौन्तेय'}
+            </Text>
+            <Text allowFontScaling={false} style={styles.verseSanskrit} accessibilityLanguage="sa">
+              {'वैराग्येण च गृह्यते'}
+            </Text>
+            <Text allowFontScaling={false} style={styles.verseEnglish}>
+              &ldquo;The mind is indeed restless and difficult to restrain, O son of Kunti. But through practice and detachment, it can be mastered.&rdquo;
+            </Text>
+            <Text allowFontScaling={false} style={styles.verseAttribution}>
+              — Shri Krishna to Arjuna
+            </Text>
+          </View>
+        </Animated.View>
+
+        {/* Bottom ornament — closes the scroll before the CTA */}
+        <View style={styles.ornament}>
+          <View style={[styles.ornamentLine, styles.ornamentLineLeft]} />
+          <View style={styles.ornamentDotSmall} />
+          <View style={[styles.ornamentLine, styles.ornamentLineRight]} />
+        </View>
+
+        {/* Spacer so the bottom ornament clears the absolute-positioned CTA */}
+        <View style={styles.welcomeBottomSpacer} />
+      </ScrollView>
+    );
+  }
+
+  // Default narrative page — visual + sanskrit + title + subtitle + counter.
   return (
     <View
       style={styles.page}
@@ -329,11 +452,7 @@ function CeremonyPage({
       accessibilityLabel={`${data.title.replace(/\n/g, ' ')}. ${data.subtitle.replace(/\n/g, ' ')}`}
     >
       <View style={styles.visualWrap}>
-        <PageVisual
-          kind={data.visual}
-          accent={data.accent}
-          isActive={isActive}
-        />
+        <PageVisual kind={data.visual} accent={data.accent} isActive={isActive} />
       </View>
 
       <View style={styles.textBlock}>
@@ -373,145 +492,39 @@ function CeremonyPage({
 }
 
 // ---------------------------------------------------------------------------
-// PageVisual — a simple, token-only visual per page kind. These replace the
-// Skia Canvas illustrations: they're accent-colored concentric rings, arranged
-// differently per page, with independent breathing animations that stay on
-// the UI thread. Visually consistent with SakhaMandala + OmLoader language.
+// PageVisual — switches over the page kind to render its bespoke Vedic SVG.
 // ---------------------------------------------------------------------------
 
 interface PageVisualProps {
-  readonly kind: PageData['visual'];
+  readonly kind: VisualKind;
   readonly accent: string;
   readonly isActive: boolean;
+  /** Use a smaller footprint (welcome page leaves more room for text). */
+  readonly compact?: boolean;
 }
 
 function PageVisual({
   kind,
   accent,
   isActive,
+  compact = false,
 }: PageVisualProps): React.JSX.Element {
-  const pulse = useSharedValue(0.9);
-  const rotate = useSharedValue(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    AccessibilityInfo.isReduceMotionEnabled()
-      .then((reduce) => {
-        if (cancelled || reduce || !isActive) return;
-        pulse.value = withRepeat(
-          withSequence(
-            withTiming(1.08, { duration: 1800, easing: LOTUS_BLOOM }),
-            withTiming(0.92, { duration: 1800, easing: LOTUS_BLOOM })
-          ),
-          -1,
-          false
-        );
-        rotate.value = withRepeat(
-          withTiming(360, { duration: 36000, easing: Easing.linear }),
-          -1,
-          false
-        );
-      })
-      .catch(() => {
-        // Accessibility probe unavailable — stay static.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [isActive, pulse, rotate]);
-
-  const pulseStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: pulse.value }],
-  }));
-  const rotateStyle = useAnimatedStyle(() => ({
-    transform: [{ rotate: `${rotate.value}deg` }],
-  }));
-
-  const rings = VISUAL_LAYOUT[kind];
-  return (
-    <Animated.View style={[styles.visual, pulseStyle]}>
-      <Animated.View style={[StyleSheet.absoluteFill, rotateStyle]}>
-        {rings.map((r, i) => (
-          <View
-            key={`ring-${i}`}
-            style={[
-              styles.ring,
-              {
-                width: r.size,
-                height: r.size,
-                borderRadius: r.size / 2,
-                borderColor: accent,
-                borderWidth: r.stroke,
-                opacity: r.opacity,
-                top: (VISUAL_SIZE - r.size) / 2 + (r.offsetY ?? 0),
-                left: (VISUAL_SIZE - r.size) / 2 + (r.offsetX ?? 0),
-              },
-            ]}
-          />
-        ))}
-      </Animated.View>
-
-      {/* Central gold core — anchors the eye. */}
-      <View
-        style={[
-          styles.core,
-          {
-            backgroundColor: accent,
-            shadowColor: accent,
-          },
-        ]}
-      />
-    </Animated.View>
-  );
+  const size = compact ? VISUAL_SIZE * 0.78 : VISUAL_SIZE;
+  switch (kind) {
+    case 'chariot':
+      return <ChariotChakraVisual accent={accent} isActive={isActive} size={size} />;
+    case 'mandala':
+      return <SriYantraVisual accent={accent} isActive={isActive} size={size} />;
+    case 'akshara':
+      return <ManuscriptVisual accent={accent} isActive={isActive} size={size} />;
+    case 'shadripu':
+      return <ShatkonaVisual accent={accent} isActive={isActive} size={size} />;
+    case 'lock':
+      return <PadmaSealVisual accent={accent} isActive={isActive} size={size} />;
+    case 'welcome':
+      return <KiaanWelcomeVisual accent={accent} isActive={isActive} size={size} />;
+  }
 }
-
-// ---------------------------------------------------------------------------
-// Visual layouts — each page gets a distinct ring composition so the five
-// screens feel different while sharing a design language.
-// ---------------------------------------------------------------------------
-
-const VISUAL_SIZE = 220;
-
-interface RingSpec {
-  size: number;
-  stroke: number;
-  opacity: number;
-  offsetX?: number;
-  offsetY?: number;
-}
-
-const VISUAL_LAYOUT: Record<PageData['visual'], readonly RingSpec[]> = {
-  // Chariot — a single grounded wheel with a rising horizon line above.
-  chariot: [
-    { size: 140, stroke: 2, opacity: 0.65 },
-    { size: 80, stroke: 1, opacity: 0.4 },
-    { size: 200, stroke: 0.8, opacity: 0.18 },
-  ],
-  // Mandala — three concentric golden auras.
-  mandala: [
-    { size: 200, stroke: 1, opacity: 0.35 },
-    { size: 150, stroke: 1.5, opacity: 0.55 },
-    { size: 100, stroke: 2, opacity: 0.8 },
-  ],
-  // Akshara — asymmetric scatter suggesting Sanskrit syllables in space.
-  akshara: [
-    { size: 120, stroke: 1.2, opacity: 0.55, offsetX: -36 },
-    { size: 80, stroke: 1, opacity: 0.45, offsetX: 52, offsetY: -30 },
-    { size: 140, stroke: 0.8, opacity: 0.3, offsetY: 28 },
-  ],
-  // Shadripu — a hexagonal suggestion with 6 orbs via stacked rings at angles.
-  shadripu: [
-    { size: 180, stroke: 1, opacity: 0.35 },
-    { size: 120, stroke: 1.5, opacity: 0.55 },
-    { size: 60, stroke: 2, opacity: 0.85 },
-  ],
-  // Lock — tight concentric rings evoking a sealed vault.
-  lock: [
-    { size: 130, stroke: 2, opacity: 0.7 },
-    { size: 100, stroke: 1.5, opacity: 0.55 },
-    { size: 70, stroke: 1, opacity: 0.4 },
-  ],
-} as const;
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -543,25 +556,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  visual: {
-    width: VISUAL_SIZE,
-    height: VISUAL_SIZE,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  ring: {
-    position: 'absolute',
-    backgroundColor: 'transparent',
-  },
-  core: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0.9,
-    shadowRadius: 14,
-    elevation: 10,
-  },
   textBlock: {
     alignItems: 'center',
     width: '100%',
@@ -576,7 +570,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   title: {
-    fontFamily: 'CormorantGaramond-Italic',
+    fontFamily: 'CormorantGaramond-LightItalic',
     fontStyle: 'italic',
     fontSize: 26,
     lineHeight: 34,
@@ -639,11 +633,23 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'rgba(212, 160, 23, 0.3)',
   },
+  ctaButtonGold: {
+    borderColor: 'rgba(255, 220, 140, 0.55)',
+    shadowColor: GOLD,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.5,
+    shadowRadius: 18,
+    elevation: 8,
+  },
   ctaText: {
     fontSize: 17,
     fontFamily: 'Outfit-SemiBold',
     color: '#F5F0E8',
     letterSpacing: 0.3,
+  },
+  ctaTextDark: {
+    color: '#1A0F02',
+    letterSpacing: 0.6,
   },
   skipBtn: {
     alignItems: 'center',
@@ -656,5 +662,155 @@ const styles = StyleSheet.create({
   },
   skipPlaceholder: {
     height: 32,
+  },
+
+  // -------------------------------------------------------------------------
+  // Welcome page (page 6) — scrollable rich content
+  // -------------------------------------------------------------------------
+  welcomeContent: {
+    paddingHorizontal: 28,
+    paddingTop: 56,
+    alignItems: 'center',
+  },
+  welcomeVisualWrap: {
+    marginTop: 4,
+    marginBottom: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ornament: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 14,
+    width: '100%',
+  },
+  ornamentLine: {
+    height: 1,
+    width: 56,
+  },
+  ornamentLineLeft: {
+    backgroundColor: 'rgba(212, 164, 76, 0.4)',
+  },
+  ornamentLineRight: {
+    backgroundColor: 'rgba(212, 164, 76, 0.4)',
+  },
+  ornamentDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: GOLD_SOFT,
+    marginHorizontal: 10,
+    shadowColor: GOLD,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.7,
+    shadowRadius: 6,
+    elevation: 3,
+  },
+  ornamentDotSmall: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(212, 164, 76, 0.55)',
+    marginHorizontal: 10,
+  },
+  eyebrow: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    letterSpacing: 3,
+    color: 'rgba(212, 164, 76, 0.7)',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  welcomeTitle: {
+    fontFamily: 'CormorantGaramond-LightItalic',
+    fontStyle: 'italic',
+    fontSize: 34,
+    lineHeight: 42,
+    color: GOLD,
+    textAlign: 'center',
+    marginBottom: 22,
+    textShadowColor: 'rgba(212, 164, 76, 0.35)',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 14,
+  },
+  welcomeBodyWrap: {
+    width: '100%',
+    maxWidth: 420,
+    gap: 16,
+  },
+  welcomeBody: {
+    fontFamily: 'CrimsonText-Regular',
+    fontSize: 15.5,
+    lineHeight: 24,
+    color: 'rgba(245, 240, 232, 0.78)',
+    textAlign: 'center',
+  },
+  welcomeBodyDim: {
+    fontFamily: 'CrimsonText-Regular',
+    fontSize: 15.5,
+    lineHeight: 24,
+    color: 'rgba(245, 240, 232, 0.66)',
+    textAlign: 'center',
+  },
+  welcomeBodyItalic: {
+    fontFamily: 'CrimsonText-Italic',
+    fontStyle: 'italic',
+    color: GOLD_SOFT,
+  },
+  welcomeAccent: {
+    fontFamily: 'Outfit-SemiBold',
+    color: GOLD,
+    letterSpacing: 1,
+  },
+  welcomeAccentSoft: {
+    color: '#E8B54A',
+    fontFamily: 'CrimsonText-Italic',
+    fontStyle: 'italic',
+  },
+  verseCard: {
+    marginTop: 14,
+    paddingVertical: 22,
+    paddingHorizontal: 18,
+    borderRadius: 18,
+    backgroundColor: 'rgba(212, 164, 76, 0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(212, 164, 76, 0.18)',
+    alignItems: 'center',
+    gap: 8,
+  },
+  verseEyebrow: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 10.5,
+    letterSpacing: 3,
+    color: 'rgba(212, 164, 76, 0.55)',
+    marginBottom: 8,
+  },
+  verseSanskrit: {
+    fontFamily: 'NotoSansDevanagari-Medium',
+    fontSize: 17,
+    lineHeight: 26,
+    color: '#F0C96D',
+    letterSpacing: 0.5,
+    textAlign: 'center',
+  },
+  verseEnglish: {
+    fontFamily: 'CrimsonText-Italic',
+    fontStyle: 'italic',
+    fontSize: 13.5,
+    lineHeight: 21,
+    color: 'rgba(212, 164, 76, 0.7)',
+    textAlign: 'center',
+    marginTop: 10,
+    paddingHorizontal: 4,
+  },
+  verseAttribution: {
+    fontFamily: 'Outfit-Regular',
+    fontSize: 12,
+    color: 'rgba(212, 164, 76, 0.5)',
+    marginTop: 6,
+  },
+  welcomeBottomSpacer: {
+    height: 200,
   },
 });

--- a/kiaanverse-mobile/apps/mobile/app/arrival/visuals.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/visuals.tsx
@@ -1,0 +1,788 @@
+/**
+ * Arrival Ceremony — Vedic Visual Library
+ *
+ * Six bespoke Sacred-geometry illustrations, one per arrival page. Each is
+ * built with react-native-svg + Reanimated so the animation lives on the UI
+ * thread (no JS bridge frames during the breathing / rotation cycles). They
+ * intentionally share a 220-point square viewport, a single accent color
+ * driven from PAGES, and a quiet "breath" + "spin" idle animation pair so
+ * the five+one screens feel like one continuous ceremony.
+ *
+ * Pages → visuals
+ *   1. arjuna   → ChariotChakraVisual   — 24-spoke Ashoka Dharma Chakra +
+ *                                          peacock-eye feather above the wheel.
+ *   2. sakha    → SriYantraVisual       — 9 interlocking triangles inside an
+ *                                          8-petal lotus, OM bindu at center.
+ *   3. gita     → ManuscriptVisual      — Krishna's flute crossing concentric
+ *                                          shabda (sound) rings + central OM.
+ *   4. journey  → ShatkonaVisual        — Shatkona hexagram with 6 ripu orbs
+ *                                          at the outer points, bindu inside.
+ *   5. sacred   → PadmaSealVisual       — Layered 16+8 petal lotus encircling
+ *                                          a four-fold yantra seal.
+ *   6. welcome  → KiaanWelcomeVisual    — Full Sri Yantra mandala crowned by
+ *                                          a peacock feather; the grand finale.
+ *
+ * Reduced-motion: every animation hook respects AccessibilityInfo so the
+ * visual settles to a static, equally-beautiful frame for users who request it.
+ */
+
+import React, { useEffect, useMemo } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
+import Svg, {
+  Circle,
+  Defs,
+  G,
+  Path,
+  Polygon,
+  RadialGradient,
+  Stop,
+} from 'react-native-svg';
+
+// ---------------------------------------------------------------------------
+// Shared geometry helpers
+// ---------------------------------------------------------------------------
+
+export const VISUAL_SIZE = 220;
+const CENTER = VISUAL_SIZE / 2;
+
+const LOTUS_BLOOM = Easing.bezier(0.22, 1.0, 0.36, 1.0);
+
+interface VisualProps {
+  /** Accent hex used for primary strokes / glows. */
+  readonly accent: string;
+  /** Whether this page is on screen — pauses motion when false. */
+  readonly isActive: boolean;
+  /** Override the default 220pt square footprint. */
+  readonly size?: number;
+}
+
+/** Build a regular-polygon point list inscribed in a circle (SVG `points`). */
+function regularPolygon(
+  cx: number,
+  cy: number,
+  r: number,
+  sides: number,
+  rotationDeg = -90
+): string {
+  const pts: string[] = [];
+  for (let i = 0; i < sides; i += 1) {
+    const a = ((rotationDeg + (i * 360) / sides) * Math.PI) / 180;
+    pts.push(`${(cx + r * Math.cos(a)).toFixed(2)},${(cy + r * Math.sin(a)).toFixed(2)}`);
+  }
+  return pts.join(' ');
+}
+
+/** Build a multi-petal lotus path. Each petal is a teardrop cubic. */
+function lotusPath(cx: number, cy: number, r: number, petals: number): string {
+  let d = '';
+  for (let i = 0; i < petals; i += 1) {
+    const a = (i * 2 * Math.PI) / petals;
+    const tipX = cx + r * Math.cos(a);
+    const tipY = cy + r * Math.sin(a);
+    const baseAngle = Math.PI / petals;
+    const baseR = r * 0.34;
+    const lX = cx + baseR * Math.cos(a + baseAngle);
+    const lY = cy + baseR * Math.sin(a + baseAngle);
+    const rX = cx + baseR * Math.cos(a - baseAngle);
+    const rY = cy + baseR * Math.sin(a - baseAngle);
+    const c1X = cx + r * 0.78 * Math.cos(a + baseAngle * 0.55);
+    const c1Y = cy + r * 0.78 * Math.sin(a + baseAngle * 0.55);
+    const c2X = cx + r * 0.78 * Math.cos(a - baseAngle * 0.55);
+    const c2Y = cy + r * 0.78 * Math.sin(a - baseAngle * 0.55);
+    d += `M ${lX.toFixed(2)} ${lY.toFixed(2)} `;
+    d += `C ${c1X.toFixed(2)} ${c1Y.toFixed(2)}, ${tipX.toFixed(2)} ${tipY.toFixed(2)}, ${tipX.toFixed(2)} ${tipY.toFixed(2)} `;
+    d += `C ${tipX.toFixed(2)} ${tipY.toFixed(2)}, ${c2X.toFixed(2)} ${c2Y.toFixed(2)}, ${rX.toFixed(2)} ${rY.toFixed(2)} `;
+    d += `Z `;
+  }
+  return d;
+}
+
+/** Build N straight spokes from the inner hub radius to the outer ring. */
+function spokesPath(cx: number, cy: number, rIn: number, rOut: number, count: number): string {
+  let d = '';
+  for (let i = 0; i < count; i += 1) {
+    const a = (i * 2 * Math.PI) / count;
+    const x1 = cx + rIn * Math.cos(a);
+    const y1 = cy + rIn * Math.sin(a);
+    const x2 = cx + rOut * Math.cos(a);
+    const y2 = cy + rOut * Math.sin(a);
+    d += `M ${x1.toFixed(2)} ${y1.toFixed(2)} L ${x2.toFixed(2)} ${y2.toFixed(2)} `;
+  }
+  return d;
+}
+
+// ---------------------------------------------------------------------------
+// Animation primitives — one shared "breath" + N independent spin layers
+// ---------------------------------------------------------------------------
+
+function useReducedMotionFlag(): SharedValue<number> {
+  // 0 = animations on, 1 = motion-reduced (snap to static).
+  const flag = useSharedValue(0);
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((reduce) => {
+        if (cancelled) return;
+        flag.value = reduce ? 1 : 0;
+      })
+      .catch(() => {
+        // Probe failed — assume motion is OK.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [flag]);
+  return flag;
+}
+
+function useBreath(isActive: boolean, reduced: SharedValue<number>): SharedValue<number> {
+  const v = useSharedValue(1);
+  useEffect(() => {
+    if (!isActive || reduced.value === 1) {
+      v.value = withTiming(1, { duration: 240 });
+      return;
+    }
+    v.value = withRepeat(
+      withSequence(
+        withTiming(1.05, { duration: 1900, easing: LOTUS_BLOOM }),
+        withTiming(0.95, { duration: 1900, easing: LOTUS_BLOOM })
+      ),
+      -1,
+      false
+    );
+  }, [isActive, v, reduced]);
+  return v;
+}
+
+function useSpin(
+  isActive: boolean,
+  reduced: SharedValue<number>,
+  durationMs: number,
+  direction: 1 | -1
+): SharedValue<number> {
+  const v = useSharedValue(0);
+  useEffect(() => {
+    if (!isActive || reduced.value === 1) {
+      // Hold the current angle so the visual settles into a balanced pose.
+      return;
+    }
+    v.value = 0;
+    v.value = withRepeat(
+      withTiming(360 * direction, {
+        duration: durationMs,
+        easing: Easing.linear,
+      }),
+      -1,
+      false
+    );
+  }, [isActive, v, reduced, durationMs, direction]);
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+// 1. ChariotChakraVisual — Ashoka Dharma Chakra + peacock-eye feather
+// ---------------------------------------------------------------------------
+
+export function ChariotChakraVisual({
+  accent,
+  isActive,
+  size = VISUAL_SIZE,
+}: VisualProps): React.JSX.Element {
+  const reduced = useReducedMotionFlag();
+  const breath = useBreath(isActive, reduced);
+  const wheelSpin = useSpin(isActive, reduced, 42000, 1);
+  const auraSpin = useSpin(isActive, reduced, 80000, -1);
+
+  const breathStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  const wheelStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${wheelSpin.value}deg` }] }));
+  const auraStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${auraSpin.value}deg` }] }));
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const rOuter = size * 0.42;
+  const rInner = size * 0.085;
+  const rRim = rOuter * 0.93;
+  const spokes24 = useMemo(() => spokesPath(cx, cy, rInner, rRim, 24), [cx, cy, rInner, rRim]);
+
+  // Peacock-feather "eye" lifted above the wheel — three concentric ovals
+  // and a curling quill that grounds the chariot scene.
+  const featherCx = cx;
+  const featherCy = cy - rOuter * 0.78;
+  const featherSize = size * 0.13;
+
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {/* Soft aura disc — slow counter-rotation to break monotony */}
+      <Animated.View style={[StyleSheet.absoluteFill, auraStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Defs>
+            <RadialGradient id="aura-chariot" cx="50%" cy="50%" r="50%">
+              <Stop offset="0%" stopColor={accent} stopOpacity={0.22} />
+              <Stop offset="65%" stopColor={accent} stopOpacity={0.05} />
+              <Stop offset="100%" stopColor={accent} stopOpacity={0} />
+            </RadialGradient>
+          </Defs>
+          <Circle cx={cx} cy={cy} r={rOuter * 1.05} fill="url(#aura-chariot)" />
+        </Svg>
+      </Animated.View>
+
+      {/* Static peacock feather — sits above the spinning wheel */}
+      <View style={StyleSheet.absoluteFill} pointerEvents="none">
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {/* Quill */}
+          <Path
+            d={`M ${featherCx} ${featherCy + featherSize * 0.4} Q ${featherCx + featherSize * 0.6} ${cy - rOuter * 0.4} ${featherCx + featherSize * 0.2} ${cy - rOuter * 0.05}`}
+            stroke={accent}
+            strokeOpacity={0.45}
+            strokeWidth={1}
+            fill="none"
+          />
+          {/* Outer eye */}
+          <Path
+            d={`M ${featherCx} ${featherCy - featherSize} C ${featherCx + featherSize} ${featherCy - featherSize * 0.4}, ${featherCx + featherSize} ${featherCy + featherSize * 0.4}, ${featherCx} ${featherCy + featherSize} C ${featherCx - featherSize} ${featherCy + featherSize * 0.4}, ${featherCx - featherSize} ${featherCy - featherSize * 0.4}, ${featherCx} ${featherCy - featherSize} Z`}
+            fill="#0E7490"
+            opacity={0.55}
+          />
+          {/* Mid teal */}
+          <Circle cx={featherCx} cy={featherCy} r={featherSize * 0.55} fill="#06B6D4" opacity={0.65} />
+          {/* Gold ring of the eye */}
+          <Circle cx={featherCx} cy={featherCy} r={featherSize * 0.32} fill="#D4A017" opacity={0.85} />
+          {/* Indigo pupil */}
+          <Circle cx={featherCx} cy={featherCy} r={featherSize * 0.13} fill="#1B0F4A" />
+        </Svg>
+      </View>
+
+      {/* Spinning Dharma Chakra — 24 spokes (Ashoka style) */}
+      <Animated.View style={[StyleSheet.absoluteFill, wheelStyle, breathStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Circle cx={cx} cy={cy} r={rOuter} stroke={accent} strokeOpacity={0.65} strokeWidth={2} fill="none" />
+          <Circle cx={cx} cy={cy} r={rRim} stroke={accent} strokeOpacity={0.35} strokeWidth={1} fill="none" />
+          <Path d={spokes24} stroke={accent} strokeOpacity={0.55} strokeWidth={1.1} strokeLinecap="round" />
+          {/* Hub */}
+          <Circle cx={cx} cy={cy} r={rInner} fill={accent} fillOpacity={0.18} stroke={accent} strokeWidth={1.4} />
+          <Circle cx={cx} cy={cy} r={rInner * 0.45} fill={accent} />
+        </Svg>
+      </Animated.View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. SriYantraVisual — 9 interlocking triangles inside an 8-petal lotus
+// ---------------------------------------------------------------------------
+
+export function SriYantraVisual({
+  accent,
+  isActive,
+  size = VISUAL_SIZE,
+}: VisualProps): React.JSX.Element {
+  const reduced = useReducedMotionFlag();
+  const breath = useBreath(isActive, reduced);
+  const lotusSpin = useSpin(isActive, reduced, 90000, -1);
+  const yantraSpin = useSpin(isActive, reduced, 60000, 1);
+
+  const breathStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  const lotusStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${lotusSpin.value}deg` }] }));
+  const yantraStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${yantraSpin.value}deg` }] }));
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const rOuter = size * 0.46;
+  const rLotus = size * 0.4;
+  const rYantra = size * 0.3;
+
+  const lotus = useMemo(() => lotusPath(cx, cy, rLotus, 8), [cx, cy, rLotus]);
+
+  // 5 downward + 4 upward triangles, scaled in a Sri Yantra–style cascade.
+  const triangles = useMemo(() => {
+    const downRadii = [1.0, 0.84, 0.68, 0.52, 0.38];
+    const upRadii = [0.92, 0.76, 0.6, 0.44];
+    const down = downRadii.map((s) => regularPolygon(cx, cy, rYantra * s, 3, 90));
+    const up = upRadii.map((s) => regularPolygon(cx, cy, rYantra * s, 3, -90));
+    return { down, up };
+  }, [cx, cy, rYantra]);
+
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {/* Aura disc */}
+      <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={StyleSheet.absoluteFill}>
+        <Defs>
+          <RadialGradient id="aura-yantra" cx="50%" cy="50%" r="50%">
+            <Stop offset="0%" stopColor={accent} stopOpacity={0.32} />
+            <Stop offset="60%" stopColor={accent} stopOpacity={0.07} />
+            <Stop offset="100%" stopColor={accent} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle cx={cx} cy={cy} r={rOuter} fill="url(#aura-yantra)" />
+      </Svg>
+
+      {/* Outer 8-petal lotus — slow counter-rotation */}
+      <Animated.View style={[StyleSheet.absoluteFill, lotusStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Path d={lotus} stroke={accent} strokeOpacity={0.7} strokeWidth={1.6} fill="none" strokeLinejoin="round" strokeLinecap="round" />
+          <Circle cx={cx} cy={cy} r={rOuter} stroke={accent} strokeOpacity={0.3} strokeWidth={1} fill="none" />
+        </Svg>
+      </Animated.View>
+
+      {/* Sri Yantra triangles — clockwise rotation */}
+      <Animated.View style={[StyleSheet.absoluteFill, yantraStyle, breathStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {triangles.down.map((pts, i) => (
+            <Polygon key={`d-${i}`} points={pts} stroke={accent} strokeOpacity={0.78 - i * 0.08} strokeWidth={1.1} fill="none" strokeLinejoin="round" />
+          ))}
+          {triangles.up.map((pts, i) => (
+            <Polygon key={`u-${i}`} points={pts} stroke={accent} strokeOpacity={0.78 - i * 0.08} strokeWidth={1.1} fill="none" strokeLinejoin="round" />
+          ))}
+          {/* Bindu — the seed point */}
+          <Circle cx={cx} cy={cy} r={size * 0.022} fill={accent} />
+          <Circle cx={cx} cy={cy} r={size * 0.05} stroke={accent} strokeOpacity={0.5} strokeWidth={0.8} fill="none" />
+        </Svg>
+      </Animated.View>
+
+      {/* Stationary OM */}
+      <View style={[StyleSheet.absoluteFill, styles.glyphCenter]} pointerEvents="none">
+        <Text allowFontScaling={false} style={[styles.omGlyph, { color: accent, fontSize: size * 0.11 }]}>
+          {'ॐ'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. ManuscriptVisual — Krishna's flute over concentric shabda rings
+// ---------------------------------------------------------------------------
+
+export function ManuscriptVisual({
+  accent,
+  isActive,
+  size = VISUAL_SIZE,
+}: VisualProps): React.JSX.Element {
+  const reduced = useReducedMotionFlag();
+  const breath = useBreath(isActive, reduced);
+  const ringPulse = useSharedValue(0);
+  const fluteSpin = useSpin(isActive, reduced, 70000, 1);
+
+  useEffect(() => {
+    if (!isActive || reduced.value === 1) {
+      ringPulse.value = withTiming(0, { duration: 240 });
+      return;
+    }
+    ringPulse.value = withRepeat(
+      withTiming(1, { duration: 3400, easing: LOTUS_BLOOM }),
+      -1,
+      false
+    );
+  }, [isActive, reduced, ringPulse]);
+
+  const breathStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  const fluteStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${fluteSpin.value}deg` }] }));
+  const ring1 = useAnimatedStyle(() => ({
+    opacity: 1 - ringPulse.value,
+    transform: [{ scale: 0.55 + ringPulse.value * 0.7 }],
+  }));
+  const ring2 = useAnimatedStyle(() => ({
+    opacity: 1 - ((ringPulse.value + 0.33) % 1),
+    transform: [{ scale: 0.55 + ((ringPulse.value + 0.33) % 1) * 0.7 }],
+  }));
+  const ring3 = useAnimatedStyle(() => ({
+    opacity: 1 - ((ringPulse.value + 0.66) % 1),
+    transform: [{ scale: 0.55 + ((ringPulse.value + 0.66) % 1) * 0.7 }],
+  }));
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const rRing = size * 0.42;
+
+  // Flute: a long thin horizontal silhouette tilted slightly, with finger
+  // holes implied as small dots. Drawn at native horizontal then rotated.
+  const fluteLen = size * 0.78;
+  const fluteThick = size * 0.034;
+  const fluteY = cy;
+  const fluteStartX = cx - fluteLen / 2;
+  const holeY = fluteY;
+  const holes = [0.5, 0.58, 0.66, 0.74, 0.82];
+
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {/* Sound waves — three out-of-phase rings */}
+      <Animated.View style={[StyleSheet.absoluteFill, ring1]} pointerEvents="none">
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Circle cx={cx} cy={cy} r={rRing} stroke={accent} strokeOpacity={0.55} strokeWidth={1} fill="none" />
+        </Svg>
+      </Animated.View>
+      <Animated.View style={[StyleSheet.absoluteFill, ring2]} pointerEvents="none">
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Circle cx={cx} cy={cy} r={rRing} stroke={accent} strokeOpacity={0.45} strokeWidth={1} fill="none" />
+        </Svg>
+      </Animated.View>
+      <Animated.View style={[StyleSheet.absoluteFill, ring3]} pointerEvents="none">
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Circle cx={cx} cy={cy} r={rRing} stroke={accent} strokeOpacity={0.35} strokeWidth={1} fill="none" />
+        </Svg>
+      </Animated.View>
+
+      {/* Subtle aura behind the flute */}
+      <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={StyleSheet.absoluteFill}>
+        <Defs>
+          <RadialGradient id="aura-flute" cx="50%" cy="50%" r="50%">
+            <Stop offset="0%" stopColor={accent} stopOpacity={0.22} />
+            <Stop offset="100%" stopColor={accent} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle cx={cx} cy={cy} r={size * 0.28} fill="url(#aura-flute)" />
+      </Svg>
+
+      {/* Flute — slowly orbits */}
+      <Animated.View style={[StyleSheet.absoluteFill, fluteStyle, breathStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <G transform={`rotate(-18 ${cx} ${cy})`}>
+            <Path
+              d={`M ${fluteStartX} ${fluteY - fluteThick / 2} L ${fluteStartX + fluteLen} ${fluteY - fluteThick / 2} L ${fluteStartX + fluteLen + fluteThick * 0.6} ${fluteY} L ${fluteStartX + fluteLen} ${fluteY + fluteThick / 2} L ${fluteStartX} ${fluteY + fluteThick / 2} L ${fluteStartX - fluteThick * 0.6} ${fluteY} Z`}
+              fill={accent}
+              fillOpacity={0.18}
+              stroke={accent}
+              strokeOpacity={0.85}
+              strokeWidth={1.2}
+              strokeLinejoin="round"
+            />
+            {holes.map((p, i) => (
+              <Circle
+                key={`hole-${i}`}
+                cx={fluteStartX + fluteLen * p}
+                cy={holeY}
+                r={fluteThick * 0.28}
+                fill="#050714"
+              />
+            ))}
+            {/* Mouthpiece accent */}
+            <Circle
+              cx={fluteStartX + fluteLen * 0.36}
+              cy={holeY}
+              r={fluteThick * 0.32}
+              fill={accent}
+              fillOpacity={0.7}
+            />
+          </G>
+        </Svg>
+      </Animated.View>
+
+      {/* Bindu OM at center */}
+      <View style={[StyleSheet.absoluteFill, styles.glyphCenter]} pointerEvents="none">
+        <Text allowFontScaling={false} style={[styles.omGlyph, { color: accent, fontSize: size * 0.1 }]}>
+          {'ॐ'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4. ShatkonaVisual — Six-pointed star (Shadripu hexagram)
+// ---------------------------------------------------------------------------
+
+export function ShatkonaVisual({
+  accent,
+  isActive,
+  size = VISUAL_SIZE,
+}: VisualProps): React.JSX.Element {
+  const reduced = useReducedMotionFlag();
+  const breath = useBreath(isActive, reduced);
+  const orbSpin = useSpin(isActive, reduced, 50000, 1);
+  const triSpin = useSpin(isActive, reduced, 75000, -1);
+
+  const breathStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  const orbStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${orbSpin.value}deg` }] }));
+  const triStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${triSpin.value}deg` }] }));
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const rOuter = size * 0.42;
+  const rTri = size * 0.34;
+  const rOrb = size * 0.46;
+
+  const triUp = useMemo(() => regularPolygon(cx, cy, rTri, 3, -90), [cx, cy, rTri]);
+  const triDown = useMemo(() => regularPolygon(cx, cy, rTri, 3, 90), [cx, cy, rTri]);
+
+  // 6 ripu orbs at hexagonal positions
+  const orbs = useMemo(() => {
+    const arr: Array<{ x: number; y: number }> = [];
+    for (let i = 0; i < 6; i += 1) {
+      const a = ((i * 60 - 90) * Math.PI) / 180;
+      arr.push({ x: cx + rOrb * Math.cos(a), y: cy + rOrb * Math.sin(a) });
+    }
+    return arr;
+  }, [cx, cy, rOrb]);
+
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {/* Soft outer halo */}
+      <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={StyleSheet.absoluteFill}>
+        <Defs>
+          <RadialGradient id="aura-shat" cx="50%" cy="50%" r="50%">
+            <Stop offset="0%" stopColor={accent} stopOpacity={0.28} />
+            <Stop offset="100%" stopColor={accent} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle cx={cx} cy={cy} r={rOuter * 1.05} fill="url(#aura-shat)" />
+        <Circle cx={cx} cy={cy} r={rOuter} stroke={accent} strokeOpacity={0.35} strokeWidth={1} fill="none" />
+      </Svg>
+
+      {/* Orbiting ripu orbs — 6 small filled circles connected by a hex */}
+      <Animated.View style={[StyleSheet.absoluteFill, orbStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Polygon
+            points={regularPolygon(cx, cy, rOrb, 6, -90)}
+            stroke={accent}
+            strokeOpacity={0.25}
+            strokeWidth={0.8}
+            fill="none"
+            strokeDasharray="2 6"
+          />
+          {orbs.map((o, i) => (
+            <G key={`orb-${i}`}>
+              <Circle cx={o.x} cy={o.y} r={size * 0.038} fill={accent} fillOpacity={0.85} />
+              <Circle cx={o.x} cy={o.y} r={size * 0.06} stroke={accent} strokeOpacity={0.4} strokeWidth={1} fill="none" />
+            </G>
+          ))}
+        </Svg>
+      </Animated.View>
+
+      {/* Counter-rotating Shatkona — interlocked triangles */}
+      <Animated.View style={[StyleSheet.absoluteFill, triStyle, breathStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Polygon points={triUp} stroke={accent} strokeOpacity={0.85} strokeWidth={1.5} fill="none" strokeLinejoin="round" />
+          <Polygon points={triDown} stroke={accent} strokeOpacity={0.85} strokeWidth={1.5} fill="none" strokeLinejoin="round" />
+          {/* Inner downward triangle (kept in same group so it co-rotates) */}
+          <Polygon
+            points={regularPolygon(cx, cy, rTri * 0.45, 3, 90)}
+            stroke={accent}
+            strokeOpacity={0.55}
+            strokeWidth={1}
+            fill="none"
+          />
+          {/* Bindu */}
+          <Circle cx={cx} cy={cy} r={size * 0.025} fill={accent} />
+        </Svg>
+      </Animated.View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 5. PadmaSealVisual — Layered 16+8 petal lotus encircling a yantra seal
+// ---------------------------------------------------------------------------
+
+export function PadmaSealVisual({
+  accent,
+  isActive,
+  size = VISUAL_SIZE,
+}: VisualProps): React.JSX.Element {
+  const reduced = useReducedMotionFlag();
+  const breath = useBreath(isActive, reduced);
+  const outerSpin = useSpin(isActive, reduced, 110000, -1);
+  const innerSpin = useSpin(isActive, reduced, 70000, 1);
+
+  const breathStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  const outerStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${outerSpin.value}deg` }] }));
+  const innerStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${innerSpin.value}deg` }] }));
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const rOuter = size * 0.46;
+  const r16 = size * 0.42;
+  const r8 = size * 0.3;
+  const rSeal = size * 0.16;
+
+  const lotus16 = useMemo(() => lotusPath(cx, cy, r16, 16), [cx, cy, r16]);
+  const lotus8 = useMemo(() => lotusPath(cx, cy, r8, 8), [cx, cy, r8]);
+
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {/* Aura */}
+      <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={StyleSheet.absoluteFill}>
+        <Defs>
+          <RadialGradient id="aura-padma" cx="50%" cy="50%" r="50%">
+            <Stop offset="0%" stopColor={accent} stopOpacity={0.3} />
+            <Stop offset="100%" stopColor={accent} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle cx={cx} cy={cy} r={rOuter} fill="url(#aura-padma)" />
+        <Circle cx={cx} cy={cy} r={rOuter} stroke={accent} strokeOpacity={0.3} strokeWidth={1} fill="none" />
+      </Svg>
+
+      {/* Outer 16-petal lotus */}
+      <Animated.View style={[StyleSheet.absoluteFill, outerStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Path d={lotus16} stroke={accent} strokeOpacity={0.55} strokeWidth={1.2} fill="none" strokeLinejoin="round" />
+        </Svg>
+      </Animated.View>
+
+      {/* Inner 8-petal lotus, counter-spin */}
+      <Animated.View style={[StyleSheet.absoluteFill, innerStyle, breathStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Path d={lotus8} stroke={accent} strokeOpacity={0.85} strokeWidth={1.6} fill="none" strokeLinejoin="round" />
+        </Svg>
+      </Animated.View>
+
+      {/* Yantra seal — square + diamond + bindu suggesting sealed sanctum */}
+      <View style={StyleSheet.absoluteFill} pointerEvents="none">
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Polygon
+            points={regularPolygon(cx, cy, rSeal, 4, 0)}
+            stroke={accent}
+            strokeOpacity={0.85}
+            strokeWidth={1.4}
+            fill="none"
+          />
+          <Polygon
+            points={regularPolygon(cx, cy, rSeal * 0.78, 4, 45)}
+            stroke={accent}
+            strokeOpacity={0.65}
+            strokeWidth={1}
+            fill="none"
+          />
+          <Circle cx={cx} cy={cy} r={size * 0.024} fill={accent} />
+        </Svg>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 6. KiaanWelcomeVisual — Grand finale mandala with peacock-feather crown
+// ---------------------------------------------------------------------------
+
+export function KiaanWelcomeVisual({
+  accent,
+  isActive,
+  size = VISUAL_SIZE,
+}: VisualProps): React.JSX.Element {
+  const reduced = useReducedMotionFlag();
+  const breath = useBreath(isActive, reduced);
+  const lotusSpin = useSpin(isActive, reduced, 120000, -1);
+  const yantraSpin = useSpin(isActive, reduced, 80000, 1);
+
+  const breathStyle = useAnimatedStyle(() => ({ transform: [{ scale: breath.value }] }));
+  const lotusStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${lotusSpin.value}deg` }] }));
+  const yantraStyle = useAnimatedStyle(() => ({ transform: [{ rotate: `${yantraSpin.value}deg` }] }));
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const rOuter = size * 0.46;
+  const rLotus = size * 0.4;
+  const rYantra = size * 0.28;
+
+  const lotus16 = useMemo(() => lotusPath(cx, cy, rLotus, 16), [cx, cy, rLotus]);
+  const triangles = useMemo(() => {
+    const downRadii = [1.0, 0.78, 0.54, 0.36];
+    const upRadii = [0.9, 0.66, 0.46];
+    return {
+      down: downRadii.map((s) => regularPolygon(cx, cy, rYantra * s, 3, 90)),
+      up: upRadii.map((s) => regularPolygon(cx, cy, rYantra * s, 3, -90)),
+    };
+  }, [cx, cy, rYantra]);
+
+  // Peacock feather "crown" above mandala — one large eye plus two smaller flank eyes.
+  const crownY = cy - rOuter * 0.92;
+  const crownEye = size * 0.075;
+
+  return (
+    <View style={[styles.box, { width: size, height: size }]}>
+      {/* Aura halo */}
+      <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={StyleSheet.absoluteFill}>
+        <Defs>
+          <RadialGradient id="aura-welcome" cx="50%" cy="50%" r="50%">
+            <Stop offset="0%" stopColor={accent} stopOpacity={0.4} />
+            <Stop offset="55%" stopColor={accent} stopOpacity={0.08} />
+            <Stop offset="100%" stopColor={accent} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle cx={cx} cy={cy} r={rOuter * 1.08} fill="url(#aura-welcome)" />
+        <Circle cx={cx} cy={cy} r={rOuter} stroke={accent} strokeOpacity={0.45} strokeWidth={1} fill="none" />
+      </Svg>
+
+      {/* Peacock feather crown — three feather eyes above the mandala */}
+      <View style={StyleSheet.absoluteFill} pointerEvents="none">
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {/* Center eye */}
+          <Path
+            d={`M ${cx} ${crownY - crownEye} C ${cx + crownEye} ${crownY - crownEye * 0.4}, ${cx + crownEye} ${crownY + crownEye * 0.4}, ${cx} ${crownY + crownEye} C ${cx - crownEye} ${crownY + crownEye * 0.4}, ${cx - crownEye} ${crownY - crownEye * 0.4}, ${cx} ${crownY - crownEye} Z`}
+            fill="#0E7490"
+            opacity={0.6}
+          />
+          <Circle cx={cx} cy={crownY} r={crownEye * 0.55} fill="#06B6D4" opacity={0.7} />
+          <Circle cx={cx} cy={crownY} r={crownEye * 0.32} fill={accent} opacity={0.9} />
+          <Circle cx={cx} cy={crownY} r={crownEye * 0.13} fill="#1B0F4A" />
+
+          {/* Flank eyes */}
+          {[-1, 1].map((dir) => (
+            <G key={`flank-${dir}`}>
+              <Circle cx={cx + dir * crownEye * 1.4} cy={crownY + crownEye * 0.5} r={crownEye * 0.55} fill="#0E7490" opacity={0.55} />
+              <Circle cx={cx + dir * crownEye * 1.4} cy={crownY + crownEye * 0.5} r={crownEye * 0.34} fill="#06B6D4" opacity={0.7} />
+              <Circle cx={cx + dir * crownEye * 1.4} cy={crownY + crownEye * 0.5} r={crownEye * 0.18} fill={accent} opacity={0.9} />
+            </G>
+          ))}
+        </Svg>
+      </View>
+
+      {/* 16-petal lotus — slow counter spin */}
+      <Animated.View style={[StyleSheet.absoluteFill, lotusStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          <Path d={lotus16} stroke={accent} strokeOpacity={0.65} strokeWidth={1.4} fill="none" strokeLinejoin="round" />
+        </Svg>
+      </Animated.View>
+
+      {/* Inner Sri Yantra — clockwise */}
+      <Animated.View style={[StyleSheet.absoluteFill, yantraStyle, breathStyle]}>
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {triangles.down.map((pts, i) => (
+            <Polygon key={`d-${i}`} points={pts} stroke={accent} strokeOpacity={0.78 - i * 0.12} strokeWidth={1.1} fill="none" strokeLinejoin="round" />
+          ))}
+          {triangles.up.map((pts, i) => (
+            <Polygon key={`u-${i}`} points={pts} stroke={accent} strokeOpacity={0.7 - i * 0.12} strokeWidth={1.1} fill="none" strokeLinejoin="round" />
+          ))}
+          <Circle cx={cx} cy={cy} r={size * 0.04} fill={accent} fillOpacity={0.18} stroke={accent} strokeWidth={1} />
+        </Svg>
+      </Animated.View>
+
+      {/* Stationary OM at the heart */}
+      <View style={[StyleSheet.absoluteFill, styles.glyphCenter]} pointerEvents="none">
+        <Text allowFontScaling={false} style={[styles.omGlyph, { color: accent, fontSize: size * 0.13 }]}>
+          {'ॐ'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  box: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  glyphCenter: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  omGlyph: {
+    fontFamily: 'CormorantGaramond-SemiBold',
+    textAlign: 'center',
+    textShadowColor: 'rgba(212, 160, 23, 0.45)',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 8,
+  },
+});

--- a/kiaanverse-mobile/packages/store/src/index.ts
+++ b/kiaanverse-mobile/packages/store/src/index.ts
@@ -9,7 +9,7 @@
 export { useAuthStore, type AuthStatus } from './authStore';
 
 // Theme
-export { useThemeStore, type ThemeMode } from './themeStore';
+export { useThemeStore, type ThemeMode, type PaletteId } from './themeStore';
 
 // Journey
 export { useJourneyStore, type JourneyProgress } from './journeyStore';

--- a/kiaanverse-mobile/packages/store/src/themeStore.ts
+++ b/kiaanverse-mobile/packages/store/src/themeStore.ts
@@ -1,8 +1,14 @@
 /**
  * Theme Store
  *
- * Persists the user's theme preference (dark/light/system)
- * using AsyncStorage via zustand/persist.
+ * Persists the user's theme preferences to AsyncStorage via zustand/persist:
+ *   - `mode`     — dark / light / system
+ *   - `palette`  — which sacred color scheme is active
+ *                  (Indigo/Peacock, Maroon, Dark Green, Black & Gold)
+ *
+ * The palette id is a plain string union here so this package does not need
+ * a runtime dependency on `@kiaanverse/ui`. The actual palette config lives
+ * in `@kiaanverse/ui/tokens/palettes.ts` and is keyed by the same id.
  */
 
 import { create } from 'zustand';
@@ -16,12 +22,20 @@ declare const __DEV__: boolean;
 
 export type ThemeMode = 'dark' | 'light' | 'system';
 
+/** Mirror of the `PaletteId` union exported from `@kiaanverse/ui`. Kept in
+ *  sync by convention — the four ids are stable string literals. */
+export type PaletteId = 'indigoPeacock' | 'maroon' | 'darkGreen' | 'blackGold';
+
+const DEFAULT_PALETTE: PaletteId = 'indigoPeacock';
+
 interface ThemeState {
   mode: ThemeMode;
+  palette: PaletteId;
 }
 
 interface ThemeActions {
   setMode: (mode: ThemeMode) => void;
+  setPalette: (palette: PaletteId) => void;
 }
 
 export const useThemeStore = create<ThemeState & ThemeActions>()(
@@ -29,16 +43,26 @@ export const useThemeStore = create<ThemeState & ThemeActions>()(
     persist(
       immer((set) => ({
         mode: 'dark' as ThemeMode,
+        palette: DEFAULT_PALETTE,
 
         setMode: (mode: ThemeMode) => {
           set((state) => {
             state.mode = mode;
           });
         },
+
+        setPalette: (palette: PaletteId) => {
+          set((state) => {
+            state.palette = palette;
+          });
+        },
       })),
       {
         name: 'kiaanverse-theme',
         storage: createJSONStorage(() => AsyncStorage),
+        // Migration: existing users will hydrate with no `palette` field.
+        // Zustand's persist merges the default state, so they will land on
+        // 'indigoPeacock' (the previous look) — no flash of unfamiliar color.
       },
     ),
     {

--- a/kiaanverse-mobile/packages/ui/src/components/DivineBackground.tsx
+++ b/kiaanverse-mobile/packages/ui/src/components/DivineBackground.tsx
@@ -25,7 +25,6 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/useTheme';
-import { gradients } from '../tokens/gradients';
 import { duration } from '../tokens/motion';
 
 export type DivineBackgroundVariant = 'cosmic' | 'sacred' | 'warm';
@@ -48,8 +47,8 @@ function DivineBackgroundInner({
   style,
   children,
 }: DivineBackgroundProps): React.JSX.Element {
-  const { isDark } = useTheme();
-  const mode = isDark ? 'dark' : 'light';
+  const { theme, isDark } = useTheme();
+  const scheme = theme.colorScheme;
 
   // Breathing aura opacity
   const auraOpacity = useSharedValue(0.4);
@@ -71,11 +70,20 @@ function DivineBackgroundInner({
     opacity: auraOpacity.value,
   }));
 
-  // Select gradient colors based on variant
-  const bgColors = gradients.cosmicBackground[mode];
-  const auraColors = variant === 'warm'
-    ? gradients.peacockSheen[mode]
-    : gradients.divineAura[mode];
+  // Light mode keeps a warm cream backdrop regardless of the picked palette
+  // (palettes are designed for the cosmic/dark side of the app). Dark mode
+  // uses the active sacred color scheme — Indigo, Maroon, Forest, or Black/Gold.
+  const bgColors: readonly string[] = isDark
+    ? scheme.bg.gradient
+    : ['#FAF7F2', '#F5F0E8', '#EDE8DC'];
+
+  // The aura tints the top breathing glow toward the palette's primary mood.
+  // 'sacred' variant biases the aura toward divine gold for a temple feel,
+  // while 'warm' and 'cosmic' use the palette's own aura ramp.
+  const auraColors: readonly string[] =
+    variant === 'sacred'
+      ? [scheme.accent.divine + '55', scheme.accent.divine + '22', 'transparent']
+      : [scheme.aura[0], scheme.aura[1], scheme.aura[2]];
 
   return (
     <View style={[styles.container, style]}>

--- a/kiaanverse-mobile/packages/ui/src/index.ts
+++ b/kiaanverse-mobile/packages/ui/src/index.ts
@@ -53,6 +53,15 @@ export {
   type ChakraColor,
 } from './tokens/sacred';
 export { gradients } from './tokens/gradients';
+export {
+  PALETTES,
+  PALETTE_ORDER,
+  DEFAULT_PALETTE_ID,
+  resolvePalette,
+  type Palette,
+  type PaletteAccent,
+  type PaletteId,
+} from './tokens/palettes';
 
 // ---------------------------------------------------------------------------
 // Theme (composed token system with dark/light mode)

--- a/kiaanverse-mobile/packages/ui/src/theme/ThemeProvider.tsx
+++ b/kiaanverse-mobile/packages/ui/src/theme/ThemeProvider.tsx
@@ -4,29 +4,45 @@
  * Wraps the app in a React context carrying the full typed theme object.
  * Resolves 'system' mode via the Appearance API and memoises the theme
  * to prevent unnecessary re-renders in the component tree.
+ *
+ * Also threads the active **sacred color scheme** (palette) through the
+ * theme. The host app reads `paletteId` from a persisted store
+ * (`@kiaanverse/store/themeStore`) and passes it in; we look up the full
+ * palette config from `tokens/palettes.ts` and merge it onto `theme.colorScheme`.
  */
 
 import React, { createContext, useMemo } from 'react';
 import { useColorScheme } from 'react-native';
 import { darkTheme, lightTheme } from './themes';
+import { DEFAULT_PALETTE_ID, PALETTES } from '../tokens/palettes';
 import type { ThemeContextValue, ThemeMode } from './types';
+import type { PaletteId } from '../tokens/palettes';
 
 export const ThemeContext = createContext<ThemeContextValue>({
-  theme: darkTheme,
+  theme: { ...darkTheme, colorScheme: PALETTES[DEFAULT_PALETTE_ID] },
   isDark: true,
   mode: 'dark',
   setMode: () => {},
+  paletteId: DEFAULT_PALETTE_ID,
+  setPaletteId: () => {},
 });
 
 interface ThemeProviderProps {
   mode: ThemeMode;
   onModeChange: (mode: ThemeMode) => void;
+  /** Active palette id from the host store. @default 'indigoPeacock' */
+  paletteId?: PaletteId;
+  /** Called when the user switches palette via the picker. No-op default
+   *  keeps the provider usable in tests / Storybook without a real store. */
+  onPaletteChange?: (id: PaletteId) => void;
   children: React.ReactNode;
 }
 
 export function ThemeProvider({
   mode,
   onModeChange,
+  paletteId = DEFAULT_PALETTE_ID,
+  onPaletteChange,
   children,
 }: ThemeProviderProps): React.JSX.Element {
   const systemScheme = useColorScheme();
@@ -35,13 +51,18 @@ export function ThemeProvider({
     const resolvedDark =
       mode === 'system' ? systemScheme !== 'light' : mode === 'dark';
 
+    const baseTheme = resolvedDark ? darkTheme : lightTheme;
+    const colorScheme = PALETTES[paletteId] ?? PALETTES[DEFAULT_PALETTE_ID];
+
     return {
-      theme: resolvedDark ? darkTheme : lightTheme,
+      theme: { ...baseTheme, colorScheme },
       isDark: resolvedDark,
       mode,
       setMode: onModeChange,
+      paletteId,
+      setPaletteId: onPaletteChange ?? (() => {}),
     };
-  }, [mode, systemScheme, onModeChange]);
+  }, [mode, systemScheme, onModeChange, paletteId, onPaletteChange]);
 
   return (
     <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>

--- a/kiaanverse-mobile/packages/ui/src/theme/themes.ts
+++ b/kiaanverse-mobile/packages/ui/src/theme/themes.ts
@@ -14,6 +14,7 @@ import { fontFamily, fontSize, lineHeight, letterSpacing, textPresets } from '..
 import { spacing } from '../tokens/spacing';
 import { radii } from '../tokens/radii';
 import { duration, spring } from '../tokens/motion';
+import { PALETTES, DEFAULT_PALETTE_ID } from '../tokens/palettes';
 import type { Theme, ThemeColors } from './types';
 
 // ---------------------------------------------------------------------------
@@ -97,12 +98,20 @@ const sharedTokens = {
 // Composed theme objects
 // ---------------------------------------------------------------------------
 
+/** Default palette is overwritten at runtime by ThemeProvider once the host
+ *  store hydrates the user's choice. The static themes carry the indigoPeacock
+ *  scheme so anyone using `darkTheme` / `lightTheme` directly (tests, Storybook)
+ *  still gets a valid, themeable object. */
+const DEFAULT_SCHEME = PALETTES[DEFAULT_PALETTE_ID];
+
 export const darkTheme: Theme = {
   colors: darkColors,
   ...sharedTokens,
+  colorScheme: DEFAULT_SCHEME,
 };
 
 export const lightTheme: Theme = {
   colors: lightColors,
   ...sharedTokens,
+  colorScheme: DEFAULT_SCHEME,
 };

--- a/kiaanverse-mobile/packages/ui/src/theme/types.ts
+++ b/kiaanverse-mobile/packages/ui/src/theme/types.ts
@@ -10,6 +10,7 @@ import type { fontFamily, fontSize, lineHeight, letterSpacing, textPresets } fro
 import type { spacing } from '../tokens/spacing';
 import type { radii } from '../tokens/radii';
 import type { duration, spring } from '../tokens/motion';
+import type { Palette, PaletteId } from '../tokens/palettes';
 
 // ---------------------------------------------------------------------------
 // Theme mode
@@ -89,6 +90,11 @@ export interface Theme {
   /** Animation timing */
   readonly duration: typeof duration;
   readonly spring: typeof spring;
+
+  /** Active sacred color scheme — drives DivineBackground gradient + aura,
+   *  arrival page accents, and primary CTA gradient. Switched at runtime by
+   *  the user via the palette picker. */
+  readonly colorScheme: Palette;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,4 +106,8 @@ export interface ThemeContextValue {
   readonly isDark: boolean;
   readonly mode: ThemeMode;
   readonly setMode: (mode: ThemeMode) => void;
+  /** Active palette id — the picker reads this to highlight the current pick. */
+  readonly paletteId: PaletteId;
+  /** Switch to a different sacred color scheme. Persists via the host store. */
+  readonly setPaletteId: (id: PaletteId) => void;
 }

--- a/kiaanverse-mobile/packages/ui/src/tokens/palettes.ts
+++ b/kiaanverse-mobile/packages/ui/src/tokens/palettes.ts
@@ -1,0 +1,189 @@
+/**
+ * Sacred Palette Tokens — four Vedic-aesthetic color schemes the user can
+ * choose between (Indigo/Peacock, Maroon, Dark Green, Black & Gold).
+ *
+ * Each palette defines:
+ *   - bg.gradient   — vertical screen backdrop (top, mid, bottom)
+ *   - bg.void       — flat fallback color for non-gradient surfaces
+ *   - aura          — three-stop rgba ramp for the breathing top-glow
+ *   - accent.*      — the six per-page arrival accents (primary, warm, cool,
+ *                     deep, life, divine). Components that previously hardcoded
+ *                     KRISHNA_BLUE / PEACOCK_BRIGHT / etc. read from these.
+ *   - text.title    — primary title color on dark surfaces
+ *   - text.body     — body copy with built-in opacity
+ *   - cta           — two-stop gradient for the primary CTA button
+ *
+ * Gold (`#D4A017` / `#D4A44C`) is preserved as **brand identity** in every
+ * palette via `accent.warm` and `accent.divine` so OM glyphs, XP seals, and
+ * tier badges stay coherent across schemes.
+ *
+ * The picker is wired into `useThemeStore` (`@kiaanverse/store`) and threaded
+ * through `ThemeProvider` so any component using `useTheme().palette` updates
+ * automatically when the user switches.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** All shipping palette ids. Keep in sync with the `PaletteId` union in
+ *  `@kiaanverse/store/themeStore.ts` — string literals so they match
+ *  structurally without a cross-package import. */
+export type PaletteId = 'indigoPeacock' | 'maroon' | 'darkGreen' | 'blackGold';
+
+export interface PaletteAccent {
+  readonly primary: string;
+  readonly warm: string;
+  readonly cool: string;
+  readonly deep: string;
+  readonly life: string;
+  readonly divine: string;
+}
+
+export interface Palette {
+  readonly id: PaletteId;
+  /** Long display label for sheet cards. */
+  readonly label: string;
+  /** Short label for chips / one-line previews. */
+  readonly shortLabel: string;
+  readonly bg: {
+    readonly void: string;
+    readonly gradient: readonly [string, string, string];
+  };
+  /** Three-stop rgba ramp for the breathing aura at the top of the screen. */
+  readonly aura: readonly [string, string, string];
+  readonly accent: PaletteAccent;
+  readonly text: {
+    readonly title: string;
+    readonly body: string;
+  };
+  /** Two-stop CTA gradient (start, end). */
+  readonly cta: readonly [string, string];
+}
+
+// ---------------------------------------------------------------------------
+// Palette definitions
+// ---------------------------------------------------------------------------
+
+const indigoPeacock: Palette = {
+  id: 'indigoPeacock',
+  label: 'Indigo & Peacock',
+  shortLabel: 'Indigo',
+  bg: {
+    void: '#050714',
+    gradient: ['#050714', '#0A1228', '#050714'],
+  },
+  aura: ['rgba(27, 79, 187, 0.28)', 'rgba(14, 116, 144, 0.10)', 'transparent'],
+  accent: {
+    primary: '#1B4FBB',
+    warm: '#D4A017',
+    cool: '#06B6D4',
+    deep: '#8B5CF6',
+    life: '#10B981',
+    divine: '#D4A44C',
+  },
+  text: {
+    title: '#F5F0E8',
+    body: 'rgba(245, 240, 232, 0.78)',
+  },
+  cta: ['#1B4FBB', '#0E7490'],
+};
+
+const maroon: Palette = {
+  id: 'maroon',
+  label: 'Maroon & Saffron',
+  shortLabel: 'Maroon',
+  bg: {
+    void: '#1A0606',
+    gradient: ['#1A0606', '#2B0A0A', '#3B0E0E'],
+  },
+  aura: ['rgba(139, 0, 0, 0.32)', 'rgba(180, 83, 9, 0.10)', 'transparent'],
+  accent: {
+    primary: '#8B1A1A',
+    warm: '#D4A017',
+    cool: '#C9302C',
+    deep: '#6B0F1A',
+    life: '#B45309',
+    divine: '#D4A44C',
+  },
+  text: {
+    title: '#F5DEB3',
+    body: 'rgba(245, 222, 179, 0.78)',
+  },
+  cta: ['#6B0F1A', '#8B0000'],
+};
+
+const darkGreen: Palette = {
+  id: 'darkGreen',
+  label: 'Forest & Sage',
+  shortLabel: 'Forest',
+  bg: {
+    void: '#0A1F0F',
+    gradient: ['#0A1F0F', '#102818', '#163A22'],
+  },
+  aura: ['rgba(45, 134, 89, 0.30)', 'rgba(143, 188, 143, 0.10)', 'transparent'],
+  accent: {
+    primary: '#1B4D2E',
+    warm: '#D4A017',
+    cool: '#2D8659',
+    deep: '#5B8C5A',
+    life: '#8FBC8F',
+    divine: '#D4A44C',
+  },
+  text: {
+    title: '#E8F5E8',
+    body: 'rgba(232, 245, 232, 0.78)',
+  },
+  cta: ['#1B4D2E', '#2D8659'],
+};
+
+const blackGold: Palette = {
+  id: 'blackGold',
+  label: 'Black & Gold',
+  shortLabel: 'Gold',
+  bg: {
+    void: '#000000',
+    gradient: ['#000000', '#0A0A0A', '#141414'],
+  },
+  aura: ['rgba(212, 160, 23, 0.32)', 'rgba(212, 160, 23, 0.08)', 'transparent'],
+  accent: {
+    primary: '#D4A017',
+    warm: '#E8B54A',
+    cool: '#B8860B',
+    deep: '#8B6914',
+    life: '#F0C96D',
+    divine: '#FFD700',
+  },
+  text: {
+    title: '#D4A44C',
+    body: 'rgba(212, 164, 76, 0.82)',
+  },
+  cta: ['#D4A017', '#E8B54A'],
+};
+
+/** Lookup table — ordered for the picker UI (default first). */
+export const PALETTES: Record<PaletteId, Palette> = {
+  indigoPeacock,
+  maroon,
+  darkGreen,
+  blackGold,
+} as const;
+
+/** Stable display order for the picker bottom sheet. */
+export const PALETTE_ORDER: readonly PaletteId[] = [
+  'indigoPeacock',
+  'maroon',
+  'darkGreen',
+  'blackGold',
+] as const;
+
+export const DEFAULT_PALETTE_ID: PaletteId = 'indigoPeacock';
+
+/** Resolve a palette by id with a safe default — handy when reading from
+ *  persisted storage where the user might be on a stale id. */
+export function resolvePalette(id: string | null | undefined): Palette {
+  if (id && id in PALETTES) {
+    return PALETTES[id as PaletteId];
+  }
+  return PALETTES[DEFAULT_PALETTE_ID];
+}


### PR DESCRIPTION
The 5-page arrival ceremony shipped with five near-identical concentric ring
illustrations that read as "loading spinners" rather than sacred geometry.
This swaps each page's visual for a hand-built SVG that matches the Gita /
Vedic theme of its copy, and appends a sixth page carrying the full
"Welcome, Dear Friend" message with Bhagavad Gita 6.35.

Per page:
  1. arjuna  — Ashoka Dharma Chakra (24 spokes) crowned by a peacock-eye feather
  2. sakha   — full Sri Yantra (9 interlocking triangles) inside an 8-petal lotus
  3. gita    — Krishna's flute orbiting concentric shabda (sound) rings
  4. journey — Shatkona hexagram with 6 ripu orbs at its outer points
  5. sacred  — 16+8 layered padma encircling a four-fold yantra seal
  6. welcome — Grand Sri Yantra mandala crowned by a 3-eye peacock feather

Each mandala has its own breath + multi-axis rotation cadence (UI-thread
Reanimated), respects prefers-reduced-motion, and shares the Sri-Yantra
geometry helpers (regular polygon, multi-petal lotus, spoke fan) from a
new arrival/visuals.tsx module.

Page 6 carries the same copy as the kiaanverse.com/m IntroOverlay:
  - "KIAAN — YOUR DIVINE FRIEND" eyebrow
  - "Welcome, Dear Friend" italic title
  - Two body paragraphs (companion + Krishna-Arjuna metaphor)
  - Verse card: Bhagavad Gita 6.35 Devanagari + English + attribution
  - Gold-gradient "Enter the Sacred Space" CTA replaces "Begin Your Journey"

Layout: page 6 is internally scrollable so the verse card never collides
with the absolute-positioned CTA, and a 200pt bottom spacer ensures the
last ornament clears both the progress bar and the gold button on small
screens. The italic title now references CormorantGaramond-LightItalic
(the family actually registered in useSacredFonts) instead of the missing
CormorantGaramond-Italic.

https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY