### PR TITLE
Journey step screen — remove cream/khaki bands bleeding through content

### DIFF
--- a/kiaanverse-mobile/apps/mobile/app/journey/step/[day].tsx
+++ b/kiaanverse-mobile/apps/mobile/app/journey/step/[day].tsx
@@ -33,7 +33,7 @@ import * as Haptics from 'expo-haptics';
 import {
   Text,
   GoldenButton,
-  DivineGradient,
+  DivineBackground,
   GlowCard,
   SacredStepIndicator,
   SacredDivider,
@@ -92,18 +92,14 @@ const DAY_META: Record<number, { theme: string; focus: string }> = {
   14: { theme: 'Completion', focus: 'New Beginning' },
 };
 
-/**
- * DivineGradient variant mapped from enemy keywords.
- * Falls back to 'divine' if no mapping exists.
- */
-const ENEMY_GRADIENT_VARIANT: Record<string, string> = {
-  kama: 'renewal',
-  krodha: 'release',
-  lobha: 'healing',
-  moha: 'healing',
-  mada: 'divine',
-  matsarya: 'peace',
-};
+// ENEMY_GRADIENT_VARIANT was previously used to map each shadripu to one of
+// the `sacredGradients` presets ('peace', 'healing', etc.). Those presets
+// have #FFD700 / #F0C040 as their third color, which DivineGradient renders
+// as a flex:1 layer at 0.3 opacity — producing the cream/khaki bands the
+// user reported as overlapping the journey content. The screen now uses
+// `<DivineBackground variant="cosmic">` (palette-driven dark cosmic), and
+// per-enemy theming is preserved via the inner `accentColor` instead of
+// the page background.
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -405,9 +401,6 @@ export default function StepPlayerScreen(): React.JSX.Element {
   const accentColor = enemyKey
     ? (ENEMY_COLORS[enemyKey] ?? colors.primary[500])
     : colors.primary[500];
-  const gradientVariant = (
-    enemyKey ? ENEMY_GRADIENT_VARIANT[enemyKey] : 'divine'
-  ) as 'divine' | 'peace' | 'healing' | 'release' | 'renewal';
 
   const currentStep = useMemo(() => {
     if (!data?.steps) return null;
@@ -474,27 +467,21 @@ export default function StepPlayerScreen(): React.JSX.Element {
   // Loading state
   if (isLoading || !data) {
     return (
-      <DivineGradient
-        variant="divine"
-        style={{ flex: 1, paddingTop: insets.top }}
-      >
+      <DivineBackground variant="cosmic" style={{ paddingTop: insets.top }}>
         <View style={styles.centerState}>
           <LoadingMandala size={80} />
           <Text variant="bodySmall" color={colors.text.muted}>
             Preparing your practice...
           </Text>
         </View>
-      </DivineGradient>
+      </DivineBackground>
     );
   }
 
   // Error state
   if (error || !currentStep) {
     return (
-      <DivineGradient
-        variant="divine"
-        style={{ flex: 1, paddingTop: insets.top }}
-      >
+      <DivineBackground variant="cosmic" style={{ paddingTop: insets.top }}>
         <View style={styles.centerState}>
           <Text variant="body" color={colors.semantic.error}>
             {currentStep === null
@@ -510,12 +497,22 @@ export default function StepPlayerScreen(): React.JSX.Element {
             onPress={() => router.back()}
           />
         </View>
-      </DivineGradient>
+      </DivineBackground>
     );
   }
 
+  // The previous wrapper here was `<DivineGradient variant={gradientVariant}>`.
+  // sacredGradients[variant][2] resolves to bright #FFD700 — DivineGradient
+  // stacks that gold as a flex:1 layer at 0.3 opacity (and again in the
+  // cross-fade overlay at 0.4 in the middle band), which is what produced
+  // the cream/khaki bands the user reported as overlapping the journey
+  // step content. DivineBackground is palette-driven (theme.colorScheme.bg
+  // .gradient → dark cosmic), keeps the dark theme intact, and STILL
+  // honours the user's chosen palette. The per-enemy `accentColor` is
+  // still applied to inner UI accents below (titles, borders, the verse
+  // BG-pill), so the screen continues to feel themed per shadripu.
   return (
-    <DivineGradient variant={gradientVariant} style={{ flex: 1 }}>
+    <DivineBackground variant="cosmic" style={{ flex: 1 }}>
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -672,7 +669,7 @@ export default function StepPlayerScreen(): React.JSX.Element {
           }}
         />
       ) : null}
-    </DivineGradient>
+    </DivineBackground>
   );
 }
 


### PR DESCRIPTION
## Summary

Single-commit follow-up. The journey step screen rendered cream/khaki bands across the verse, the Micro Commitment card, and the bottom CTA footer — making "Add Reflection (Optional)" / "Complete Today's Step" near-cream-on-cream and unreadable.

**Root cause.** `journey/step/[day].tsx` wrapped its content in `<DivineGradient variant={gradientVariant}>`. `DivineGradient` renders three `flex: 1` vertical layers from `sacredGradients[variant]` — and **every preset (peace / healing / release / renewal / divine) has `#FFD700` (or `#F0C040`) as its third color**. The bottom layer paints that pure gold at `opacity: 0.3` across a full third of the screen height, and the cross-fade overlay paints it again across the **middle band** at `opacity: 0.4`. Result: a cream/yellow band wherever those two gold layers landed.

**Fix.** Replaced all three `<DivineGradient>` wrappers (loading state, error state, main content) with `<DivineBackground variant="cosmic">`. `DivineBackground` reads `theme.colorScheme.bg.gradient`, so the journey screen now wears the user's chosen palette (Indigo / Maroon / Forest / Black-&-Gold) with no bright-gold bleed-through. Per-shadripu theming is preserved via the existing `accentColor` on titles, borders, and the verse-card pill — the page background is just no longer the place that themes them.

Removed the unused `gradientVariant` derivation and `ENEMY_GRADIENT_VARIANT` map; left an explanatory comment in their place.

`DivineGradient` itself is untouched (still used by `tools/emotional-reset/[step].tsx` and `components/emotional-reset/SummaryStep.tsx`). Same fix can be applied there if the bands show up — but those screens haven't been reported.

## Test plan

- [ ] Open any active journey → tap "Continue" / step day → step screen has no cream/khaki bands; the verse text, Micro Commitment card, and CTA footer are all readable on the dark cosmic bg.
- [ ] Switch palette to Maroon / Forest / Black-&-Gold from the arrival picker → re-enter the journey step screen → bg follows the chosen palette.
- [ ] `pnpm tsc --noEmit` clean.

https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY)_