### PR TITLE
feat(splash): name Sakha at the threshold of entry

### DIFF
--- a/kiaanverse-mobile/apps/mobile/components/common/SacredArrival.tsx
+++ b/kiaanverse-mobile/apps/mobile/components/common/SacredArrival.tsx
@@ -56,6 +56,7 @@ const SACRED_WHITE = '#F5F0E8';
 const TEXT_MUTED = 'rgba(200, 191, 168, 0.6)';
 
 const TITLE = 'Kiaanverse';
+const BYLINE = 'Sakha · your spiritual companion';
 const INVOCATION = 'ॐ सर्वे भवन्तु सुखिनः';
 
 // Fixed-length tuple of shared value slots — keeps hook order stable.
@@ -93,6 +94,7 @@ function SacredArrivalInner({
   const omScale = useSharedValue(0.8);
   const omAuraOpacity = useSharedValue(0);
   const invocationOpacity = useSharedValue(0);
+  const bylineOpacity = useSharedValue(0);
   const sceneScale = useSharedValue(1);
   const sceneOpacity = useSharedValue(1);
 
@@ -155,6 +157,7 @@ function SacredArrivalInner({
           omProgress.value = withTiming(1, { duration: 200 });
           omAuraOpacity.value = withTiming(0.5, { duration: 200 });
           invocationOpacity.value = withTiming(0.6, { duration: 200 });
+          bylineOpacity.value = withTiming(0.85, { duration: 200 });
           letterOpacities.forEach((sv) => {
             sv.value = withTiming(1, { duration: 200 });
           });
@@ -209,6 +212,18 @@ function SacredArrivalInner({
             withTiming(0, { duration: 320, easing: LOTUS_BLOOM })
           );
         });
+
+        // ACT 3.5 — SAKHA BYLINE. Eye-trail: name → byline → invocation.
+        // Fades in 200ms before the Sanskrit so the user reads top-down
+        // in order. Same DIVINE_IN curve as the invocation for visual
+        // family. Lands at 0.85 (vs invocation's 0.6) — Latin glyphs at
+        // 14pt need a bit more contrast than Devanagari at the same size
+        // to feel equally present, and the byline is the new identity
+        // beat we want the user to actually see.
+        bylineOpacity.value = withDelay(
+          ACT4_INVOCATION - 200,
+          withTiming(0.85, { duration: 600, easing: DIVINE_IN })
+        );
 
         // ACT 4 — INVOCATION
         invocationOpacity.value = withDelay(
@@ -271,6 +286,9 @@ function SacredArrivalInner({
   }));
   const invocationStyle = useAnimatedStyle(() => ({
     opacity: invocationOpacity.value,
+  }));
+  const bylineStyle = useAnimatedStyle(() => ({
+    opacity: bylineOpacity.value,
   }));
 
   // Per-letter styles — top-level hooks (not in a loop) to keep hook order stable.
@@ -440,6 +458,19 @@ function SacredArrivalInner({
         ))}
       </View>
 
+      {/* ACT 3.5 — Sakha byline. Names the companion at the threshold of
+          entry, before the Sanskrit benediction. Established as Sakha
+          everywhere downstream (chat tab, Ask Sakha CTA, arrival page 2),
+          so the splash is the right moment to introduce the name. */}
+      <Animated.Text
+        allowFontScaling={false}
+        accessibilityRole="text"
+        accessibilityLabel="Sakha, your spiritual companion"
+        style={[styles.byline, bylineStyle]}
+      >
+        {BYLINE}
+      </Animated.Text>
+
       {/* ACT 4 — Sanskrit invocation. */}
       <Animated.Text
         allowFontScaling={false}
@@ -461,7 +492,13 @@ export const SacredArrival = React.memo(SacredArrivalInner);
 const OM_SIZE = 96;
 const YANTRA_SIZE = 220;
 const NAME_TOP = H / 2 + 72;
-const INVOCATION_TOP = NAME_TOP + 56;
+// Sakha byline sits 38pt below the name (7pt clear from the bottom of
+// the 28pt italic glyphs which extend ~31pt below NAME_TOP).
+const BYLINE_TOP = NAME_TOP + 38;
+// Pushed from +56 to +68 (+12pt) to leave room for the new byline. The
+// invocation is still inside the visible safe area on every device the
+// app supports (smallest target ~640pt screen height).
+const INVOCATION_TOP = NAME_TOP + 68;
 
 // ---------------------------------------------------------------------------
 // Splash yantra geometry — pre-computed at module load so the splash never
@@ -587,6 +624,18 @@ const styles = StyleSheet.create({
     fontFamily: 'CormorantGaramond-LightItalic',
     fontStyle: 'italic',
     letterSpacing: 0.3 * 28,
+  },
+  byline: {
+    position: 'absolute',
+    top: BYLINE_TOP,
+    left: 0,
+    right: 0,
+    fontSize: 13,
+    lineHeight: 20,
+    color: 'rgba(245, 222, 179, 0.92)',
+    fontFamily: 'Outfit-Regular',
+    textAlign: 'center',
+    letterSpacing: 1.4,
   },
   invocation: {
     // Was rendered at TEXT_MUTED (#6B6355) which is the same value as the


### PR DESCRIPTION
## Summary

The splash currently introduces "Kiaanverse" letter-by-letter and follows with a Sanskrit benediction, but never names the companion the user is about to meet. Sakha is established everywhere downstream — chat tab labelled "Sakha", "Ask Sakha →" verse-card CTA, "I am Sakha, your spiritual companion" chat welcome, "Sakha means Friend" arrival page 2, "Sakha is reflecting…" chat state — yet the user never sees the name at the ceremonial moment of entry.

This adds a one-line byline between the Kiaanverse wordmark and the Sanskrit invocation: **"Sakha · your spiritual companion"**.

## Why splash, not the Home header

The Home header is already tightly packed (OM glyph + Kiaanverse wordmark + avatar in ~30pt of vertical space, with a `GoldenDivider` directly under it) — there's no room for a subtitle without crowding. The splash is the ceremonial threshold and already had vertical slack (originally 56pt between the name and the Sanskrit). Naming the companion at the moment of entry sets up the cascade: splash → arrival page 2 ("Sakha means Friend") → chat tab labelled "Sakha" → chat welcome ("I am Sakha, your spiritual companion").

## Animation

Same `DIVINE_IN` easing as the existing invocation for visual family. Fades in at `ACT4_INVOCATION - 200` (= 2000ms post-boot) so the eye reads top-down: name → byline → invocation. Both reach rest opacity by ~2400ms.

| t (ms) | Event |
|---|---|
| 0 | App boot |
| 600 | Point of light |
| 1400 | "Kiaanverse" letters begin landing |
| 2000 | **Sakha byline starts fading in (NEW — 400ms ramp to 0.85)** |
| 2200 | Sanskrit invocation fades in (existing) |
| 3400 | Splash dismisses |

## Layout

- `BYLINE_TOP = NAME_TOP + 38` — 7pt clear from the bottom of the 28pt italic name glyphs.
- `INVOCATION_TOP` pushed from `NAME_TOP + 56` → `NAME_TOP + 68` (+12pt) to make room. Still inside the visible safe area on the smallest device target (~640pt screen height).
- `byline` style: `Outfit-Regular` 13pt, warm cream `rgba(245, 222, 179, 0.92)`, 1.4pt letter spacing, `left: 0, right: 0` + `textAlign: 'center'` to guarantee centering across screen widths.

## Accessibility

- `accessibilityRole="text"` + `accessibilityLabel="Sakha, your spiritual companion"` so screen readers announce the byline as a single phrase rather than parsing the middle dot.
- Reduced-motion path snaps the byline to 0.85 opacity in 200ms alongside the existing invocation snap — no long fade for users with the OS toggle on.

## Test plan

- [ ] Cold-launch on Android. Confirm at ~1.4s the "Kiaanverse" letters land, at ~2.0s the Sakha byline fades in below, at ~2.2s the Sanskrit fades in below the byline. All three visible together for ~1s before the splash dismisses around 3.4s.
- [ ] Enable Settings → Accessibility → Reduce Motion, cold-launch again. Byline should snap to its rest opacity (~0.85) without a long fade.
- [ ] `pnpm tsc --noEmit` from `apps/mobile` — clean (only the pre-existing `tsconfig baseUrl` deprecation warning).
- [ ] Visual smoke on a small screen (Pixel 4a, 360×800) — confirm the byline doesn't wrap.
- [ ] Visual smoke on a tall screen (Pixel 7 Pro, 412×892) — confirm the byline sits tucked under the name, not floating.
- [ ] Tap-through: finish the splash → arrival ceremony → page 2 ("Sakha means Friend.") still reads as the natural deepening of the byline's introduction, not a contradiction.

## Out of scope

- Home tab header — explicitly left alone (already optimal, no vertical slack).
- Arrival ceremony pages — already name Sakha on page 2, no change needed.
- App rename — Kiaanverse stays the platform name; Sakha is the companion within it.
- Static `splash.png` — the dynamic SacredArrival overlays it within ~250ms of mount, so the static asset never shows long enough to need rework.

https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgp9sG5gL9GN9dt66S8KbY)_