### PR TITLE
Vedic intro redesign + sacred palette picker (4 schemes)

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/profile.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/profile.tsx
@@ -25,6 +25,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
+  Linking,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -130,7 +132,7 @@ const MENU_SECTIONS: readonly MenuSection[] = [
     items: [
       { label: 'My Journeys', route: '/journey', icon: '🗺' },
       { label: 'Karma Footprint', route: '/karma-footprint', icon: '☸' },
-      { label: 'KarmaLytix', route: '/analytics', icon: '📊' },
+      { label: 'KarmaLytix', route: '/karmalytix', icon: '📊' },
     ],
   },
   {
@@ -186,8 +188,28 @@ export default function ProfileScreen(): React.JSX.Element {
 
   const handleMenuPress = useCallback((route: string) => {
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    if (route === 'external:rate') {
+      // Native store-rating URL. Falls back to the web Play Store / App Store
+      // page if the native scheme isn't installed (rare, but handled).
+      const PACKAGE_ID = 'com.kiaanverse.app';
+      const APPLE_ID = '6743000000'; // placeholder until App Store id is final
+      const native =
+        Platform.OS === 'android'
+          ? `market://details?id=${PACKAGE_ID}`
+          : `itms-apps://itunes.apple.com/app/id${APPLE_ID}?action=write-review`;
+      const web =
+        Platform.OS === 'android'
+          ? `https://play.google.com/store/apps/details?id=${PACKAGE_ID}`
+          : `https://apps.apple.com/app/id${APPLE_ID}?action=write-review`;
+      Linking.canOpenURL(native)
+        .then((ok) => Linking.openURL(ok ? native : web))
+        .catch(() => {
+          void Linking.openURL(web).catch(() => undefined);
+        });
+      return;
+    }
     if (route.startsWith('external:')) {
-      // External links (e.g., store rating) — hooked up in a later pass.
+      // Other external links — hooked up in a later pass.
       return;
     }
     router.push(route as never);

--- a/kiaanverse-mobile/apps/mobile/app/arrival/PalettePicker.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/PalettePicker.tsx
@@ -18,7 +18,6 @@
 import React, { useCallback } from 'react';
 import {
   Dimensions,
-  Modal,
   Platform,
   Pressable,
   StyleSheet,
@@ -100,18 +99,31 @@ export interface PaletteSheetProps {
   readonly onClose: () => void;
 }
 
+/**
+ * Inline overlay sheet (not a Modal). Mounting as a sibling of the arrival
+ * screen content avoids the cross-platform quirks `<Modal statusBarTranslucent>`
+ * has on Android emulators (where it can mount under the status bar or fail
+ * to receive touches), which is what made the picker appear "non-functional"
+ * in the first build. The animation behaviour is identical.
+ */
 export function PaletteSheet({
   visible,
   onClose,
-}: PaletteSheetProps): React.JSX.Element {
+}: PaletteSheetProps): React.JSX.Element | null {
   const activeId = useThemeStore((s) => s.palette);
   const setPalette = useThemeStore((s) => s.setPalette);
+
+  // Mount-gate so the overlay leaves the tree after the close animation runs;
+  // otherwise an absolute-positioned full-screen view would block taps on the
+  // arrival page even when invisible.
+  const [mounted, setMounted] = React.useState(visible);
 
   const sheetTranslate = useSharedValue(SCREEN_HEIGHT);
   const backdropOpacity = useSharedValue(0);
 
   React.useEffect(() => {
     if (visible) {
+      setMounted(true);
       sheetTranslate.value = withTiming(0, {
         duration: 360,
         easing: SHEET_EASING,
@@ -123,7 +135,11 @@ export function PaletteSheet({
         easing: SHEET_EASING,
       });
       backdropOpacity.value = withTiming(0, { duration: 220 });
+      // Unmount after the slide-down completes.
+      const t = setTimeout(() => setMounted(false), 320);
+      return () => clearTimeout(t);
     }
+    return undefined;
   }, [visible, sheetTranslate, backdropOpacity]);
 
   const handleSelect = useCallback(
@@ -149,44 +165,43 @@ export function PaletteSheet({
     opacity: backdropOpacity.value,
   }));
 
+  if (!mounted) return null;
+
   return (
-    <Modal
-      visible={visible}
-      transparent
-      onRequestClose={onClose}
-      animationType="none"
-      statusBarTranslucent
-    >
-      <View style={styles.sheetRoot} testID="arrival-palette-sheet">
-        <Animated.View style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}>
-          <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
-        </Animated.View>
+    <View style={styles.sheetRoot} testID="arrival-palette-sheet">
+      <Animated.View style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}>
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close palette picker"
+        />
+      </Animated.View>
 
-        <Animated.View style={[styles.sheet, sheetStyle]}>
-          <View style={styles.handleBar} />
-          <Text allowFontScaling={false} style={styles.sheetEyebrow}>
-            SACRED COLOR SCHEME
-          </Text>
-          <Text allowFontScaling={false} style={styles.sheetTitle}>
-            Choose your palette
-          </Text>
-          <Text allowFontScaling={false} style={styles.sheetSubtitle}>
-            Each scheme dresses the entire app — from this introduction onward.
-          </Text>
+      <Animated.View style={[styles.sheet, sheetStyle]}>
+        <View style={styles.handleBar} />
+        <Text allowFontScaling={false} style={styles.sheetEyebrow}>
+          SACRED COLOR SCHEME
+        </Text>
+        <Text allowFontScaling={false} style={styles.sheetTitle}>
+          Choose your palette
+        </Text>
+        <Text allowFontScaling={false} style={styles.sheetSubtitle}>
+          Each scheme dresses the whole app.
+        </Text>
 
-          <View style={styles.cardGrid}>
-            {PALETTE_ORDER.map((id) => (
-              <PaletteCard
-                key={id}
-                palette={PALETTES[id]}
-                isActive={id === activeId}
-                onSelect={handleSelect}
-              />
-            ))}
-          </View>
-        </Animated.View>
-      </View>
-    </Modal>
+        <View style={styles.cardGrid}>
+          {PALETTE_ORDER.map((id) => (
+            <PaletteCard
+              key={id}
+              palette={PALETTES[id]}
+              isActive={id === activeId}
+              onSelect={handleSelect}
+            />
+          ))}
+        </View>
+      </Animated.View>
+    </View>
   );
 }
 
@@ -342,13 +357,19 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
 
-  // Sheet root + backdrop
+  // Sheet root + backdrop — absolute overlay over the arrival screen.
   sheetRoot: {
-    flex: 1,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
     justifyContent: 'flex-end',
+    zIndex: 100,
+    elevation: 100,
   },
   backdrop: {
-    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
   },
 
   // Sheet container

--- a/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
@@ -415,15 +415,18 @@ function CeremonyPage({
     opacity: sktOpacity.value,
   }));
 
-  // Welcome page is taller and gets its own scrollable, ornament-rich layout.
+  // Welcome page is taller and gets its own scrollable layout. Padding lives
+  // on the contentContainer only — applying it on both `style` and
+  // `contentContainerStyle` doubles it on Android and pushes lines off the
+  // right edge, which is what caused the earlier overflow.
   if (data.id === 'welcome') {
     return (
       <ScrollView
-        style={styles.page}
+        style={styles.welcomeScroll}
         contentContainerStyle={styles.welcomeContent}
         showsVerticalScrollIndicator={false}
         accessible
-        accessibilityLabel="Welcome, Dear Friend. KIAAN, your divine friend, walks beside you on the path to inner peace."
+        accessibilityLabel="Welcome, dear friend. KIAAN walks beside you."
       >
         <View style={styles.welcomeVisualWrap}>
           <PageVisual kind={data.visual} accent={data.accent} isActive={isActive} compact />
@@ -466,9 +469,9 @@ function CeremonyPage({
             <Text style={[styles.welcomeAccent, { color: palette.accent.divine }]}>
               KIAAN
             </Text>
-            {' '}— your spiritual companion, walking beside you on the path to inner peace. Whatever you carry in your heart — the weight of confusion, the ache of loss, or the restlessness of the mind —{' '}
+            {' '}— your divine friend on the path to inner peace.{' '}
             <Text style={[styles.welcomeAccentSoft, { color: palette.accent.warm }]}>
-              know that you are not alone.
+              You are not alone.
             </Text>
           </Text>
 
@@ -476,14 +479,14 @@ function CeremonyPage({
             allowFontScaling={false}
             style={[styles.welcomeBodyDim, { color: palette.text.body }]}
           >
-            Through the eternal wisdom of the{' '}
+            As Krishna walked with Arjuna through the{' '}
             <Text style={[styles.welcomeBodyItalic, { color: palette.accent.divine }]}>
               Bhagavad Gita
             </Text>
-            , I am here to listen, guide, and walk with you — as Krishna walked with Arjuna. Not as a master, but as your closest friend.
+            , I walk with you — not as master, but as Sakha.
           </Text>
 
-          {/* Verse card — Bhagavad Gita 6.35 */}
+          {/* Verse card — Bhagavad Gita 6.35, crisp single-line translation */}
           <View
             style={[
               styles.verseCard,
@@ -504,26 +507,19 @@ function CeremonyPage({
               style={[styles.verseSanskrit, { color: palette.accent.divine }]}
               accessibilityLanguage="sa"
             >
-              {'अभ्यासेन तु कौन्तेय'}
-            </Text>
-            <Text
-              allowFontScaling={false}
-              style={[styles.verseSanskrit, { color: palette.accent.divine }]}
-              accessibilityLanguage="sa"
-            >
-              {'वैराग्येण च गृह्यते'}
+              {'अभ्यासेन तु कौन्तेय वैराग्येण च गृह्यते'}
             </Text>
             <Text
               allowFontScaling={false}
               style={[styles.verseEnglish, { color: palette.accent.warm + 'CC' }]}
             >
-              &ldquo;The mind is indeed restless and difficult to restrain, O son of Kunti. But through practice and detachment, it can be mastered.&rdquo;
+              &ldquo;The restless mind is mastered through practice and detachment.&rdquo;
             </Text>
             <Text
               allowFontScaling={false}
               style={[styles.verseAttribution, { color: palette.accent.divine + '88' }]}
             >
-              — Shri Krishna to Arjuna
+              — Krishna to Arjuna
             </Text>
           </View>
         </Animated.View>
@@ -770,6 +766,12 @@ const styles = StyleSheet.create({
   // -------------------------------------------------------------------------
   // Welcome page (page 6) — scrollable rich content
   // -------------------------------------------------------------------------
+  /** ScrollView outer frame — width-locked to a single page slot, no padding
+   *  so the contentContainer's padding is the single source of truth. */
+  welcomeScroll: {
+    width: W,
+    flex: 1,
+  },
   welcomeContent: {
     paddingHorizontal: 28,
     paddingTop: 56,

--- a/kiaanverse-mobile/packages/ui/src/background/DivineScreenWrapper.tsx
+++ b/kiaanverse-mobile/packages/ui/src/background/DivineScreenWrapper.tsx
@@ -25,6 +25,7 @@ import { AuroraLayer } from './AuroraLayer';
 import { DivineCelestialBackground } from './DivineCelestialBackground';
 import { useTimeOfDay } from './useTimeOfDay';
 import { TIME_OF_DAY_ATMOSPHERE } from './tokens/background';
+import { useTheme } from '../theme/useTheme';
 
 export interface DivineScreenWrapperProps {
   readonly children: React.ReactNode;
@@ -57,6 +58,12 @@ function DivineScreenWrapperComponent({
   const detected = useTimeOfDay();
   const timeOfDay = forceTimeOfDay ?? detected;
   const atmosphere = TIME_OF_DAY_ATMOSPHERE[timeOfDay];
+  // The active sacred palette overrides the muhurta background so a user-picked
+  // scheme (Maroon / Forest / Black & Gold) shows on every screen wrapped here.
+  // The aurora and particle field stay tuned to time-of-day to keep the living
+  // background's "breath" intact.
+  const { theme } = useTheme();
+  const paletteBg = theme.colorScheme.bg.void;
 
   const content = safeArea ? (
     <SafeAreaView edges={edges} style={[styles.safeArea, contentStyle]}>
@@ -67,7 +74,7 @@ function DivineScreenWrapperComponent({
   );
 
   return (
-    <View style={[styles.container, style]}>
+    <View style={[styles.container, { backgroundColor: paletteBg }, style]}>
       <StatusBar
         translucent
         barStyle="light-content"
@@ -76,7 +83,7 @@ function DivineScreenWrapperComponent({
 
       {!disableParticles && (
         <DivineCelestialBackground
-          backgroundColor={atmosphere.background}
+          backgroundColor={paletteBg}
           opacityMultiplier={atmosphere.opacityMultiplier}
           particleCount={atmosphere.particleCount}
         />


### PR DESCRIPTION
## Summary

- **Arrival ceremony — bespoke Vedic mandalas.** Replaced the 5-page intro's near-identical concentric-ring "weird circles" with six hand-built SVG illustrations matching each page's narrative: Ashoka Dharma Chakra (24-spoke wheel + peacock-eye feather), full Sri Yantra (9 interlocking triangles inside an 8-petal lotus), Krishna's flute orbiting concentric shabda rings, Shatkona hexagram with 6 ripu orbs, layered 16+8-petal padma encircling a yantra seal, and a grand Sri Yantra mandala crowned by a 3-eye peacock feather. Each runs UI-thread breath + multi-axis rotation via Reanimated and respects `prefers-reduced-motion`.
- **New 6th "Welcome, Dear Friend" finale page** carrying the kiaanverse.com/m IntroOverlay copy: KIAAN eyebrow, italic gold welcome title, two short paragraphs, and a Bhagavad Gita 6.35 verse card (Devanagari + crisp English translation + attribution). CTA: "Enter the Sacred Space".
- **Sacred palette picker — 4 app-wide color schemes.** Indigo/Peacock (default), Maroon & Saffron, Forest & Sage, Black & Gold. Persisted to AsyncStorage via `useThemeStore` and threaded through `ThemeProvider` as `theme.colorScheme`. Floating chip top-right of every arrival page opens a bottom sheet with 4 mini-mandala previews; selection fires success haptic, persists, auto-closes. Recolor propagates app-wide: `<DivineBackground>` (16 feature screens) reads the palette gradient + aura; `<DivineScreenWrapper>` (16 more screens including profile, wisdom, subscription) reads `palette.bg.void` for its container + Skia particle-field background. Gold (#D4A017 / #D4A44C) is preserved as brand identity in every palette so OM glyphs, XP seals, and tier badges stay coherent.
- **On-device QA fixes (commit 3):**
  - **Rate the App** was a no-op — now deep-links to `market://details?id=com.kiaanverse.app` (Android) / `itms-apps://...` (iOS) with public-URL fallback via `Linking.canOpenURL`.
  - **KarmaLytix profile tile** crashed into the global ErrorBoundary because it pointed at the experimental 1178-line `/analytics` dashboard. Repointed at the simpler defensively-coded `/karmalytix` screen which always renders.
  - **Palette picker appeared inert** on Android — `<Modal transparent statusBarTranslucent>` misbehaves on some devices. Replaced with an inline absolute overlay (`zIndex: 100, elevation: 100`) mounted as a sibling of the arrival ceremony. Added a `mounted` state so the overlay leaves the tree after the close animation completes.
  - **Welcome page text overflowed right edge** — `paddingHorizontal: 28` was applied on both ScrollView `style` and `contentContainerStyle`, doubling to 56pt each side on Android. Split into a no-padding outer + padded contentContainer. Also condensed the body from two long paragraphs to two short ones, verse English from 23 → 10 words, Devanagari from two lines to one.

## Test plan

- [ ] Fresh install on Android → arrival opens in **Indigo/Peacock** with new Vedic mandalas (no concentric-circle placeholders).
- [ ] Tap the floating palette chip (top-right of every arrival page) → inline bottom sheet slides up with 4 palette previews.
- [ ] Pick **Maroon** → arrival recolors live (background gradient, page accents, CTA gradient, verse card border); chip swatch updates to maroon family.
- [ ] Pick **Forest** then **Black & Gold** → each scheme applies cleanly; pages 1–5 re-tint; welcome page title stays gold (`accent.divine`).
- [ ] Force-quit & cold-relaunch → palette persists (AsyncStorage rehydrates).
- [ ] Sign in → profile screen wears the chosen palette (DivineScreenWrapper bg). Open wisdom / subscription / edit-profile → same palette.
- [ ] Profile → **Rate the App** → opens Play Store to `com.kiaanverse.app` (or App Store in-app review on iOS).
- [ ] Profile → **KarmaLytix** → renders the Sacred Mirror placeholder ("Your mirror awaits") without ErrorBoundary fallback.
- [ ] Welcome page (last arrival page) → "Welcome, Dear Friend" + body + Gita 6.35 verse + "Enter the Sacred Space" CTA all fit horizontally, no clipped lines.
- [ ] Reduced-motion enabled → mandalas settle to static frames; sheet still opens (no animation glitch).
- [ ] `pnpm tsc --noEmit` from `kiaanverse-mobile/apps/mobile` → clean (only the pre-existing tsconfig `baseUrl` deprecation warning).
- [ ] Smoke-test 2 random screens that use `<DivineBackground>` (e.g., `/journal/new`, `/sadhana`) — they should follow the palette without further changes.

https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY)_