### PR TITLE
Arrival drift + Devanagari clipping + splash yantra + app-wide palette + inline swatches

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/arrival/PalettePicker.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/PalettePicker.tsx
@@ -307,6 +307,79 @@ function SwatchQuadrant({
 }
 
 // ---------------------------------------------------------------------------
+// InlinePaletteSwatches — visible row of palette options on the welcome page
+// ---------------------------------------------------------------------------
+
+export interface InlinePaletteSwatchesProps {
+  /** Which palette is currently active (for the check tick). */
+  readonly activeId: PaletteId;
+}
+
+/**
+ * A horizontal row of four palette pills shown directly on the welcome page,
+ * so the color options are visible without tapping the floating chip. Tapping
+ * a pill applies the palette immediately. This complements the chip + sheet
+ * (the chip remains for users on pages 1–5).
+ */
+export function InlinePaletteSwatches({
+  activeId,
+}: InlinePaletteSwatchesProps): React.JSX.Element {
+  const setPalette = useThemeStore((s) => s.setPalette);
+
+  const handle = useCallback(
+    (id: PaletteId) => {
+      if (id === activeId) return;
+      if (Platform.OS !== 'web') {
+        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+          () => undefined
+        );
+      }
+      setPalette(id);
+    },
+    [activeId, setPalette]
+  );
+
+  return (
+    <>
+      {PALETTE_ORDER.map((id) => {
+        const p = PALETTES[id];
+        const isActive = id === activeId;
+        return (
+          <TouchableOpacity
+            key={id}
+            onPress={() => handle(id)}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isActive }}
+            accessibilityLabel={`Select ${p.label} palette`}
+            testID={`arrival-palette-inline-${id}`}
+            style={[
+              styles.inlinePill,
+              {
+                backgroundColor: p.bg.void,
+                borderColor: isActive
+                  ? p.accent.divine
+                  : 'rgba(212, 164, 76, 0.25)',
+                borderWidth: isActive ? 2 : 1,
+              },
+            ]}
+          >
+            <SwatchQuadrant palette={p} size={28} />
+            <Text
+              allowFontScaling={false}
+              style={[styles.inlinePillLabel, { color: p.text.title }]}
+              numberOfLines={1}
+            >
+              {p.shortLabel}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Hook — small helper so the chip + sheet can co-live in one parent screen
 // ---------------------------------------------------------------------------
 
@@ -452,5 +525,22 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
+  },
+
+  // Inline palette swatches (visible on the welcome page)
+  inlinePill: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    borderRadius: 14,
+    minWidth: 64,
+    gap: 4,
+  },
+  inlinePillLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 11,
+    letterSpacing: 0.4,
   },
 });

--- a/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
@@ -55,9 +55,21 @@ import {
   SriYantraVisual,
   VISUAL_SIZE,
 } from './visuals';
-import { PalettePickerChip, PaletteSheet, usePaletteSheet } from './PalettePicker';
+import {
+  InlinePaletteSwatches,
+  PalettePickerChip,
+  PaletteSheet,
+  usePaletteSheet,
+} from './PalettePicker';
 
-const { width: W } = Dimensions.get('window');
+// Use integer pixel widths everywhere on this slider. `Dimensions.get` returns
+// a fractional value on many Android devices (e.g. 411.42857) — when that
+// fractional W feeds both the page width AND the per-page translateX, Yoga
+// rounds the actual rendered widths but the translateX uses the unrounded
+// number, so each page lands a fraction of a pixel off. Over 5 transitions
+// the drift compounds into a visible right-shift on later pages. Rounding W
+// to an integer eliminates the mismatch.
+const W = Math.round(Dimensions.get('window').width);
 
 // ---------------------------------------------------------------------------
 // Page definitions
@@ -203,10 +215,21 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
     if (page < PAGE_COUNT - 1) {
       haptic('light');
       const nextIndex = page + 1;
-      translateX.value = withSpring(-nextIndex * W, {
-        damping: 22,
-        stiffness: 90,
-      });
+      const target = -nextIndex * W;
+      // Snap to the exact integer offset on completion. Reanimated springs
+      // settle within an epsilon of the target; over many transitions the
+      // residue compounds and shifts later pages right of center. Forcing
+      // the final value here keeps every page perfectly aligned.
+      translateX.value = withSpring(
+        target,
+        { damping: 22, stiffness: 90 },
+        (finished) => {
+          'worklet';
+          if (finished) {
+            translateX.value = target;
+          }
+        }
+      );
       setPage(nextIndex);
     } else {
       void handleComplete();
@@ -531,6 +554,20 @@ function CeremonyPage({
           <View style={[styles.ornamentLine, styles.ornamentLineRight]} />
         </View>
 
+        {/* Inline palette swatch row — makes the color options visible right
+            on the welcome page (so the user sees the choices before tapping
+            the chip). Each swatch is itself tappable and applies the palette
+            immediately, so this row IS the picker for users who never spot
+            the floating chip in the corner. */}
+        <View style={styles.paletteRow}>
+          <Text allowFontScaling={false} style={styles.paletteRowLabel}>
+            CHOOSE YOUR SACRED PALETTE
+          </Text>
+          <View style={styles.paletteRowSwatches}>
+            <InlinePaletteSwatches activeId={palette.id} />
+          </View>
+        </View>
+
         {/* Spacer so the bottom ornament clears the absolute-positioned CTA */}
         <View style={styles.welcomeBottomSpacer} />
       </ScrollView>
@@ -656,11 +693,15 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   sanskrit: {
+    // Devanagari needs ~1.7x line-height to clear matras above (शिरोरेखा)
+    // and below (्, ु, ृ) the consonant. The previous 22pt line-height
+    // clipped the lower matras on most Android devices.
     fontFamily: 'NotoSansDevanagari-Regular',
-    fontSize: 15,
-    lineHeight: 22,
+    fontSize: 17,
+    lineHeight: 32,
     letterSpacing: 0.3,
     textAlign: 'center',
+    paddingVertical: 4,
   },
   title: {
     fontFamily: 'CormorantGaramond-LightItalic',
@@ -892,12 +933,16 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   verseSanskrit: {
+    // Same Devanagari descender allowance as `sanskrit` — both vowel signs
+    // and the upper bar must clear in a single line so a long shloka like
+    // "अभ्यासेन तु कौन्तेय वैराग्येण च गृह्यते" (which has ृ, ौ, ्य) renders cleanly.
     fontFamily: 'NotoSansDevanagari-Medium',
-    fontSize: 17,
-    lineHeight: 26,
+    fontSize: 18,
+    lineHeight: 34,
     color: '#F0C96D',
     letterSpacing: 0.5,
     textAlign: 'center',
+    paddingVertical: 4,
   },
   verseEnglish: {
     fontFamily: 'CrimsonText-Italic',
@@ -917,5 +962,25 @@ const styles = StyleSheet.create({
   },
   welcomeBottomSpacer: {
     height: 200,
+  },
+  paletteRow: {
+    width: '100%',
+    maxWidth: 420,
+    alignItems: 'center',
+    marginTop: 18,
+    marginBottom: 6,
+    gap: 12,
+  },
+  paletteRowLabel: {
+    fontFamily: 'Outfit-Medium',
+    fontSize: 10.5,
+    letterSpacing: 3,
+    color: 'rgba(212, 164, 76, 0.7)',
+    textAlign: 'center',
+  },
+  paletteRowSwatches: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 14,
   },
 });

--- a/kiaanverse-mobile/apps/mobile/components/common/SacredArrival.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/common/SacredArrival.tsx
@@ -42,7 +42,7 @@ import Animated, {
   withTiming,
   type SharedValue,
 } from 'react-native-reanimated';
-import Svg, { Circle, Defs, RadialGradient, Stop } from 'react-native-svg';
+import Svg, { Circle, Defs, Path, Polygon, RadialGradient, Stop } from 'react-native-svg';
 
 const { width: W, height: H } = Dimensions.get('window');
 
@@ -353,21 +353,79 @@ function SacredArrivalInner({
         />
       </Svg>
 
-      {/* OM aura — concentric golden glow that breathes behind the glyph. */}
+      {/* OM aura — concentric golden glow that breathes behind the glyph.
+          Boosted from the previous flat brownish radial: now a richer
+          gold→indigo→transparent ramp that reads as "divine fire" instead
+          of a bland grey disc. */}
       <Animated.View
         style={[styles.auraWrap, omAuraStyle]}
         pointerEvents="none"
       >
         <LinearGradient
           colors={[
-            'rgba(212, 160, 23, 0.35)',
-            'rgba(27, 79, 187, 0.12)',
+            'rgba(240, 192, 64, 0.55)',
+            'rgba(212, 160, 23, 0.38)',
+            'rgba(27, 79, 187, 0.20)',
             'transparent',
           ]}
+          locations={[0, 0.35, 0.7, 1]}
           start={{ x: 0.5, y: 0.5 }}
           end={{ x: 1, y: 1 }}
           style={styles.auraGradient}
         />
+      </Animated.View>
+
+      {/* Veda yantra plate — replaces the previous bland grey disc. A static
+          gold-stroked Sri-Yantra-style design (8-petal lotus + shatkona +
+          inscribed circle) sits behind the OM, giving the splash a proper
+          sacred-geometry presence instead of just a gradient blur. */}
+      <Animated.View
+        style={[styles.yantraWrap, omAuraStyle]}
+        pointerEvents="none"
+      >
+        <Svg width={YANTRA_SIZE} height={YANTRA_SIZE} viewBox={`0 0 ${YANTRA_SIZE} ${YANTRA_SIZE}`}>
+          {/* Outer ring */}
+          <Circle
+            cx={YANTRA_SIZE / 2}
+            cy={YANTRA_SIZE / 2}
+            r={YANTRA_SIZE / 2 - 2}
+            stroke="rgba(212, 160, 23, 0.55)"
+            strokeWidth={1.2}
+            fill="none"
+          />
+          {/* 8-petal lotus */}
+          <Path
+            d={SPLASH_LOTUS_PATH}
+            stroke="rgba(212, 160, 23, 0.7)"
+            strokeWidth={1.4}
+            fill="none"
+            strokeLinejoin="round"
+          />
+          {/* Inner circle */}
+          <Circle
+            cx={YANTRA_SIZE / 2}
+            cy={YANTRA_SIZE / 2}
+            r={YANTRA_SIZE * 0.32}
+            stroke="rgba(212, 160, 23, 0.45)"
+            strokeWidth={1}
+            fill="none"
+          />
+          {/* Shatkona — two interlocking triangles */}
+          <Polygon
+            points={SPLASH_TRI_UP}
+            stroke="rgba(212, 160, 23, 0.85)"
+            strokeWidth={1.4}
+            fill="none"
+            strokeLinejoin="round"
+          />
+          <Polygon
+            points={SPLASH_TRI_DOWN}
+            stroke="rgba(212, 160, 23, 0.85)"
+            strokeWidth={1.4}
+            fill="none"
+            strokeLinejoin="round"
+          />
+        </Svg>
       </Animated.View>
 
       {/* ACT 1 — point of light. */}
@@ -418,8 +476,62 @@ export const SacredArrival = React.memo(SacredArrivalInner);
 
 const OM_SIZE = 96;
 const AURA_SIZE = 260;
+const YANTRA_SIZE = 220;
 const NAME_TOP = H / 2 + 72;
 const INVOCATION_TOP = NAME_TOP + 56;
+
+// ---------------------------------------------------------------------------
+// Splash yantra geometry — pre-computed at module load so the splash never
+// re-builds these paths on each frame. The 8-petal lotus is rendered as a
+// chain of cubic teardrops; the shatkona is two interlocking triangles
+// inscribed in a circle of radius r = YANTRA_SIZE * 0.30.
+// ---------------------------------------------------------------------------
+
+function splashLotusPath(): string {
+  const cx = YANTRA_SIZE / 2;
+  const cy = YANTRA_SIZE / 2;
+  const r = YANTRA_SIZE * 0.4;
+  const petals = 8;
+  let d = '';
+  for (let i = 0; i < petals; i += 1) {
+    const a = (i * 2 * Math.PI) / petals;
+    const tipX = cx + r * Math.cos(a);
+    const tipY = cy + r * Math.sin(a);
+    const baseAngle = Math.PI / petals;
+    const baseR = r * 0.34;
+    const lX = cx + baseR * Math.cos(a + baseAngle);
+    const lY = cy + baseR * Math.sin(a + baseAngle);
+    const rX = cx + baseR * Math.cos(a - baseAngle);
+    const rY = cy + baseR * Math.sin(a - baseAngle);
+    const c1X = cx + r * 0.78 * Math.cos(a + baseAngle * 0.55);
+    const c1Y = cy + r * 0.78 * Math.sin(a + baseAngle * 0.55);
+    const c2X = cx + r * 0.78 * Math.cos(a - baseAngle * 0.55);
+    const c2Y = cy + r * 0.78 * Math.sin(a - baseAngle * 0.55);
+    d += `M ${lX.toFixed(2)} ${lY.toFixed(2)} `;
+    d += `C ${c1X.toFixed(2)} ${c1Y.toFixed(2)}, ${tipX.toFixed(2)} ${tipY.toFixed(2)}, ${tipX.toFixed(2)} ${tipY.toFixed(2)} `;
+    d += `C ${tipX.toFixed(2)} ${tipY.toFixed(2)}, ${c2X.toFixed(2)} ${c2Y.toFixed(2)}, ${rX.toFixed(2)} ${rY.toFixed(2)} `;
+    d += `Z `;
+  }
+  return d;
+}
+
+function splashTrianglePoints(rotationDeg: number): string {
+  const cx = YANTRA_SIZE / 2;
+  const cy = YANTRA_SIZE / 2;
+  const r = YANTRA_SIZE * 0.3;
+  const pts: string[] = [];
+  for (let i = 0; i < 3; i += 1) {
+    const a = ((rotationDeg + (i * 360) / 3) * Math.PI) / 180;
+    pts.push(
+      `${(cx + r * Math.cos(a)).toFixed(2)},${(cy + r * Math.sin(a)).toFixed(2)}`
+    );
+  }
+  return pts.join(' ');
+}
+
+const SPLASH_LOTUS_PATH = splashLotusPath();
+const SPLASH_TRI_UP = splashTrianglePoints(-90);
+const SPLASH_TRI_DOWN = splashTrianglePoints(90);
 
 const styles = StyleSheet.create({
   root: {
@@ -439,6 +551,15 @@ const styles = StyleSheet.create({
   },
   auraGradient: {
     flex: 1,
+  },
+  yantraWrap: {
+    position: 'absolute',
+    width: YANTRA_SIZE,
+    height: YANTRA_SIZE,
+    top: H / 2 - YANTRA_SIZE / 2 - 32,
+    left: W / 2 - YANTRA_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   pointWrap: {
     position: 'absolute',
@@ -486,21 +607,29 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   nameLetter: {
+    // CormorantGaramond-Italic isn't registered (only LightItalic is). The
+    // previous spelling silently fell back to the system font on Android,
+    // making the title look wrong. Use the registered face.
     fontSize: 28,
     lineHeight: 34,
     color: SACRED_WHITE,
-    fontFamily: 'CormorantGaramond-Italic',
+    fontFamily: 'CormorantGaramond-LightItalic',
     fontStyle: 'italic',
     letterSpacing: 0.3 * 28,
   },
   invocation: {
+    // Was rendered at TEXT_MUTED (#6B6355) which is the same value as the
+    // splash's near-black backdrop in poor lighting — the Sanskrit looked
+    // missing. Lift to a soft warm gold and give it real Devanagari
+    // descender room (lineHeight 26 for fontSize 14) so ु and ्र don't clip.
     position: 'absolute',
     top: INVOCATION_TOP,
-    fontSize: 13,
-    lineHeight: 19,
-    color: TEXT_MUTED,
+    fontSize: 14,
+    lineHeight: 26,
+    color: 'rgba(245, 222, 179, 0.78)',
     fontFamily: 'NotoSansDevanagari-Regular',
     textAlign: 'center',
     letterSpacing: 0.4,
+    paddingVertical: 4,
   },
 });

--- a/kiaanverse-mobile/packages/ui/src/components/SacredCard.tsx
+++ b/kiaanverse-mobile/packages/ui/src/components/SacredCard.tsx
@@ -30,12 +30,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { LinearGradient } from 'expo-linear-gradient';
-
-/** Sacred body gradient — parity with web indigo glass surface. */
-const SACRED_CARD_BODY = [
-  'rgba(22, 26, 66, 0.95)',
-  'rgba(17, 20, 53, 0.98)',
-] as const;
+import { useTheme } from '../theme/useTheme';
 
 /** Top shimmer strip — horizontal gold edge, never clipped. */
 const SACRED_TOP_SHIMMER = [
@@ -84,6 +79,17 @@ function SacredCardInner({
   testID,
   accessibilityLabel,
 }: SacredCardProps): React.JSX.Element {
+  // Read the active sacred palette so cards follow the user's chosen scheme
+  // (Indigo / Maroon / Forest / Black-&-Gold). Previously this gradient was
+  // hardcoded to indigo, which is why the profile menu stayed navy even when
+  // the user selected Black-&-Gold from the arrival picker.
+  const { theme } = useTheme();
+  const cardBody: readonly string[] = [
+    theme.colorScheme.bg.surface,
+    theme.colorScheme.bg.card,
+  ];
+  const containerBg = theme.colorScheme.bg.card;
+
   const scale = useSharedValue(1);
 
   const handlePressIn = useCallback(() => {
@@ -124,9 +130,9 @@ function SacredCardInner({
         style={styles.topShimmer}
         pointerEvents="none"
       />
-      {/* Indigo body gradient. */}
+      {/* Palette-tinted body gradient (was hardcoded indigo). */}
       <LinearGradient
-        colors={SACRED_CARD_BODY as unknown as string[]}
+        colors={cardBody as unknown as string[]}
         start={{ x: 0, y: 0 }}
         end={{ x: 0, y: 1 }}
         style={[styles.body, contentStyle]}
@@ -147,7 +153,13 @@ function SacredCardInner({
         accessibilityLabel={accessibilityLabel}
         accessibilityState={{ disabled }}
         testID={testID}
-        style={[styles.container, glowStyle, animatedStyle, style]}
+        style={[
+          styles.container,
+          { backgroundColor: containerBg },
+          glowStyle,
+          animatedStyle,
+          style,
+        ]}
       >
         {surface}
       </AnimatedPressable>
@@ -156,7 +168,12 @@ function SacredCardInner({
 
   return (
     <View
-      style={[styles.container, glowStyle, style]}
+      style={[
+        styles.container,
+        { backgroundColor: containerBg },
+        glowStyle,
+        style,
+      ]}
       testID={testID}
       accessibilityLabel={accessibilityLabel}
     >
@@ -170,10 +187,12 @@ export const SacredCard = React.memo(SacredCardInner);
 
 const styles = StyleSheet.create({
   container: {
+    // Background is applied inline from theme.colorScheme.bg.card so the
+    // card automatically follows the active palette. The static value was
+    // removed so it can't override the palette-driven inline color.
     borderRadius: SACRED_RADIUS,
     borderWidth: 1,
     borderColor: SACRED_BORDER_COLOR,
-    backgroundColor: 'rgba(17, 20, 53, 0.98)',
     position: 'relative',
   },
   body: {

--- a/kiaanverse-mobile/packages/ui/src/theme/ThemeProvider.tsx
+++ b/kiaanverse-mobile/packages/ui/src/theme/ThemeProvider.tsx
@@ -54,8 +54,23 @@ export function ThemeProvider({
     const baseTheme = resolvedDark ? darkTheme : lightTheme;
     const colorScheme = PALETTES[paletteId] ?? PALETTES[DEFAULT_PALETTE_ID];
 
+    // Light mode keeps its warm-cream surfaces regardless of palette — the
+    // palettes are designed for dark/cosmic surfaces. In dark mode we
+    // override the four background slots so every screen reading
+    // `theme.colors.{background,card,surface,surfaceElevated}` follows the
+    // active palette automatically.
+    const themeColors = resolvedDark
+      ? {
+          ...baseTheme.colors,
+          background: colorScheme.bg.void,
+          card: colorScheme.bg.card,
+          surface: colorScheme.bg.surface,
+          surfaceElevated: colorScheme.bg.elevated,
+        }
+      : baseTheme.colors;
+
     return {
-      theme: { ...baseTheme, colorScheme },
+      theme: { ...baseTheme, colors: themeColors, colorScheme },
       isDark: resolvedDark,
       mode,
       setMode: onModeChange,

--- a/kiaanverse-mobile/packages/ui/src/tokens/palettes.ts
+++ b/kiaanverse-mobile/packages/ui/src/tokens/palettes.ts
@@ -47,8 +47,16 @@ export interface Palette {
   /** Short label for chips / one-line previews. */
   readonly shortLabel: string;
   readonly bg: {
+    /** Flat fallback bg (root view, status-bar safe-area). */
     readonly void: string;
+    /** Three-stop vertical gradient for `<DivineBackground>`. */
     readonly gradient: readonly [string, string, string];
+    /** Card / panel surface — what `theme.colors.card` resolves to. */
+    readonly card: string;
+    /** Slightly raised surface — `theme.colors.surface`. */
+    readonly surface: string;
+    /** Highest-elevation surface — `theme.colors.surfaceElevated`. */
+    readonly elevated: string;
   };
   /** Three-stop rgba ramp for the breathing aura at the top of the screen. */
   readonly aura: readonly [string, string, string];
@@ -72,6 +80,9 @@ const indigoPeacock: Palette = {
   bg: {
     void: '#050714',
     gradient: ['#050714', '#0A1228', '#050714'],
+    card: '#0B0E2A',
+    surface: '#161A42',
+    elevated: '#1E2448',
   },
   aura: ['rgba(27, 79, 187, 0.28)', 'rgba(14, 116, 144, 0.10)', 'transparent'],
   accent: {
@@ -96,6 +107,9 @@ const maroon: Palette = {
   bg: {
     void: '#1A0606',
     gradient: ['#1A0606', '#2B0A0A', '#3B0E0E'],
+    card: '#2B0A0A',
+    surface: '#3B0E0E',
+    elevated: '#4A1414',
   },
   aura: ['rgba(139, 0, 0, 0.32)', 'rgba(180, 83, 9, 0.10)', 'transparent'],
   accent: {
@@ -120,6 +134,9 @@ const darkGreen: Palette = {
   bg: {
     void: '#0A1F0F',
     gradient: ['#0A1F0F', '#102818', '#163A22'],
+    card: '#102818',
+    surface: '#163A22',
+    elevated: '#1F4A2C',
   },
   aura: ['rgba(45, 134, 89, 0.30)', 'rgba(143, 188, 143, 0.10)', 'transparent'],
   accent: {
@@ -144,6 +161,9 @@ const blackGold: Palette = {
   bg: {
     void: '#000000',
     gradient: ['#000000', '#0A0A0A', '#141414'],
+    card: '#0A0A0A',
+    surface: '#141414',
+    elevated: '#1F1F1F',
   },
   aura: ['rgba(212, 160, 23, 0.32)', 'rgba(212, 160, 23, 0.08)', 'transparent'],
   accent: {


### PR DESCRIPTION
## Summary

Follow-up to merged PRs #1714 and #1715 fixing five issues caught during on-device QA of the new Vedic intro + palette picker.

- **Page-drift fix.** Pages slid progressively right on successive arrival pages (visible by page 5: "This is your sacred space." was clipped at the right edge). `Dimensions.get('window').width` returned a fractional value (`411.42857` on the test device); Yoga rounded the rendered page widths to integers but the spring `withSpring(-nextIndex * W, …)` target used the unrounded number, so each transition landed a fraction of a pixel off and the residue compounded. Fix: `Math.round(W)` at module load + a worklet completion callback that snaps `translateX.value` back to the exact integer target after every spring finish.
- **Devanagari clipping fix.** "षड्रिपु", "वैराग्येण च गृह्यते", "ॐ सर्वे भवन्तु" — lower vowel signs (ु, ृ, ्र) and the upper bar (शिरोरेखा) were getting cropped because line-heights were tuned for Latin script. Bumped `sanskrit` (page eyebrows) to fontSize 17 / lineHeight 32, `verseSanskrit` (welcome verse) to 18 / 34, splash `invocation` to 14 / 26. Added `paddingVertical: 4` so descenders always clear.
- **Splash screen Veda yantra.** Behind the OM glyph the splash was just a flat radial gradient that read as "loading spinner" rather than darshan. Added a static gold-stroked Veda yantra (8-petal lotus + outer ring + inscribed circle + interlocking shatkona, 220pt) plus strengthened the breathing aura into a 4-stop gold→gold→indigo→transparent ramp. Yantra geometry pre-computed at module load — zero per-frame work. Also fixed: `nameLetter` font now uses the registered `CormorantGaramond-LightItalic` (the previous `CormorantGaramond-Italic` silently fell back to system sans on Android), and the Sanskrit invocation lifted from `TEXT_MUTED` (#6B6355, near-invisible) to `rgba(245, 222, 179, 0.78)`.
- **App-wide palette propagation.** Profile / subscription / edit-profile cards stayed navy-indigo regardless of palette pick because `theme.colors.card` etc. were resolved from static tokens. Each palette now ships a 4-step bg scale (`bg.void`, `bg.card`, `bg.surface`, `bg.elevated`); ThemeProvider overrides `theme.colors.{background,card,surface,surfaceElevated}` from the active palette in dark mode; and `<SacredCard>` (23 consumers) reads its body gradient + container background from `theme.colorScheme.bg.*`. Combined, every screen using `<DivineBackground>`, `<DivineScreenWrapper>`, `<SacredCard>`, `<Card>`, or `<GlowCard>` now follows the palette automatically.
- **Inline palette swatches.** The picker was hidden behind a small floating chip; users couldn't see the color options at a glance. Added `<InlinePaletteSwatches>` — a horizontal row of four palette pills rendered directly on the welcome page between the bottom ornament and the CTA. Each pill shows a 4-quadrant color preview + the palette's short label, painted on the palette's own background so the user previews exactly what they'll get. Tapping a pill applies the palette instantly. Floating chip + bottom sheet remain for pages 1–5 and as a compact alt access route.

## Test plan

- [ ] Arrival → swipe through pages 1 → 5 → 6 with each palette: every visual stays centered (no rightward drift), title text never clips at the right edge.
- [ ] Sanskrit on every arrival page + the splash invocation reads cleanly with no clipped matras above or below the line.
- [ ] Splash on cold launch shows the gold yantra (8-petal lotus + shatkona) behind the OM, with the lifted gold invocation legible.
- [ ] Welcome page → tap any of the four inline swatch pills → the entire app recolors instantly (verify on profile, journal, sadhana, wisdom, subscription).
- [ ] Force-quit + cold-relaunch → palette persists.
- [ ] `pnpm tsc --noEmit` from `kiaanverse-mobile/apps/mobile` → clean.

https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY)_