### PR TITLE
Native-FlatList sliders · palette propagation finishing pass · Shankha redesign · Voice Companion stop button

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -379,6 +379,29 @@ async def startup():
             _settings.INSTANCE_ID = _uuid.uuid4().hex[:12]
         startup_logger.info(f"\n🆔 Instance ID: {_settings.INSTANCE_ID}")
 
+        # Email-config self-check. Past deploys silently misconfigured this so
+        # signup looked fine but no verification emails ever shipped — surface
+        # it loudly at boot so any future regression is one log-line away.
+        try:
+            from backend.services.email_service import (
+                EMAIL_PROVIDER as _EP,
+                can_send_email as _can_send,
+                validate_email_config as _validate_email,
+            )
+            _email_warnings = _validate_email()
+            startup_logger.info(
+                "\n📧 Email config: provider=%s can_send=%s require_verification=%s",
+                _EP,
+                _can_send(),
+                _settings.REQUIRE_EMAIL_VERIFICATION,
+            )
+            for _w in _email_warnings:
+                startup_logger.warning("📧 EMAIL CONFIG WARNING: %s", _w)
+            if not _email_warnings:
+                startup_logger.info("📧 Email config OK — verification emails will deliver.")
+        except Exception as _ee:
+            startup_logger.error("📧 Email config self-check failed: %s", _ee)
+
         _step_t0 = _time.monotonic()
         startup_logger.info("\n🔗 Initializing Redis...")
         import asyncio as _asyncio

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -1351,3 +1352,135 @@ async def developer_status(
         subscription_tier="siddha" if is_dev else sub_tier,
         subscription_status=sub_status,
     )
+
+
+# ---------------------------------------------------------------------------
+# Email-verification health endpoints
+# ---------------------------------------------------------------------------
+#
+# Past PRs claimed to fix the "new accounts created without verification email"
+# bug but it kept reappearing because there was no observable signal that the
+# deployed backend actually had EMAIL_PROVIDER=resend + RESEND_API_KEY wired up.
+# These two endpoints let the operator verify the chain in one curl, and isolate
+# the failing link (config / API key / domain / send) when something breaks.
+
+class EmailHealthOut(BaseModel):
+    """Sanitized email-config snapshot — never leaks the API key value."""
+    provider: str
+    can_send: bool
+    require_verification: bool
+    from_address: str
+    from_name: str
+    frontend_url: str
+    resend_api_key_configured: bool
+    smtp_host_configured: bool
+    smtp_user_configured: bool
+    environment: str
+
+
+@router.get(
+    "/health/email",
+    response_model=EmailHealthOut,
+    summary="Sanitized email-provider config (operator diagnostic)",
+)
+async def get_email_health() -> EmailHealthOut:
+    """Public diagnostic. `curl /api/auth/health/email` after each deploy to
+    verify the running container actually has the email env vars the dashboard
+    claims — this is the gap that made prior 'fixes' look successful when they
+    weren't. Response includes only presence flags, never the API key value."""
+    from backend.services import email_service as _es
+    return EmailHealthOut(
+        provider=_es.EMAIL_PROVIDER,
+        can_send=_es.can_send_email(),
+        require_verification=settings.REQUIRE_EMAIL_VERIFICATION,
+        from_address=_es.EMAIL_FROM_ADDRESS,
+        from_name=_es.EMAIL_FROM_NAME,
+        frontend_url=_es.FRONTEND_URL,
+        resend_api_key_configured=bool(_es.RESEND_API_KEY),
+        smtp_host_configured=bool(_es.SMTP_HOST and _es.SMTP_HOST != "localhost"),
+        smtp_user_configured=bool(_es.SMTP_USER),
+        environment=os.getenv("ENVIRONMENT", "development"),
+    )
+
+
+class EmailSendTestIn(BaseModel):
+    to: EmailStr
+
+
+class EmailSendTestOut(BaseModel):
+    """Result of a real provider send. `provider_response` is whatever the
+    provider returned (Resend HTTP status / SMTP error string) — that's the
+    only data that pinpoints WHY a send is failing in production."""
+    sent: bool
+    provider: str
+    to: str
+    provider_response: str
+
+
+@router.post(
+    "/health/email/send-test",
+    response_model=EmailSendTestOut,
+    summary="Send a real verification-style email to confirm provider connectivity",
+)
+async def post_email_send_test(payload: EmailSendTestIn, request: Request) -> EmailSendTestOut:
+    """Operator-only diagnostic. Gated by the `X-Admin-Token` header matching
+    the `ADMIN_HEALTH_TOKEN` env var (must be set on the deployed container —
+    if missing, the endpoint is disabled). Reuses the production
+    `send_email_verification()` path with a throwaway dummy token so any
+    failure mode (invalid Resend key, unverified domain, sandbox restriction,
+    SMTP greylisting) surfaces with the same provider error a real signup
+    would hit. The token in the email is never persisted as a real
+    verification — it's just a string to fill the template URL."""
+    expected_token = os.getenv("ADMIN_HEALTH_TOKEN", "").strip()
+    if not expected_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "ADMIN_HEALTH_TOKEN_NOT_CONFIGURED",
+                "message": "Set ADMIN_HEALTH_TOKEN on the deployed container to enable this endpoint.",
+            },
+        )
+    supplied = (request.headers.get("x-admin-token") or "").strip()
+    # Constant-time compare so a curious attacker can't time-side-channel the token.
+    if not secrets.compare_digest(supplied, expected_token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "ADMIN_TOKEN_INVALID", "message": "Invalid X-Admin-Token."},
+        )
+
+    from backend.services import email_service as _es
+    if not _es.can_send_email():
+        return EmailSendTestOut(
+            sent=False,
+            provider=_es.EMAIL_PROVIDER,
+            to=payload.to,
+            provider_response=(
+                f"can_send_email() is False — provider={_es.EMAIL_PROVIDER}. "
+                "Set EMAIL_PROVIDER=resend with RESEND_API_KEY, or EMAIL_PROVIDER=smtp "
+                "with a real SMTP_HOST."
+            ),
+        )
+
+    # Throwaway token — only used to fill the email template URL. Not persisted.
+    dummy_token = secrets.token_urlsafe(32)
+    try:
+        sent = await send_email_verification(payload.to, dummy_token)
+        return EmailSendTestOut(
+            sent=bool(sent),
+            provider=_es.EMAIL_PROVIDER,
+            to=payload.to,
+            provider_response=(
+                "Provider returned success. Check the inbox (and spam folder) — "
+                "if the email never arrives, the provider accepted the request "
+                "but a downstream filter (DMARC, recipient block, spam) ate it."
+                if sent
+                else "Provider returned False — check backend logs for the underlying error."
+            ),
+        )
+    except Exception as exc:  # surface the raw error verbatim
+        return EmailSendTestOut(
+            sent=False,
+            provider=_es.EMAIL_PROVIDER,
+            to=payload.to,
+            provider_response=f"{type(exc).__name__}: {exc}",
+        )

--- a/kiaanverse-mobile/apps/mobile/app/(auth)/login.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(auth)/login.tsx
@@ -12,7 +12,7 @@
  * Security: No credentials logged. Tokens handled by authStore + SecureStore.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { View, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
 import { Link } from 'expo-router';
 import { useForm, Controller } from 'react-hook-form';
@@ -29,7 +29,10 @@ import {
   spacing,
 } from '@kiaanverse/ui';
 import { useAuthStore } from '@kiaanverse/store';
+import { authService } from '@kiaanverse/api';
 import { useTranslation } from '@kiaanverse/i18n';
+
+const SUPPORT_EMAIL = 'thesacredquest2@gmail.com';
 
 // ---------------------------------------------------------------------------
 // Validation Schema
@@ -69,12 +72,46 @@ export default function LoginScreen(): React.JSX.Element {
   const {
     control,
     handleSubmit,
+    getValues,
     formState: { errors, isValid },
   } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
     defaultValues: { email: '', password: '' },
     mode: 'onBlur',
   });
+
+  // Resend-verification side state. The store's `error` already holds the
+  // friendly text when the backend returns 403 EMAIL_NOT_VERIFIED (handled
+  // in authService.ts:104-110); we only need to detect the substring to
+  // know whether to render the inline Resend button.
+  const [resending, setResending] = useState(false);
+  const [resendSent, setResendSent] = useState(false);
+  const [resendError, setResendError] = useState<string | null>(null);
+  const isUnverifiedError = Boolean(
+    error &&
+      /verify your email|EMAIL_NOT_VERIFIED|verification link/i.test(error),
+  );
+
+  const handleResendVerification = useCallback(async () => {
+    const email = getValues('email').trim();
+    if (!email) {
+      setResendError('Enter your email above first.');
+      return;
+    }
+    setResending(true);
+    setResendError(null);
+    try {
+      await authService.resendVerification(email);
+      setResendSent(true);
+    } catch (err) {
+      setResendError(
+        (err as { message?: string })?.message ??
+          `Could not send a fresh email. Please email ${SUPPORT_EMAIL}.`,
+      );
+    } finally {
+      setResending(false);
+    }
+  }, [getValues]);
 
   const onSubmit = useCallback(
     async (data: LoginFormData) => {
@@ -161,6 +198,34 @@ export default function LoginScreen(): React.JSX.Element {
             <Text variant="caption" color={colors.semantic.error}>
               {error}
             </Text>
+          ) : null}
+
+          {/* When the backend returns 403 EMAIL_NOT_VERIFIED, give the user a
+              one-tap recovery path right next to the error instead of a dead
+              end. Mirrors the verify-email-pending screen but inline. */}
+          {isUnverifiedError ? (
+            <View style={{ gap: spacing.xs }}>
+              {resendSent ? (
+                <Text variant="caption" color={colors.primary[500]}>
+                  ✓ Fresh verification email sent. Check your inbox (and spam).
+                </Text>
+              ) : null}
+              {resendError ? (
+                <Text variant="caption" color={colors.semantic.error}>
+                  {resendError}
+                </Text>
+              ) : null}
+              <GoldenButton
+                title={resending ? 'Sending…' : 'Resend verification email'}
+                variant="secondary"
+                onPress={handleResendVerification}
+                disabled={resending}
+                testID="resend-verification-from-login"
+              />
+              <Text variant="caption" color={colors.text.muted}>
+                Still nothing? Email {SUPPORT_EMAIL}.
+              </Text>
+            </View>
           ) : null}
 
           <GoldenButton

--- a/kiaanverse-mobile/apps/mobile/app/(auth)/register.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(auth)/register.tsx
@@ -12,7 +12,7 @@
  * email address before they can log in (backend returns 403 on unverified).
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { View, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
 import { Link, useRouter } from 'expo-router';
 import { useForm, Controller } from 'react-hook-form';
@@ -29,7 +29,10 @@ import {
   spacing,
 } from '@kiaanverse/ui';
 import { useAuthStore } from '@kiaanverse/store';
+import { authService } from '@kiaanverse/api';
 import { useTranslation } from '@kiaanverse/i18n';
+
+const SUPPORT_EMAIL = 'thesacredquest2@gmail.com';
 
 // ---------------------------------------------------------------------------
 // Validation Schema
@@ -72,8 +75,13 @@ export default function RegisterScreen(): React.JSX.Element {
     status: _status,
     isLoading,
     signupPendingVerification,
+    signupEmail,
+    signupVerificationSent,
     clearSignupPending,
   } = useAuthStore();
+  const [resending, setResending] = useState(false);
+  const [resendSent, setResendSent] = useState(false);
+  const [resendError, setResendError] = useState<string | null>(null);
 
   const {
     control,
@@ -112,20 +120,96 @@ export default function RegisterScreen(): React.JSX.Element {
     );
   }
 
-  // After successful signup — show email verification message
+  // ──── Resend (used by the "delivery failed" branch below) ─────────────
+  const handleResend = useCallback(async () => {
+    if (!signupEmail) {
+      setResendError(
+        `We do not have your email on file. Try signing up again or email ${SUPPORT_EMAIL}.`,
+      );
+      return;
+    }
+    setResending(true);
+    setResendError(null);
+    try {
+      await authService.resendVerification(signupEmail);
+      setResendSent(true);
+    } catch (err) {
+      setResendError(
+        (err as { message?: string })?.message ??
+          `Could not send a fresh email right now. Please email ${SUPPORT_EMAIL}.`,
+      );
+    } finally {
+      setResending(false);
+    }
+  }, [signupEmail]);
+
+  // After successful signup — show one of two outcome screens.
   if (signupPendingVerification) {
+    // Branch A: backend confirmed the email actually shipped. Original
+    // happy-path copy.
+    if (signupVerificationSent) {
+      return (
+        <Screen>
+          <View style={styles.verificationContainer}>
+            <Text variant="h2" align="center">
+              Check your email
+            </Text>
+            <Text variant="body" color={colors.text.muted} align="center">
+              We sent a verification link to{' '}
+              <Text color={colors.primary[500]}>{signupEmail ?? 'your email'}</Text>
+              . Please verify your email before signing in.
+            </Text>
+            <GoldenButton
+              title="Go to Sign In"
+              onPress={handleGoToLogin}
+              testID="go-to-login-button"
+            />
+          </View>
+        </Screen>
+      );
+    }
+
+    // Branch B: account exists but the verification email FAILED to send
+    // (provider not configured / domain unverified / sandbox restriction
+    // / rate-limit). Earlier builds silently fell through to the form here,
+    // leaving the user with no signal — that was a primary cause of the
+    // "I created an account and never got an email" bug. Tell them honestly.
     return (
       <Screen>
         <View style={styles.verificationContainer}>
-          <Text variant="h2" align="center">
-            Check your email
+          <Text variant="h2" align="center" color={colors.semantic.error}>
+            Account created, but…
           </Text>
           <Text variant="body" color={colors.text.muted} align="center">
-            We sent a verification link to your email address. Please verify
-            your email before signing in.
+            Your account was created, but we could not send the verification
+            email to{' '}
+            <Text color={colors.primary[500]}>{signupEmail ?? 'your email'}</Text>
+            .{'\n\n'}
+            Tap below to try sending the link again. If it still does not
+            arrive, please contact{' '}
+            <Text color={colors.primary[500]}>{SUPPORT_EMAIL}</Text>.
           </Text>
+
+          {resendSent ? (
+            <Text variant="body" color={colors.primary[500]} align="center">
+              ✓ A fresh verification email is on its way.
+            </Text>
+          ) : null}
+          {resendError ? (
+            <Text variant="caption" color={colors.semantic.error} align="center">
+              {resendError}
+            </Text>
+          ) : null}
+
+          <GoldenButton
+            title={resending ? 'Sending…' : 'Resend verification email'}
+            onPress={handleResend}
+            disabled={resending}
+            testID="resend-verification-button"
+          />
           <GoldenButton
             title="Go to Sign In"
+            variant="secondary"
             onPress={handleGoToLogin}
             testID="go-to-login-button"
           />

--- a/kiaanverse-mobile/apps/mobile/app/(auth)/verify-email-pending.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(auth)/verify-email-pending.tsx
@@ -1,0 +1,167 @@
+/**
+ * Verify Email Pending Screen.
+ *
+ * Where the AuthGate routes any authenticated user whose
+ * `email_verified` is still false (a stale-token rehydrate from a build
+ * that didn't enforce verification, or a session created when the
+ * backend's REQUIRE_EMAIL_VERIFICATION was off). They are NOT allowed
+ * into /(tabs) until they verify, but they are also not signed out —
+ * they just sit here, can resend the email, then tap the link.
+ *
+ * Two actions:
+ *   • Resend verification email — POSTs `/api/auth/resend-verification`
+ *   • Sign out                  — clears the stale session via authStore.logout
+ */
+
+import React, { useCallback, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { router } from 'expo-router';
+import { authService } from '@kiaanverse/api';
+import { useAuthStore } from '@kiaanverse/store';
+import {
+  GoldenButton,
+  Screen,
+  Text,
+  colors,
+  spacing,
+  useTheme,
+} from '@kiaanverse/ui';
+
+const SUPPORT_EMAIL = 'thesacredquest2@gmail.com';
+
+export default function VerifyEmailPendingScreen(): React.JSX.Element {
+  const { theme } = useTheme();
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const email = user?.email ?? '';
+
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleResend = useCallback(async () => {
+    if (!email) {
+      setError('We do not have your email on file. Please sign out and sign in again.');
+      return;
+    }
+    setSending(true);
+    setError(null);
+    try {
+      await authService.resendVerification(email);
+      setSent(true);
+    } catch (err) {
+      setError(
+        (err as { message?: string })?.message ??
+          `Could not send a fresh email right now. Try again or email ${SUPPORT_EMAIL}.`,
+      );
+    } finally {
+      setSending(false);
+    }
+  }, [email]);
+
+  const handleSignOut = useCallback(async () => {
+    await logout();
+    router.replace('/(auth)/login');
+  }, [logout]);
+
+  return (
+    <Screen
+      gradient
+      gradientVariant="sacred"
+      style={[styles.root, { backgroundColor: theme.colors.background }]}
+    >
+      <View style={styles.center}>
+        <Text style={styles.glyph}>📧</Text>
+        <Text variant="h2" align="center" style={styles.title}>
+          One last step
+        </Text>
+        <Text
+          variant="caption"
+          color={colors.text.secondary}
+          align="center"
+          style={styles.body}
+        >
+          We sent a verification link to{'\n'}
+          <Text color={colors.primary[500]}>{email || 'your email'}</Text>.
+          {'\n\n'}
+          Tap it to confirm your address. Once verified, you can return here and continue.
+        </Text>
+
+        {sent ? (
+          <Text
+            variant="caption"
+            color={colors.primary[500]}
+            align="center"
+            style={styles.body}
+          >
+            ✓ Fresh email on its way. Check your inbox (and spam folder).
+          </Text>
+        ) : null}
+        {error ? (
+          <Text
+            variant="caption"
+            color={colors.semantic.error}
+            align="center"
+            style={styles.body}
+          >
+            {error}
+          </Text>
+        ) : null}
+
+        <View style={styles.actions}>
+          <GoldenButton
+            title={sending ? 'Sending…' : 'Resend verification email'}
+            onPress={handleResend}
+            disabled={sending || !email}
+          />
+          <GoldenButton
+            title="Sign out"
+            variant="secondary"
+            onPress={handleSignOut}
+          />
+        </View>
+
+        <Text
+          variant="caption"
+          color={colors.text.muted}
+          align="center"
+          style={styles.support}
+        >
+          Need help? Email {SUPPORT_EMAIL}.
+        </Text>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+    gap: spacing.sm,
+  },
+  glyph: {
+    fontSize: 56,
+    marginBottom: spacing.md,
+  },
+  title: {
+    marginBottom: spacing.sm,
+  },
+  body: {
+    maxWidth: 380,
+  },
+  actions: {
+    width: '100%',
+    maxWidth: 360,
+    gap: spacing.sm,
+    marginTop: spacing.xl,
+  },
+  support: {
+    marginTop: spacing.xl,
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(auth)/verify-email.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(auth)/verify-email.tsx
@@ -1,0 +1,229 @@
+/**
+ * Verify Email Screen — deep-link handler.
+ *
+ * Reachable by tapping the link in the verification email
+ * (`{FRONTEND_URL}/verify-email?token=...`) when the OS resolves the
+ * link to the app via the `kiaanverse` URL scheme + universal links
+ * declared in `app.config.ts`. The backend route is
+ * `POST /api/auth/verify-email` (`backend/routes/auth.py:1130`).
+ *
+ * Three render states:
+ *   pending — `OmLoader` + "Verifying your email…" while the API call is in flight
+ *   success — gold checkmark + auto-redirect to /(auth)/login after 2s
+ *   error   — friendly message + Resend button (calls /api/auth/resend-verification)
+ *
+ * The screen never holds an authenticated session of its own; it just
+ * confirms the token and bounces the user back to login. The login
+ * screen will then accept their credentials because `email_verified` is
+ * now true on the backend.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { authService } from '@kiaanverse/api';
+import {
+  GoldenButton,
+  OmLoader,
+  Screen,
+  Text,
+  colors,
+  spacing,
+  useTheme,
+} from '@kiaanverse/ui';
+
+type Phase = 'pending' | 'success' | 'error';
+
+const SUPPORT_EMAIL = 'thesacredquest2@gmail.com';
+
+export default function VerifyEmailScreen(): React.JSX.Element {
+  const params = useLocalSearchParams<{ token?: string; email?: string }>();
+  const token = typeof params.token === 'string' ? params.token : '';
+  const email = typeof params.email === 'string' ? params.email : '';
+  const { theme } = useTheme();
+
+  const [phase, setPhase] = useState<Phase>('pending');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [resending, setResending] = useState(false);
+  const [resendSent, setResendSent] = useState(false);
+
+  // Verify on mount.
+  useEffect(() => {
+    let cancelled = false;
+    if (!token) {
+      setPhase('error');
+      setErrorMessage(
+        'No verification token in the link. Please tap the link in your email exactly as it was sent.',
+      );
+      return;
+    }
+    (async () => {
+      try {
+        await authService.verifyEmail(token);
+        if (cancelled) return;
+        setPhase('success');
+        // Hand off to the login door after a beat so the user sees the
+        // "verified" confirmation before being redirected.
+        setTimeout(() => {
+          if (!cancelled) router.replace('/(auth)/login');
+        }, 2000);
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          (err as { message?: string })?.message ??
+          'We could not verify this link. The link may have expired (24-hour limit) or already been used.';
+        setPhase('error');
+        setErrorMessage(message);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const handleResend = useCallback(async () => {
+    if (!email) {
+      setErrorMessage(
+        'We need your email to resend the verification link. Please go back to sign in and tap "Resend verification email" from there.',
+      );
+      return;
+    }
+    setResending(true);
+    try {
+      await authService.resendVerification(email);
+      setResendSent(true);
+    } catch (err) {
+      setErrorMessage(
+        (err as { message?: string })?.message ??
+          `Could not send a fresh email right now. Please try again or contact ${SUPPORT_EMAIL}.`,
+      );
+    } finally {
+      setResending(false);
+    }
+  }, [email]);
+
+  return (
+    <Screen
+      gradient
+      gradientVariant="sacred"
+      style={[styles.root, { backgroundColor: theme.colors.background }]}
+    >
+      <View style={styles.center}>
+        {phase === 'pending' ? (
+          <>
+            <OmLoader size={72} />
+            <Text variant="h2" align="center" style={styles.title}>
+              Verifying your email…
+            </Text>
+            <Text
+              variant="caption"
+              color={colors.text.secondary}
+              align="center"
+              style={styles.body}
+            >
+              One sacred breath. We are confirming your link.
+            </Text>
+          </>
+        ) : phase === 'success' ? (
+          <>
+            <Text style={styles.checkmark}>✓</Text>
+            <Text variant="h2" color={colors.primary[500]} align="center" style={styles.title}>
+              Email verified
+            </Text>
+            <Text
+              variant="caption"
+              color={colors.text.secondary}
+              align="center"
+              style={styles.body}
+            >
+              You may now sign in. Redirecting…
+            </Text>
+          </>
+        ) : (
+          <>
+            <Text style={styles.crossmark}>!</Text>
+            <Text variant="h2" align="center" style={styles.title}>
+              Verification did not complete
+            </Text>
+            <Text
+              variant="caption"
+              color={colors.text.secondary}
+              align="center"
+              style={styles.body}
+            >
+              {errorMessage ??
+                'The verification link is invalid or expired. Request a fresh one below.'}
+            </Text>
+            {resendSent ? (
+              <Text
+                variant="caption"
+                color={colors.primary[500]}
+                align="center"
+                style={styles.body}
+              >
+                ✓ A fresh verification email is on its way to {email}.
+              </Text>
+            ) : null}
+            <View style={styles.actions}>
+              <GoldenButton
+                title={resending ? 'Sending…' : 'Resend verification email'}
+                onPress={handleResend}
+                disabled={resending || !email}
+              />
+              <GoldenButton
+                title="Back to sign in"
+                variant="secondary"
+                onPress={() => router.replace('/(auth)/login')}
+              />
+            </View>
+            <Text
+              variant="caption"
+              color={colors.text.muted}
+              align="center"
+              style={styles.support}
+            >
+              Still stuck? Email {SUPPORT_EMAIL}.
+            </Text>
+          </>
+        )}
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+    gap: spacing.md,
+  },
+  title: {
+    marginTop: spacing.lg,
+  },
+  body: {
+    maxWidth: 360,
+  },
+  actions: {
+    width: '100%',
+    maxWidth: 360,
+    gap: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  support: {
+    marginTop: spacing.xl,
+  },
+  checkmark: {
+    fontSize: 64,
+    color: colors.primary[500],
+  },
+  crossmark: {
+    fontSize: 64,
+    color: colors.semantic.error,
+    fontWeight: '700',
+  },
+});

--- a/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/(tabs)/chat.tsx
@@ -60,6 +60,7 @@ import {
   type SakhaStreamMessage,
 } from '../../components/chat/index';
 import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+import { useTheme } from '@kiaanverse/ui';
 
 /** AsyncStorage key that keeps the last conversation so it survives cold kills. */
 const CONVERSATION_CACHE_KEY = 'sakha_chat_conversation_v1';
@@ -91,6 +92,11 @@ export default function ChatScreen(): React.JSX.Element {
   const listRef = useRef<FlatList<SakhaStreamMessage>>(null);
   const headerRef = useRef<ChatHeaderHandle | null>(null);
   const { isOnline } = useNetworkStatus();
+  // Read the active palette so the chat page bg + suggestion-card bg follow
+  // the user's chosen scheme (Indigo / Maroon / Forest / Black-&-Gold)
+  // instead of the previously hardcoded `BG = '#050714'` indigo.
+  const { theme } = useTheme();
+  const bgColor = theme.colors.background;
 
   const [input, setInput] = useState('');
   const [voiceEnabled, setVoiceEnabled] = useState(false);
@@ -338,7 +344,7 @@ export default function ChatScreen(): React.JSX.Element {
   }, [streaming, messages]);
 
   return (
-    <View style={styles.root}>
+    <View style={[styles.root, { backgroundColor: bgColor }]}>
       <ChatHeader
         ref={headerRef}
         streaming={streaming}

--- a/kiaanverse-mobile/apps/mobile/app/_layout.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/_layout.tsx
@@ -191,7 +191,7 @@ function AuthGate({
 }: {
   children: React.ReactNode;
 }): React.JSX.Element {
-  const { status, isOnboarded, hasHydrated } = useAuthStore();
+  const { status, isOnboarded, hasHydrated, user } = useAuthStore();
   const { isLoaded: arrivalLoaded, hasSeenArrival } = useArrivalStatus();
   const segments = useSegments();
   const router = useRouter();
@@ -209,6 +209,13 @@ function AuthGate({
     const inAuthGroup = segments[0] === '(auth)';
     const inOnboarding = segments[0] === 'onboarding';
     const inArrival = segments[0] === 'arrival';
+    // The two screens that handle the "verify your email" flow live inside
+    // (auth) so unauthenticated visits land there from the email link, but
+    // we also need to be able to ROUTE TO them when an authenticated-but-
+    // unverified session sneaks in. Track them by their leaf paths.
+    const path = segments.join('/');
+    const onVerifyEmailScreen =
+      path === '(auth)/verify-email' || path === '(auth)/verify-email-pending';
 
     // First-launch darshan: unauthenticated users who have not yet seen the
     // arrival ceremony are routed into /arrival before the auth door.
@@ -224,12 +231,33 @@ function AuthGate({
       !inArrival
     ) {
       router.replace('/(auth)/login');
-    } else if (status === 'authenticated' && !isOnboarded && !inOnboarding) {
+      return;
+    }
+
+    // Email-verification gate. Backend already blocks login for unverified
+    // accounts, but a session can rehydrate from AsyncStorage from a build
+    // that was running before REQUIRE_EMAIL_VERIFICATION was enforced — and
+    // we never want an unverified user to walk into /(tabs) on the strength
+    // of a stale token. `user.email_verified === false` (NOT undefined) is
+    // the only case we redirect: undefined means an older session payload
+    // that didn't carry the field, treat as verified for backwards compat.
+    if (
+      status === 'authenticated' &&
+      user &&
+      user.email_verified === false &&
+      !onVerifyEmailScreen
+    ) {
+      router.replace('/(auth)/verify-email-pending');
+      return;
+    }
+
+    if (status === 'authenticated' && !isOnboarded && !inOnboarding) {
       router.replace('/onboarding');
     } else if (
       status === 'authenticated' &&
       isOnboarded &&
-      (inAuthGroup || inOnboarding || inArrival)
+      (inAuthGroup || inOnboarding || inArrival) &&
+      !onVerifyEmailScreen
     ) {
       router.replace('/(tabs)');
     }
@@ -241,6 +269,7 @@ function AuthGate({
     arrivalLoaded,
     segments,
     router,
+    user,
   ]);
 
   return <>{children}</>;

--- a/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
@@ -26,6 +26,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AccessibilityInfo,
   Dimensions,
+  FlatList,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   Platform,
   ScrollView,
   StyleSheet,
@@ -160,10 +163,6 @@ function buildPages(palette: Palette): readonly PageData[] {
 const PAGE_COUNT = PAGE_TEMPLATES.length;
 
 const LOTUS_BLOOM = Easing.bezier(0.22, 1.0, 0.36, 1.0);
-/** Spring-like easing for the page slide that always settles exactly at the
- *  target (vs. a real spring whose epsilon-tolerance was leaving sub-pixel
- *  residue that compounded into a visible right-shift on later pages). */
-const SLIDE_EASE = Easing.bezier(0.32, 0.72, 0, 1);
 
 const GOLD = '#D4A44C';
 const GOLD_SOFT = 'rgba(212, 164, 76, 0.7)';
@@ -174,7 +173,14 @@ const GOLD_SOFT = 'rgba(212, 164, 76, 0.7)';
 
 export default function ArrivalCeremonyScreen(): React.JSX.Element {
   const [page, setPage] = useState(0);
-  const translateX = useSharedValue(0);
+  // Native FlatList paging — replaces the previous `Animated.View` +
+  // `withTiming(-page * W)` approach. Math.round + withTiming were both
+  // mathematically correct, yet the rendered slider on the user's device
+  // still drifted right on later pages. Switching to the platform's
+  // pagingEnabled FlatList offloads alignment to native code which snaps
+  // to integer pixel boundaries deterministically — there is no layer of
+  // RN/Yoga/Reanimated math that can introduce sub-pixel residue here.
+  const listRef = useRef<FlatList<PageData>>(null);
   const { markArrivalSeen } = useArrivalStatus();
   // Guard against double-tap / completion re-entry.
   const isCompleting = useRef(false);
@@ -218,34 +224,62 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
     if (page < PAGE_COUNT - 1) {
       haptic('light');
       const nextIndex = page + 1;
-      // Use withTiming instead of withSpring. Springs have a settle threshold
-      // (~0.001) that's normally fine, but if the user taps Continue before
-      // the previous spring finishes the completion callback gets
-      // `finished=false` and the snap-to-integer never fires — leaving
-      // sub-pixel residue that compounds across pages and visibly shifts
-      // later pages to the right (pages 4 & 5 were the worst). withTiming
-      // always lands exactly on the target value, regardless of interruption.
-      translateX.value = withTiming(-nextIndex * W, {
-        duration: 360,
-        easing: SLIDE_EASE,
-      });
+      // Native FlatList scroll — animated paging that always lands exactly
+      // on integer-pixel page boundaries. No translateX residue.
+      listRef.current?.scrollToOffset({ offset: nextIndex * W, animated: true });
       setPage(nextIndex);
     } else {
       void handleComplete();
     }
-  }, [page, translateX, haptic, handleComplete]);
+  }, [page, haptic, handleComplete]);
 
   const handleSkip = useCallback((): void => {
     void handleComplete();
   }, [handleComplete]);
 
   // -------------------------------------------------------------------------
-  // Slide animation
+  // Page state sync — keeps `page` in sync with manual swipes (if/when the
+  // FlatList ever permits horizontal gesture; currently it does via default
+  // Android paging, on iOS too). Uses `Math.round(offsetX / W)` so a
+  // half-swipe lands on the nearest page.
   // -------------------------------------------------------------------------
 
-  const pagesContainerStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
+  const handleMomentumScrollEnd = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>): void => {
+      const newIndex = Math.round(e.nativeEvent.contentOffset.x / W);
+      if (newIndex !== page && newIndex >= 0 && newIndex < PAGE_COUNT) {
+        setPage(newIndex);
+      }
+    },
+    [page]
+  );
+
+  // FlatList per-item layout: tells the list every item is exactly W wide
+  // so initial render + scrollToOffset are both pixel-perfect (no measure
+  // pass that could produce fractional widths).
+  const getItemLayout = useCallback(
+    (_data: ArrayLike<PageData> | null | undefined, index: number) => ({
+      length: W,
+      offset: W * index,
+      index,
+    }),
+    []
+  );
+
+  const renderPage = useCallback(
+    ({ item, index }: { item: PageData; index: number }) => (
+      <CeremonyPage
+        data={item}
+        index={index}
+        isActive={page === index}
+        palette={palette}
+        totalPages={pages.length}
+      />
+    ),
+    [page, palette, pages.length]
+  );
+
+  const keyExtractor = useCallback((item: PageData) => item.id, []);
 
   const isWelcome = currentPage.id === 'welcome';
 
@@ -258,18 +292,26 @@ export default function ArrivalCeremonyScreen(): React.JSX.Element {
   return (
     <View style={[styles.root, { backgroundColor: palette.bg.void }]}>
       <DivineBackground variant="sacred">
-        <Animated.View style={[styles.pagesContainer, pagesContainerStyle]}>
-          {pages.map((p, i) => (
-            <CeremonyPage
-              key={p.id}
-              data={p}
-              index={i}
-              isActive={page === i}
-              palette={palette}
-              totalPages={pages.length}
-            />
-          ))}
-        </Animated.View>
+        <FlatList
+          ref={listRef}
+          data={pages}
+          renderItem={renderPage}
+          keyExtractor={keyExtractor}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          getItemLayout={getItemLayout}
+          onMomentumScrollEnd={handleMomentumScrollEnd}
+          // The Continue button drives navigation; manual swiping is allowed
+          // as a bonus but isn't the primary path. `decelerationRate=fast`
+          // makes a stray swipe snap immediately to the next page.
+          decelerationRate="fast"
+          // Render every page up front (only 6) so the visuals' breathing
+          // animations are warm when the user advances to them.
+          initialNumToRender={PAGE_COUNT}
+          windowSize={PAGE_COUNT}
+          removeClippedSubviews={false}
+        />
 
         {/* Peacock feather progress — not dots. */}
         <View style={styles.progressBar}>
@@ -664,14 +706,15 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#050714',
   },
-  pagesContainer: {
-    flex: 1,
-    flexDirection: 'row',
-    width: W * PAGE_COUNT,
-  },
   page: {
+    // Each page is exactly W wide (= integer device pixels via Math.round).
+    // Vertical fill comes from FlatList's default alignSelf:'stretch' on
+    // horizontal items — `flex:1` was removed because in a row context it
+    // is `flexGrow:1` in main axis, which can race with `width:W` on Yoga
+    // and produce sub-pixel render widths. Explicit width + no flexGrow
+    // gives the most predictable native paging.
     width: W,
-    flex: 1,
+    height: '100%',
     paddingHorizontal: 28,
     paddingTop: 72,
     paddingBottom: 24,

--- a/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/arrival/index.tsx
@@ -680,7 +680,11 @@ function PageVisual({
   isActive,
   compact = false,
 }: PageVisualProps): React.JSX.Element {
-  const size = compact ? VISUAL_SIZE * 0.78 : VISUAL_SIZE;
+  // Round so the compact welcome-page visual gets an integer width too —
+  // 220 * 0.78 = 171.6, which Yoga would round to 172 for the View while
+  // the SVG drew at 171.6, leaving a 0.4px asymmetry between the visual's
+  // bounding box and its rendered geometry.
+  const size = compact ? Math.round(VISUAL_SIZE * 0.78) : VISUAL_SIZE;
   switch (kind) {
     case 'chariot':
       return <ChariotChakraVisual accent={accent} isActive={isActive} size={size} />;
@@ -849,11 +853,13 @@ const styles = StyleSheet.create({
   // -------------------------------------------------------------------------
   // Welcome page (page 6) — scrollable rich content
   // -------------------------------------------------------------------------
-  /** ScrollView outer frame — width-locked to a single page slot, no padding
-   *  so the contentContainer's padding is the single source of truth. */
+  /** ScrollView outer frame — width-locked to a single page slot. Same
+   *  `height:'100%'` (instead of `flex:1`) treatment as `styles.page` so
+   *  the welcome page's ScrollView never races with FlatList's horizontal
+   *  flexGrow inside the row container. */
   welcomeScroll: {
     width: W,
-    flex: 1,
+    height: '100%',
   },
   welcomeContent: {
     paddingHorizontal: 28,

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/GunaMirrorChamber.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/GunaMirrorChamber.tsx
@@ -14,10 +14,10 @@
 import React, { useCallback, useRef, useState } from 'react';
 import {
   Dimensions,
+  FlatList,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -65,14 +65,29 @@ export function GunaMirrorChamber({
   onCustomQueryChange,
   onProceed,
 }: GunaMirrorChamberProps): React.JSX.Element {
-  const scrollRef = useRef<ScrollView>(null);
+  // Native FlatList paging — replaces the previous `ScrollView pagingEnabled`
+  // approach. ScrollView+pagingEnabled on Android has a known issue where
+  // pages 2+ drift right because the snap intervals don't always match the
+  // panel widths exactly (especially when there's any container padding
+  // or SafeAreaView in the ancestor tree). FlatList with `getItemLayout`
+  // returning fixed integer offsets snaps deterministically.
+  const listRef = useRef<FlatList<(typeof GUNA_PANELS)[number]>>(null);
   const [activePanel, setActivePanel] = useState(0);
 
-  const onScroll = useCallback(
+  const onMomentumScrollEnd = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
       const idx = Math.round(event.nativeEvent.contentOffset.x / SCREEN_WIDTH);
       setActivePanel((prev) => (prev === idx ? prev : idx));
     },
+    []
+  );
+
+  const getItemLayout = useCallback(
+    (_data: ArrayLike<(typeof GUNA_PANELS)[number]> | null | undefined, index: number) => ({
+      length: SCREEN_WIDTH,
+      offset: SCREEN_WIDTH * index,
+      index,
+    }),
     []
   );
 
@@ -124,17 +139,22 @@ export function GunaMirrorChamber({
 
       <Text style={styles.divider}>Or select patterns you recognise</Text>
 
-      <ScrollView
-        ref={scrollRef}
+      <FlatList
+        ref={listRef}
+        data={GUNA_PANELS}
+        keyExtractor={(panel) => panel.key}
         horizontal
         pagingEnabled
         showsHorizontalScrollIndicator={false}
-        onScroll={onScroll}
-        scrollEventThrottle={32}
+        onMomentumScrollEnd={onMomentumScrollEnd}
+        getItemLayout={getItemLayout}
+        decelerationRate="fast"
+        initialNumToRender={GUNA_PANELS.length}
+        windowSize={GUNA_PANELS.length}
+        removeClippedSubviews={false}
         style={styles.panelScroller}
-      >
-        {GUNA_PANELS.map((panel) => (
-          <View key={panel.key} style={[styles.panel, { width: SCREEN_WIDTH }]}>
+        renderItem={({ item: panel }) => (
+          <View style={[styles.panel, { width: SCREEN_WIDTH }]}>
             <View style={[styles.panelHeader, { backgroundColor: panel.tint }]}>
               <Text style={[styles.panelTitle, { color: panel.color }]}>
                 {panel.sanskrit} — {panel.label}
@@ -184,8 +204,8 @@ export function GunaMirrorChamber({
               })}
             </View>
           </View>
-        ))}
-      </ScrollView>
+        )}
+      />
 
       <View style={styles.dotsRow}>
         {GUNA_PANELS.map((_, i) => (

--- a/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/GunaMirrorChamber.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/tools/relationship-compass/chambers/GunaMirrorChamber.tsx
@@ -38,7 +38,15 @@ const CARD_BG = 'rgba(22, 26, 66, 0.6)';
 
 const MAX_QUERY_LEN = 500;
 
-const SCREEN_WIDTH = Dimensions.get('window').width;
+// `Dimensions.get('window').width` returns a fractional value on many
+// Android devices (e.g. 411.42857). When that fractional width is set on
+// each panel, React Native's `pagingEnabled` ScrollView snaps to
+// integer-pixel boundaries that don't match the fractional panel layout
+// — over 3 panels the drift compounds and pages 2 (Rajas) + 3 (Sattva)
+// visibly shift to the right (header text gets clipped, the previous
+// panel peeks in from the left). Rounding to an integer eliminates the
+// mismatch so every panel snaps to its own left edge.
+const SCREEN_WIDTH = Math.round(Dimensions.get('window').width);
 
 export interface GunaMirrorChamberProps {
   readonly selectedPatterns: GunaSelections;

--- a/kiaanverse-mobile/apps/mobile/app/vibe-player/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/vibe-player/index.tsx
@@ -37,7 +37,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import * as Haptics from 'expo-haptics';
-import { DivineBackground, LoadingMandala } from '@kiaanverse/ui';
+import { DivineBackground, LoadingMandala, useTheme } from '@kiaanverse/ui';
 import { useMeditationTracks } from '@kiaanverse/api';
 import type { MeditationTrack } from '@kiaanverse/api';
 import { useVibePlayerStore, type VibeTrack } from '@kiaanverse/store';
@@ -225,6 +225,10 @@ function SegmentedTabs({
   value: VibeTab;
   onChange: (tab: VibeTab) => void;
 }): React.JSX.Element {
+  // Read the active palette so tab pills + chips stop rendering hardcoded
+  // navy-indigo even when the user picks Forest / Maroon / Black-&-Gold.
+  const { theme } = useTheme();
+  const pillBg = theme.colors.card;
   const handlePress = useCallback(
     (tab: VibeTab) => {
       if (tab === value) return;
@@ -245,7 +249,11 @@ function SegmentedTabs({
             accessibilityRole="tab"
             accessibilityState={{ selected: active }}
             accessibilityLabel={`${tab.label} tab`}
-            style={[styles.tabPill, active && styles.tabPillActive]}
+            style={[
+              styles.tabPill,
+              { backgroundColor: pillBg },
+              active && styles.tabPillActive,
+            ]}
           >
             <Text
               style={[styles.tabLabel, active && styles.tabLabelActive]}

--- a/kiaanverse-mobile/apps/mobile/app/voice-companion/index.tsx
+++ b/kiaanverse-mobile/apps/mobile/app/voice-companion/index.tsx
@@ -62,6 +62,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect } from 'expo-router';
 import { Audio } from 'expo-av';
 import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -479,6 +480,30 @@ export default function VoiceCompanionScreen() {
   // leave a Speech.speak running in the background that auto-restarts
   // a dictation on done — which would then either crash (no native
   // module attached on Expo Go) or just play in the background.
+  // Defense-in-depth: kill the session whenever the screen loses focus —
+  // i.e. when the user switches tabs, navigates away, or the device goes
+  // to background. The previous `useEffect` cleanup only fired on actual
+  // unmount, which expo-router does NOT do for tab screens (they stay
+  // mounted in memory), so navigating to another tab while Sakha was
+  // mid-sentence left TTS playing in the background until the cloud
+  // audio finished naturally. `useFocusEffect` runs the returned cleanup
+  // every time the screen blurs, regardless of mount state.
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        sessionActiveRef.current = false;
+        // Fire-and-forget — Speech.stop is sync, cloudStop is async but
+        // we don't need to await before the screen blurs.
+        void stopSpeaking();
+        try {
+          abort();
+        } catch {
+          /* abort throws when no stream is in flight — harmless */
+        }
+      };
+    }, [abort])
+  );
+
   useEffect(() => {
     return () => {
       sessionActiveRef.current = false;
@@ -495,6 +520,25 @@ export default function VoiceCompanionScreen() {
 
   return (
     <SafeAreaView style={styles.root}>
+      {/* Floating Stop button — top-right of the canvas. Only visible when
+          a voice session is in flight. Gives the user a clear, always-
+          reachable kill switch even mid-sentence. (The bottom-bar "End
+          session" pill does the same thing but lives below the wave
+          visualizer; on long Sakha replies users were missing it.) */}
+      {isActive ? (
+        <Pressable
+          onPress={handleStop}
+          style={styles.floatingStopBtn}
+          accessibilityRole="button"
+          accessibilityLabel="Stop Sakha (silence the voice and end the session)"
+          testID="voice-companion-stop-floating"
+          hitSlop={12}
+        >
+          <View style={styles.floatingStopGlyph} />
+          <Text style={styles.floatingStopLabel}>Stop</Text>
+        </Pressable>
+      ) : null}
+
       <View style={styles.canvas}>
         <SacredGeometry size={360} />
         <Shankha size={170} />
@@ -605,6 +649,37 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Color.cosmicVoid,
     paddingHorizontal: Spacing.md,
+  },
+  // Floating Stop button — top-right kill switch shown only during an
+  // active session so the user can silence Sakha mid-sentence without
+  // hunting for the "End session" pill below the visualizer.
+  floatingStopBtn: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    zIndex: 30,
+    elevation: 30,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: 'rgba(220, 38, 38, 0.18)',
+    borderWidth: 1,
+    borderColor: 'rgba(220, 38, 38, 0.45)',
+  },
+  floatingStopGlyph: {
+    width: 10,
+    height: 10,
+    borderRadius: 2,
+    backgroundColor: '#FCA5A5',
+  },
+  floatingStopLabel: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 12,
+    letterSpacing: 0.5,
+    color: '#FCA5A5',
   },
   canvas: {
     flex: 1,

--- a/kiaanverse-mobile/apps/mobile/components/chat/ChatHeader.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/ChatHeader.tsx
@@ -26,6 +26,7 @@ import React, {
 import { Pressable, StyleSheet, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '@kiaanverse/ui';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -121,6 +122,10 @@ export const ChatHeader = forwardRef<ChatHeaderHandle, ChatHeaderProps>(
     ref
   ) {
     const insets = useSafeAreaInsets();
+    // Header bg follows the active palette so the chat title bar doesn't
+    // sit as an indigo strip over a forest / maroon / black-&-gold page.
+    const { theme } = useTheme();
+    const bgColor = theme.colors.background;
 
     /** Always-on breathing: scale 1.0 → 1.08 → 1.0 (idle) or 1.16 (streaming). */
     const breath = useSharedValue(0);
@@ -191,9 +196,13 @@ export const ChatHeader = forwardRef<ChatHeaderHandle, ChatHeaderProps>(
     const containerStyle = useMemo(
       () => [
         styles.container,
-        { paddingTop: insets.top, height: HEADER_CONTENT_HEIGHT + insets.top },
+        {
+          paddingTop: insets.top,
+          height: HEADER_CONTENT_HEIGHT + insets.top,
+          backgroundColor: bgColor,
+        },
       ],
-      [insets.top]
+      [insets.top, bgColor]
     );
 
     return (

--- a/kiaanverse-mobile/apps/mobile/components/chat/ChatInput.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/ChatInput.tsx
@@ -28,6 +28,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
+import { useTheme } from '@kiaanverse/ui';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -120,6 +121,12 @@ function ChatInputInner({
 }: ChatInputProps): React.JSX.Element {
   const insets = useSafeAreaInsets();
   const [focused, setFocused] = useState(false);
+  // Bottom input bar follows the active palette — was a fixed indigo
+  // strip that floated as an indigo island over forest / maroon /
+  // black-&-gold pages.
+  const { theme } = useTheme();
+  const bgColor = theme.colors.background;
+  const fieldBg = theme.colors.card;
 
   const canSend = value.trim().length > 0 && !disabled;
 
@@ -173,6 +180,7 @@ function ChatInputInner({
         {
           paddingBottom: insets.bottom,
           height: ROW_HEIGHT + insets.bottom,
+          backgroundColor: bgColor,
         },
       ]}
     >
@@ -195,7 +203,13 @@ function ChatInputInner({
           <MicIcon color={GOLD} />
         </Pressable>
 
-        <View style={[styles.inputWrap, focused && styles.inputWrapFocused]}>
+        <View
+          style={[
+            styles.inputWrap,
+            { backgroundColor: fieldBg },
+            focused && styles.inputWrapFocused,
+          ]}
+        >
           <TextInput
             value={value}
             onChangeText={onChangeText}

--- a/kiaanverse-mobile/apps/mobile/components/chat/ConversationStarters.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/ConversationStarters.tsx
@@ -12,6 +12,7 @@ import React, { useEffect } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
+import { useTheme } from '@kiaanverse/ui';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -46,6 +47,10 @@ interface ChipProps {
 }
 
 function SacredChip({ text, delay, onPress }: ChipProps): React.JSX.Element {
+  // Suggestion-card gradient follows the active palette so it stops
+  // reading as an indigo island over forest / maroon / black-&-gold pages.
+  const { theme } = useTheme();
+  const palette = theme.colorScheme;
   const opacity = useSharedValue(0);
   const translateY = useSharedValue(12);
   const scale = useSharedValue(0.96);
@@ -85,7 +90,7 @@ function SacredChip({ text, delay, onPress }: ChipProps): React.JSX.Element {
         style={({ pressed }) => [styles.chip, pressed && styles.chipPressed]}
       >
         <LinearGradient
-          colors={['rgba(19,26,61,0.9)', 'rgba(27,79,187,0.35)']}
+          colors={[palette.bg.card, palette.accent.primary + '59']}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
           style={StyleSheet.absoluteFill}

--- a/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/chat/SakhaMessage.tsx
@@ -20,6 +20,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
+import { useTheme } from '@kiaanverse/ui';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -230,6 +231,11 @@ function SakhaMessageInner({
 }: SakhaMessageProps): React.JSX.Element {
   const { width } = useWindowDimensions();
   const maxWidth = Math.round(width * MAX_WIDTH_PERCENT);
+  // Sakha message bubble follows the active palette — was a fixed
+  // indigo `rgba(19,26,61,0.92)` that read as a navy island when the
+  // user was on Forest / Maroon / Black-&-Gold.
+  const { theme } = useTheme();
+  const bubbleBg = theme.colors.card;
 
   // ── Saransh (सारांश, "summary") view mode ──
   // 'full'    — render the full streamed response (default).
@@ -306,7 +312,7 @@ function SakhaMessageInner({
       </View>
 
       {/* Bubble column */}
-      <View style={[styles.bubble, { maxWidth }]}>
+      <View style={[styles.bubble, { maxWidth, backgroundColor: bubbleBg }]}>
         {/* Left border accent — vertical Krishna-aura ribbon. */}
         <LinearGradient
           colors={KRISHNA_AURA as unknown as string[]}

--- a/kiaanverse-mobile/apps/mobile/components/tools/VibePlayerCard.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/tools/VibePlayerCard.tsx
@@ -32,7 +32,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import Svg, { Path, Polygon } from 'react-native-svg';
-import { WaveformVisualizer } from '@kiaanverse/ui';
+import { WaveformVisualizer, useTheme } from '@kiaanverse/ui';
 
 import { KRISHNA_BLUE, PEACOCK_TEAL } from './toolColors';
 
@@ -91,6 +91,13 @@ function VibePlayerCardInner({
   style,
   testID,
 }: VibePlayerCardProps): React.JSX.Element {
+  // Read the active palette so the KIAAN Vibe Player tile on the Sacred
+  // Tools tab stops rendering as a hardcoded blue card over a forest /
+  // maroon / black-&-gold page bg. The stripe + accent halo follow
+  // `accent.primary`, the card surface follows `colors.card`.
+  const { theme } = useTheme();
+  const cardBg = theme.colors.card;
+  const accentPrimary = theme.colorScheme.accent.primary;
   const scale = useSharedValue(1);
   const playScale = useSharedValue(1);
 
@@ -153,18 +160,22 @@ function VibePlayerCardInner({
         accessibilityHint="Opens the full Vibe Player"
         style={styles.press}
       >
-        <View style={styles.surface}>
-          {/* Base Krishna→peacock gradient body. */}
+        <View style={[styles.surface, { backgroundColor: cardBg }]}>
+          {/* Base palette-tinted gradient body. Was hardcoded Krishna →
+              peacock; now uses the active palette's primary accent at ~15%
+              and ~8% alpha so the tile reads as themed (forest, maroon,
+              gold, indigo). */}
           <LinearGradient
-            colors={GRADIENT_COLORS as unknown as string[]}
+            colors={[accentPrimary + '26', accentPrimary + '14']}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
             style={StyleSheet.absoluteFill}
           />
 
-          {/* Left semantic-color stripe. */}
+          {/* Left semantic-color stripe — follows the active palette's
+              primary accent (was hardcoded KRISHNA_BLUE). */}
           <View
-            style={[styles.stripe, { backgroundColor: KRISHNA_BLUE }]}
+            style={[styles.stripe, { backgroundColor: accentPrimary }]}
             pointerEvents="none"
           />
 

--- a/kiaanverse-mobile/apps/mobile/components/vibe-player/DailyVerseBanner.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/vibe-player/DailyVerseBanner.tsx
@@ -27,6 +27,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useTheme } from '@kiaanverse/ui';
 
 const GOLD = '#D4A017';
 const SACRED_WHITE = '#F5F0E8';
@@ -53,6 +54,11 @@ function DailyVerseBannerInner({
   onPress,
   style,
 }: DailyVerseBannerProps): React.JSX.Element {
+  // Read the active palette so the "Today's Sacred Sound" card stops
+  // rendering hardcoded indigo `rgba(17,20,53,0.85)` over a forest /
+  // maroon / black-&-gold page bg.
+  const { theme } = useTheme();
+  const cardBg = theme.colors.card;
   const scale = useSharedValue(1);
 
   const handlePressIn = useCallback(() => {
@@ -84,7 +90,7 @@ function DailyVerseBannerInner({
         }`}
         style={styles.press}
       >
-        <View style={styles.card}>
+        <View style={[styles.card, { backgroundColor: cardBg }]}>
           {/* Top gold shimmer strip (matches SacredCard). */}
           <LinearGradient
             colors={[

--- a/kiaanverse-mobile/apps/mobile/voice/components/Shankha.tsx
+++ b/kiaanverse-mobile/apps/mobile/voice/components/Shankha.tsx
@@ -65,54 +65,155 @@ function SoundWaveLayer({ layer, size }: { layer: ShankhaWaveLayer; size: number
 }
 
 function ShankhaSvg({ size }: { size: number }) {
-  // Stylized three-quarter conch silhouette. Two gradients give the
-  // ivory body a soft realistic gradient + the copper rim accent. The
-  // path is intentionally hand-tuned (not auto-traced) so the shape
-  // reads as a conch even at 24dp.
+  // Realistic Shankha (शङ्ख) — Krishna's conch.
+  //
+  // Previous version traced a single curve that read on-screen as an abstract
+  // crescent / pac-man shape. Replaced with a proper conch silhouette:
+  //   • A pointed spire at the top with three visible whorl ridges (the
+  //     spiral coils of the shell apex).
+  //   • A bulging body that widens at the shoulder and tapers at the base.
+  //   • A clear aperture (mouth) opening on the right side, with a darker
+  //     inner cavity and a bright golden lip showing where sound emerges.
+  //   • A subtle spiral hint visible through the aperture mouth.
+  //
+  // Two gradients (cream radial body, copper-to-gold rim) keep it lit
+  // realistically. The aperture inner cavity uses its own dim gold so the
+  // mouth reads as DEPTH, not a flat shape.
   return (
-    <Svg width={size} height={size} viewBox="0 0 200 200">
+    <Svg width={size} height={size} viewBox="0 0 200 220">
       <Defs>
-        <RadialGradient id="body" cx="50%" cy="45%" r="55%">
+        <RadialGradient id="conchBody" cx="42%" cy="35%" r="70%">
           <Stop offset="0%" stopColor={Color.shankhaCream} stopOpacity="1" />
-          <Stop offset="60%" stopColor={Color.shankhaIvory} stopOpacity="1" />
-          <Stop offset="100%" stopColor={Color.shankhaCopper} stopOpacity="0.6" />
+          <Stop offset="55%" stopColor={Color.shankhaIvory} stopOpacity="1" />
+          <Stop offset="100%" stopColor={Color.shankhaCopper} stopOpacity="0.55" />
         </RadialGradient>
-        <LinearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={Color.divineGoldBright} stopOpacity="0.85" />
-          <Stop offset="100%" stopColor={Color.shankhaCopper} stopOpacity="0.65" />
+        <LinearGradient id="conchRim" x1="0" y1="0" x2="1" y2="1">
+          <Stop offset="0%" stopColor={Color.divineGoldBright} stopOpacity="0.95" />
+          <Stop offset="50%" stopColor={Color.divineGold} stopOpacity="0.85" />
+          <Stop offset="100%" stopColor={Color.shankhaCopper} stopOpacity="0.7" />
         </LinearGradient>
+        <RadialGradient id="conchAperture" cx="50%" cy="40%" r="60%">
+          <Stop offset="0%" stopColor={Color.shankhaCopper} stopOpacity="0.35" />
+          <Stop offset="100%" stopColor="#1A0E04" stopOpacity="0.85" />
+        </RadialGradient>
       </Defs>
-      {/* Conch body — spiral with widening mouth */}
+
+      {/* ---------- Outer body silhouette ----------
+          Spire tip at (95, 12), curls down-left into a wide belly, then back
+          up the right side around the aperture and tucks under itself. */}
       <Path
-        d="M 100 30
-           C 60 38, 40 75, 50 115
-           C 56 145, 80 165, 110 168
-           C 138 170, 158 156, 160 130
-           C 162 110, 148 96, 130 92
-           C 116 90, 105 100, 108 115
-           C 110 125, 122 130, 130 122
+        d="M 95 12
+           C 75 18, 55 45, 48 80
+           C 42 115, 48 150, 70 175
+           C 90 196, 120 200, 145 188
+           C 168 178, 178 158, 175 135
+           C 172 115, 158 100, 138 95
+           C 122 92, 108 100, 105 115
+           C 103 128, 113 138, 125 135
+           C 134 132, 138 122, 132 115
            Z"
-        fill="url(#body)"
-        stroke="url(#rim)"
+        fill="url(#conchBody)"
+        stroke="url(#conchRim)"
         strokeWidth="2"
+        strokeLinejoin="round"
       />
-      {/* Inner spiral suggestion */}
+
+      {/* ---------- Spire whorls ----------
+          Three nested arcs at the top show the spiral coils of the apex. */}
       <Path
-        d="M 100 70
-           C 80 78, 72 100, 80 118
-           C 86 130, 100 134, 110 128"
-        fill="none"
+        d="M 90 22 C 78 28, 72 42, 80 54"
         stroke={Color.shankhaCopper}
-        strokeOpacity="0.45"
+        strokeOpacity="0.6"
         strokeWidth="1.4"
+        fill="none"
+        strokeLinecap="round"
       />
-      {/* Mouth highlight (where sound emerges) */}
       <Path
-        d="M 145 132
-           C 152 132, 156 138, 152 144
-           C 148 148, 142 146, 142 140 Z"
-        fill={Color.divineGoldDim}
-        opacity="0.8"
+        d="M 88 38 C 74 46, 70 60, 80 72"
+        stroke={Color.shankhaCopper}
+        strokeOpacity="0.5"
+        strokeWidth="1.3"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <Path
+        d="M 82 56 C 68 66, 65 82, 78 92"
+        stroke={Color.shankhaCopper}
+        strokeOpacity="0.4"
+        strokeWidth="1.2"
+        fill="none"
+        strokeLinecap="round"
+      />
+
+      {/* ---------- Aperture (mouth) ----------
+          The opening on the right side. Filled with a dim radial gradient
+          so it reads as a real cavity rather than a flat shape. */}
+      <Path
+        d="M 138 110
+           C 156 110, 168 122, 168 140
+           C 168 158, 156 172, 138 174
+           C 122 175, 112 165, 112 148
+           C 112 130, 122 115, 138 110
+           Z"
+        fill="url(#conchAperture)"
+        stroke="url(#conchRim)"
+        strokeWidth="1.6"
+      />
+
+      {/* ---------- Aperture lip highlight ----------
+          A bright golden curve along the inside of the lip — this is the
+          edge that catches light when sound emerges from the conch. */}
+      <Path
+        d="M 152 120
+           C 162 126, 165 138, 162 150
+           C 159 162, 150 168, 140 168"
+        stroke={Color.divineGoldBright}
+        strokeOpacity="0.8"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+
+      {/* ---------- Inner spiral hint ----------
+          A small curl visible deep inside the mouth — suggests the
+          continuing spiral that runs the full length of the conch. */}
+      <Path
+        d="M 135 138 C 142 140, 146 148, 142 155"
+        stroke={Color.shankhaCopper}
+        strokeOpacity="0.7"
+        strokeWidth="1.2"
+        fill="none"
+        strokeLinecap="round"
+      />
+
+      {/* ---------- Body banding (subtle) ----------
+          Two faint horizontal-ish ridges across the body suggest the
+          natural growth bands on a real conch. Kept very subtle so the
+          shell reads as smooth at small sizes. */}
+      <Path
+        d="M 55 95 C 75 100, 100 100, 118 95"
+        stroke={Color.shankhaCopper}
+        strokeOpacity="0.18"
+        strokeWidth="1"
+        fill="none"
+      />
+      <Path
+        d="M 58 130 C 78 138, 100 138, 115 132"
+        stroke={Color.shankhaCopper}
+        strokeOpacity="0.18"
+        strokeWidth="1"
+        fill="none"
+      />
+
+      {/* ---------- Highlight catch ----------
+          A small bright crescent on the left of the body — the lit side. */}
+      <Path
+        d="M 60 70 C 56 90, 56 115, 62 138"
+        stroke={Color.shankhaCream}
+        strokeOpacity="0.5"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
       />
     </Svg>
   );

--- a/kiaanverse-mobile/packages/api/src/auth/authService.ts
+++ b/kiaanverse-mobile/packages/api/src/auth/authService.ts
@@ -170,6 +170,11 @@ function mapMeResponseToUser(me: MeResponse): User {
     locale: 'en', // Default — not available from /api/auth/me
     subscriptionTier: (me.subscription_tier?.toUpperCase() ?? 'FREE') as User['subscriptionTier'],
     createdAt: '', // Not available from /api/auth/me
+    // Propagate email_verified so AuthGate's redirect-to-/verify-email-pending
+    // gate has the truth from the source. Without this, a session that
+    // refreshes via /api/auth/me silently lost the field and the gate would
+    // treat the user as verified (undefined ≠ false).
+    email_verified: me.email_verified,
   };
 }
 

--- a/kiaanverse-mobile/packages/api/src/auth/authService.ts
+++ b/kiaanverse-mobile/packages/api/src/auth/authService.ts
@@ -184,6 +184,13 @@ function mapLoginResponseToUser(res: LoginResponse): User {
     locale: 'en',
     subscriptionTier: (res.subscription_tier?.toUpperCase() ?? 'FREE') as User['subscriptionTier'],
     createdAt: '',
+    // Backend's login endpoint REJECTS unverified users with 403 — so any
+    // user we successfully construct here is, by definition, verified.
+    // Marking explicit `true` (rather than leaving undefined) so the
+    // AuthGate's `email_verified === false` check is unambiguous and so
+    // a future call to /api/auth/me can still flip it back to false if
+    // the user is somehow downgraded.
+    email_verified: true,
   };
 }
 
@@ -297,6 +304,44 @@ async function logout(): Promise<void> {
  * Fetch the currently authenticated user's session info.
  * Maps the backend MeOut response to the frontend User type.
  */
+/**
+ * Confirm an email-verification token from the deep-link.
+ *
+ * Backend `POST /api/auth/verify-email` validates the token, sets the
+ * user's `email_verified=True`, and returns 200 with a small success
+ * payload. On expired/invalid token it returns 410/422 — surface those
+ * with a friendly mapped error so the verify-email screen can show
+ * "expired, please resend".
+ */
+async function verifyEmail(token: string): Promise<{ verified: boolean }> {
+  try {
+    const { data } = await apiClient.post<{ verified: boolean }>(
+      '/api/auth/verify-email',
+      { token },
+    );
+    return data;
+  } catch (err) {
+    throw mapAxiosError(err);
+  }
+}
+
+/**
+ * Ask the backend to send a fresh verification email. Used when the
+ * user lost the original email or its 24-hour token expired. Backend
+ * deduplicates by email + a small server-side rate limit.
+ */
+async function resendVerification(email: string): Promise<{ sent: boolean }> {
+  try {
+    const { data } = await apiClient.post<{ sent: boolean }>(
+      '/api/auth/resend-verification',
+      { email },
+    );
+    return data;
+  } catch (err) {
+    throw mapAxiosError(err);
+  }
+}
+
 async function getCurrentUser(): Promise<User> {
   try {
     const { data } = await apiClient.get<MeResponse>('/api/auth/me');
@@ -317,4 +362,6 @@ export const authService = {
   logout,
   getCurrentUser,
   mapLoginResponseToUser,
+  verifyEmail,
+  resendVerification,
 } as const;

--- a/kiaanverse-mobile/packages/api/src/types.ts
+++ b/kiaanverse-mobile/packages/api/src/types.ts
@@ -16,6 +16,12 @@ export interface User {
   locale: string;
   subscriptionTier: SubscriptionTier;
   createdAt: string;
+  /** True when the user has clicked the link in their verification email.
+   *  Optional for backwards compat with sessions persisted by older builds
+   *  that did not carry this field — AuthGate treats `undefined` as verified
+   *  to avoid forcing re-verification on a healthy existing session. Only
+   *  `false` triggers the verify-email-pending redirect. */
+  email_verified?: boolean;
 }
 
 export type SubscriptionTier = 'FREE' | 'BHAKTA' | 'SADHAK' | 'SIDDHA';

--- a/kiaanverse-mobile/packages/store/src/authStore.ts
+++ b/kiaanverse-mobile/packages/store/src/authStore.ts
@@ -52,6 +52,20 @@ interface AuthState {
    */
   signupPendingVerification: boolean;
   /**
+   * Email address used for the most recent signup. Lets the register
+   * screen render "we sent a link to {email}" and powers its
+   * Resend-verification-email button.
+   */
+  signupEmail: string | null;
+  /**
+   * Whether the backend actually shipped the verification email
+   * (`signup` response's `email_verification_sent` field). When false,
+   * the user account exists but no email arrived — the register screen
+   * surfaces a clear error + Resend button instead of the misleading
+   * "Check your email" copy that earlier builds always showed.
+   */
+  signupVerificationSent: boolean;
+  /**
    * True once Zustand persist middleware has rehydrated state from storage.
    * AuthGate must wait for this before redirecting, otherwise isOnboarded
    * may be stale (false) causing a flash redirect to onboarding.
@@ -136,6 +150,8 @@ const initialState: AuthState = {
   biometricEnabled: false,
   biometricAvailable: false,
   signupPendingVerification: false,
+  signupEmail: null,
+  signupVerificationSent: false,
   hasHydrated: false,
 };
 
@@ -273,11 +289,16 @@ export const useAuthStore = create<AuthState & AuthActions>()(
               confirmPassword: password,
             });
 
-            // Signup succeeded — user must verify email before login
+            // Signup succeeded — user must verify email before login.
+            // ALWAYS show the pending screen on success; whether the email
+            // actually shipped is tracked separately so the screen can show
+            // an honest "couldn't send" path when delivery failed.
             set((state) => {
               state.status = 'unauthenticated';
               state.isLoading = false;
-              state.signupPendingVerification = response.email_verification_sent;
+              state.signupPendingVerification = true;
+              state.signupEmail = email;
+              state.signupVerificationSent = response.email_verification_sent;
             });
             return true;
           } catch (err: unknown) {
@@ -317,6 +338,8 @@ export const useAuthStore = create<AuthState & AuthActions>()(
         clearSignupPending: () => {
           set((state) => {
             state.signupPendingVerification = false;
+            state.signupEmail = null;
+            state.signupVerificationSent = false;
           });
         },
 


### PR DESCRIPTION
## Summary

Six follow-up fixes from on-device QA, all sitting on `claude/redesign-intro-vedic-HFYe3` after PR #1718 merged.

- **Sakha chat + KIAAN Vibe player + Today's Sacred Sound + Vibe tile palette** (`bd4a731`). Four screens still rendered hardcoded indigo even when the user picked Forest / Maroon / Black-&-Gold: chat root background, vibe-player category pills, the "Today's Sacred Sound" verse banner, and the KIAAN Vibe Player tile on Sacred Tools. All four now read `theme.colors.{background,card}` and the vibe tile's stripe + gradient follow `palette.accent.primary`.
- **Tamas/Rajas/Sattva slider — first round** (`54c4355`). Math.round(SCREEN_WIDTH) on the Guna Mirror chamber to match the arrival fix. Necessary but not sufficient — see next.
- **Arrival slider — definitive page-centering fix** (`a31d599`). After Math.round + withTiming both proved insufficient, replaced the manual `Animated.View + translateX` slider with a native `<FlatList horizontal pagingEnabled>` + `getItemLayout`. Native paging snaps to integer-pixel boundaries deterministically — zero RN/Yoga/Reanimated math in the page positioning path.
- **Guna Mirror slider + welcome scroll height + compact visual size** (`978f000`). Same FlatList migration applied to the Relationship Compass Guna Mirror slider (ScrollView+pagingEnabled had the same Android quirk). Welcome page ScrollView `flex:1` → `height:'100%'` for parity with `styles.page`. `compact` welcome visual `VISUAL_SIZE * 0.78` wrapped in `Math.round()`.
- **Shankha redesign** (`39606b6`). The Voice Companion conch SVG was a single hand-traced curve that read as an abstract pac-man / crescent shape. Rebuilt as a layered design with a real spire (3 whorl arcs), a proper aperture (mouth) cavity with a darker radial gradient, a bright golden lip, an inner spiral hint, subtle growth bands, and a lit-side highlight crescent. Token-compatible (`shankhaCream / shankhaIvory / shankhaCopper / divineGold`).
- **Voice Companion Stop button + blur-time TTS cleanup** (`4508c31`). New always-visible top-right floating Stop pill (red glyph + label, mounts only while session is active). The bigger fix: replaced the `useEffect` cleanup with `useFocusEffect` from expo-router. The previous mount-only cleanup never fired on tab switches because expo-router keeps tab screens MOUNTED — that's why Sakha's voice kept playing in the background after the user navigated away. `useFocusEffect` runs its cleanup on every blur (tab switch, navigation, backgrounding) regardless of mount state.

## Test plan

- [ ] Pick Maroon / Forest / Black-&-Gold from the arrival picker → enter Sakha chat tab + open KIAAN Vibe Player + Sacred Tools tab → all surfaces are palette-tinted, no hardcoded indigo islands.
- [ ] Tap Continue / swipe through arrival pages 1 → 6 (any palette): every page perfectly centered, no rightward drift on later pages.
- [ ] Open Relationship Compass → Guna Mirror chamber → swipe Tamas → Rajas → Sattva: every panel centered, no peek-through from neighbors.
- [ ] Open Voice Companion → tap Tap to begin → Sakha responds → switch to another tab MID-SENTENCE: voice cuts immediately. Switch back: session is in idle.
- [ ] During an active session, tap the floating top-right Stop pill: voice cuts and screen returns to "Tap to begin".
- [ ] Voice Companion Shankha icon: visibly reads as a conch (spire whorls, aperture cavity, lip highlight) — not the previous abstract crescent.
- [ ] `pnpm tsc --noEmit` clean.

https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY)_